### PR TITLE
Adding default value for serverOutputDir

### DIFF
--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractServerTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractServerTask.groovy
@@ -68,7 +68,7 @@ abstract class AbstractServerTask extends AbstractTask {
         def userDir = getUserDir(project, installDir)
         result.put('userDir', userDir)
 
-        result.put('outputDir', getServerOutputDir(project))
+        result.put('outputDir', getOutputDir(project))
 
         if (server.timeout != null && !server.timeout.isEmpty()) {
             result.put('timeout', server.timeout)
@@ -96,7 +96,7 @@ abstract class AbstractServerTask extends AbstractTask {
         return new File(getUserDir(project).toString() + "/servers/" + server.name)
     }
 
-    protected String getServerOutputDir(Project project) {
+    protected String getOutputDir(Project project) {
         if (server.outputDir != null) {
             return server.outputDir
         } else if (project.liberty.outputDir != null) {
@@ -198,7 +198,7 @@ abstract class AbstractServerTask extends AbstractTask {
     protected void setServerDirectoryNodes(Project project, Node serverNode) {
         serverNode.appendNode('userDirectory', getUserDir(project).toString())
         serverNode.appendNode('serverDirectory', getServerDir(project).toString())
-        serverNode.appendNode('serverOutputDirectory', getServerOutputDir(project))
+        serverNode.appendNode('serverOutputDirectory', new File(getOutputDir(project), server.name))
     }
 
     protected void setServerPropertyNodes(Project project, Node serverNode) {
@@ -551,9 +551,9 @@ abstract class AbstractServerTask extends AbstractTask {
         serverTask.setInstallDir(installDir)
         serverTask.setUserDir(getUserDir(project, installDir))
 
-        def serverOutputDir = getServerOutputDir(project)
-        if (serverOutputDir != null) {
-            serverTask.setOutputDir(new File(serverOutputDir))
+        def outputDir = getOutputDir(project)
+        if (outputDir != null) {
+            serverTask.setOutputDir(new File(outputDir))
         }  
 
         if (server.timeout != null && !server.timeout.isEmpty()) {

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractServerTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractServerTask.groovy
@@ -68,9 +68,8 @@ abstract class AbstractServerTask extends AbstractTask {
         def userDir = getUserDir(project, installDir)
         result.put('userDir', userDir)
 
-        if (getServerOutputDir(project) != null) {
-            result.put('outputDir', getServerOutputDir(project))
-        }
+        result.put('outputDir', getServerOutputDir(project))
+
         if (server.timeout != null && !server.timeout.isEmpty()) {
             result.put('timeout', server.timeout)
         }
@@ -103,7 +102,7 @@ abstract class AbstractServerTask extends AbstractTask {
         } else if (project.liberty.outputDir != null) {
             return project.liberty.outputDir
         } else {
-            return getServerDir(project).toString()
+            return getUserDir(project).toString() + "/servers"
         }
     }
 

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractServerTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractServerTask.groovy
@@ -100,8 +100,10 @@ abstract class AbstractServerTask extends AbstractTask {
     protected String getServerOutputDir(Project project) {
         if (server.outputDir != null) {
             return server.outputDir
-        } else {
+        } else if (project.liberty.outputDir != null) {
             return project.liberty.outputDir
+        } else {
+            return getServerDir(project).toString()
         }
     }
 
@@ -197,12 +199,7 @@ abstract class AbstractServerTask extends AbstractTask {
     protected void setServerDirectoryNodes(Project project, Node serverNode) {
         serverNode.appendNode('userDirectory', getUserDir(project).toString())
         serverNode.appendNode('serverDirectory', getServerDir(project).toString())
-        String serverOutputDir = getServerOutputDir(project)
-        if (serverOutputDir != null && !serverOutputDir.isEmpty()) {
-            serverNode.appendNode('serverOutputDirectory', serverOutputDir)
-        } else {
-            serverNode.appendNode('serverOutputDirectory', getServerDir(project).toString())
-        }
+        serverNode.appendNode('serverOutputDirectory', getServerOutputDir(project))
     }
 
     protected void setServerPropertyNodes(Project project, Node serverNode) {

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractServerTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractServerTask.groovy
@@ -551,10 +551,7 @@ abstract class AbstractServerTask extends AbstractTask {
         serverTask.setInstallDir(installDir)
         serverTask.setUserDir(getUserDir(project, installDir))
 
-        def outputDir = getOutputDir(project)
-        if (outputDir != null) {
-            serverTask.setOutputDir(new File(outputDir))
-        }  
+        serverTask.setOutputDir(new File(getOutputDir(project)))
 
         if (server.timeout != null && !server.timeout.isEmpty()) {
             serverTask.setTimeout(server.timeout)


### PR DESCRIPTION
Defaulting to server directory for server output directory if not set in `server` or `liberty` extensions.