### PR TITLE
Add dev mode readme, update parameters

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ compileTestGroovy {
 dependencies {
     compile gradleApi()
     compile localGroovy()
-    compile ('io.openliberty.tools:liberty-ant-tasks:1.9.2')
+    compile ('io.openliberty.tools:liberty-ant-tasks:1.9.3-SNAPSHOT')
     compile ('io.openliberty.tools:ci.common:1.8-SNAPSHOT')
     compile group: 'commons-io', name: 'commons-io', version: '2.5'
     provided group: 'com.ibm.websphere.appserver.api', name: 'com.ibm.websphere.appserver.spi.kernel.embeddable', version: '1.0.0'

--- a/docs/libertyDev.md
+++ b/docs/libertyDev.md
@@ -1,0 +1,64 @@
+#### dev
+
+----
+
+Start a Liberty server in dev mode. This goal also invokes the `create`, `install-feature`, and `deploy` goals before starting the server. **Note:** This goal is designed to be executed directly from the Maven command line.  To exit dev mode, press `Control-C`, or type `q` and press Enter.
+
+Dev mode provides three key features. Code changes are detected, recompiled, and picked up by your running server. Unit and integration tests are run on demand when you press Enter in the command terminal where dev mode is running, or optionally on every code change to give you instant feedback on the status of your code. Finally, it allows you to attach a debugger to the running server at any time to step through your code.
+
+The following are dev mode supported code changes. Changes to your server such as changes to the port, server name, hostname, etc. will require restarting dev mode to be detected.  Changes other than those listed below may also require restarting dev mode to be detected.
+
+* Java source file changes and Java test file changes are detected, recompiled, and picked up by your running server.  
+* Added dependencies to your `pom.xml` are detected and added to your classpath.  Dependencies that are Liberty features will be installed via the `install-feature` goal.  Any other changes to your `pom.xml` will require restarting dev mode to be detected.
+* Resource file changes are detected and copied into your `target` directory. 
+* Configuration directory and configuration file changes are detected and copied into your `target` directory.  Added features to your `server.xml` will be installed and picked up by your running server.  Adding a configuration directory or configuration file that did not previously exist while dev mode is running will require restarting dev mode to be detected.
+
+
+###### Examples
+
+Start dev mode.
+```
+$ mvn liberty:dev
+```
+
+Start dev mode and run tests automatically after every code change.
+```
+$ mvn liberty:dev -DhotTests=true
+```
+
+Start dev mode and listen on a specific port for attaching a debugger (default is 7777).
+```
+$ mvn liberty:dev -DdebugPort=8787
+```
+
+Start dev mode without allowing to attach a debugger.
+```
+$ mvn liberty:dev -Ddebug=false
+```
+
+###### Additional Parameters
+
+The following are the parameters supported by this goal in addition to the [common server parameters](common-server-parameters.md#common-server-parameters) and the [common parameters](common-parameters.md#common-parameters).
+
+| Parameter | Description | Required |
+| --------  | ----------- | -------  |
+| hotTests | If set to `true`, run unit and integration tests automatically after every change. The default value is `false`. | No |
+| skipTests | If set to `true`, do not run any tests in dev mode. The default value is `false`. | No |
+| skipUTs | If set to `true`, skip unit tests. The default value is `false`. If the project packaging type is `ear`, unit tests are always skipped. | No |
+| skipITs | If set to `true`, skip integration tests. The default value is `false`.  | No |
+| debug | Whether to allow attaching a debugger to the running server. The default value is `true`. | No |
+| debugPort | The debug port that you can attach a debugger to. The default value is `7777`. | No |
+| compileWait | Time in seconds to wait before processing Java changes. If you encounter compile errors while refactoring, increase this value to allow all files to be saved before compilation occurs. The default value is `0.5` seconds. | No |
+| serverStartTimeout | Maximum time to wait (in seconds) to verify that the server has started. The default value is `30` seconds. | No |
+| verifyTimeout | Maximum time to wait (in seconds) to verify that the application has started before running integration tests. The default value is `30` seconds. | No |
+
+###### System Properties for Integration Tests
+
+Integration tests can read the following system properties to obtain information about the Liberty server.
+
+| Property | Description |
+| --------  | ----------- |
+| wlp.user.dir | The user directory location that contains server definitions and shared resources. |
+| liberty.hostname | The host name of the Liberty server. |
+| liberty.http.port | The port used for client HTTP requests. |
+| liberty.https.port | The port used for client HTTP requests secured with SSL (https). |

--- a/docs/libertyDev.md
+++ b/docs/libertyDev.md
@@ -1,64 +1,53 @@
-#### dev
+## libertyDev task
 
-----
-
-Start a Liberty server in dev mode. This goal also invokes the `create`, `install-feature`, and `deploy` goals before starting the server. **Note:** This goal is designed to be executed directly from the Maven command line.  To exit dev mode, press `Control-C`, or type `q` and press Enter.
+Start a Liberty server in dev mode. This task also invokes the `libertyCreate`, `installFeature`, and `deploy` tasks before starting the server. **Note:** This task is designed to be executed directly from the Gradle command line.  To exit dev mode, press `Control-C`, or type `q` and press Enter.
 
 Dev mode provides three key features. Code changes are detected, recompiled, and picked up by your running server. Unit and integration tests are run on demand when you press Enter in the command terminal where dev mode is running, or optionally on every code change to give you instant feedback on the status of your code. Finally, it allows you to attach a debugger to the running server at any time to step through your code.
 
 The following are dev mode supported code changes. Changes to your server such as changes to the port, server name, hostname, etc. will require restarting dev mode to be detected.  Changes other than those listed below may also require restarting dev mode to be detected.
 
 * Java source file changes and Java test file changes are detected, recompiled, and picked up by your running server.  
-* Added dependencies to your `pom.xml` are detected and added to your classpath.  Dependencies that are Liberty features will be installed via the `install-feature` goal.  Any other changes to your `pom.xml` will require restarting dev mode to be detected.
+* Added dependencies to your `build.gradle` are detected and added to your classpath.  Dependencies that are Liberty features will be installed via the `installFeature` task.  Any other changes to your `build.gradle` will require restarting dev mode to be detected.
 * Resource file changes are detected and copied into your `target` directory. 
 * Configuration directory and configuration file changes are detected and copied into your `target` directory.  Added features to your `server.xml` will be installed and picked up by your running server.  Adding a configuration directory or configuration file that did not previously exist while dev mode is running will require restarting dev mode to be detected.
 
 
-###### Examples
+### Examples
 
 Start dev mode.
 ```
-$ mvn liberty:dev
+$ gradle libertyDev
 ```
 
 Start dev mode and run tests automatically after every code change.
 ```
-$ mvn liberty:dev -DhotTests=true
+$ gradle libertyDev --hotTests=true
 ```
 
 Start dev mode and listen on a specific port for attaching a debugger (default is 7777).
 ```
-$ mvn liberty:dev -DdebugPort=8787
+$ gradle libertyDev --libertyDebugPort=8787
 ```
 
 Start dev mode without allowing to attach a debugger.
 ```
-$ mvn liberty:dev -Ddebug=false
+$ gradle libertyDev --libertyDebug=false
 ```
 
-###### Additional Parameters
+### Command Line Parameters
 
-The following are the parameters supported by this goal in addition to the [common server parameters](common-server-parameters.md#common-server-parameters) and the [common parameters](common-parameters.md#common-parameters).
+The following are optional command line parameters supported by this task.
 
 | Parameter | Description | Required |
 | --------  | ----------- | -------  |
-| hotTests | If set to `true`, run unit and integration tests automatically after every change. The default value is `false`. | No |
+| hotTests | If set to `true`, run tests automatically after every change. The default value is `false`. | No |
 | skipTests | If set to `true`, do not run any tests in dev mode. The default value is `false`. | No |
-| skipUTs | If set to `true`, skip unit tests. The default value is `false`. If the project packaging type is `ear`, unit tests are always skipped. | No |
-| skipITs | If set to `true`, skip integration tests. The default value is `false`.  | No |
-| debug | Whether to allow attaching a debugger to the running server. The default value is `true`. | No |
-| debugPort | The debug port that you can attach a debugger to. The default value is `7777`. | No |
+| libertyDebug | Whether to allow attaching a debugger to the running server. The default value is `true`. | No |
+| libertyDebugPort | The debug port that you can attach a debugger to. The default value is `7777`. | No |
 | compileWait | Time in seconds to wait before processing Java changes. If you encounter compile errors while refactoring, increase this value to allow all files to be saved before compilation occurs. The default value is `0.5` seconds. | No |
 | serverStartTimeout | Maximum time to wait (in seconds) to verify that the server has started. The default value is `30` seconds. | No |
-| verifyTimeout | Maximum time to wait (in seconds) to verify that the application has started before running integration tests. The default value is `30` seconds. | No |
+| verifyAppStartTimeout | Maximum time to wait (in seconds) to verify that the application has started or updated before running tests. The default value is `30` seconds. | No |
 
-###### System Properties for Integration Tests
+### Properties
 
-Integration tests can read the following system properties to obtain information about the Liberty server.
-
-| Property | Description |
-| --------  | ----------- |
-| wlp.user.dir | The user directory location that contains server definitions and shared resources. |
-| liberty.hostname | The host name of the Liberty server. |
-| liberty.http.port | The port used for client HTTP requests. |
-| liberty.https.port | The port used for client HTTP requests secured with SSL (https). |
+See the [Liberty server configuration](libertyExtensions.md#liberty-server-configuration) properties for common server configuration.

--- a/docs/libertyDev.md
+++ b/docs/libertyDev.md
@@ -21,7 +21,7 @@ $ gradle libertyDev
 
 Start dev mode and run tests automatically after every code change.
 ```
-$ gradle libertyDev --hotTests=true
+$ gradle libertyDev --hotTests
 ```
 
 Start dev mode and listen on a specific port for attaching a debugger (default is 7777).

--- a/docs/libertyDev.md
+++ b/docs/libertyDev.md
@@ -40,8 +40,8 @@ The following are optional command line parameters supported by this task.
 
 | Parameter | Description | Required |
 | --------  | ----------- | -------  |
-| hotTests | If set to `true`, run tests automatically after every change. The default value is `false`. | No |
-| skipTests | If set to `true`, do not run any tests in dev mode. The default value is `false`. | No |
+| hotTests | If this option is enabled, run tests automatically after every change. The default value is `false`. | No |
+| skipTests | If this option is enabled, do not run any tests in dev mode. The default value is `false`. | No |
 | libertyDebug | Whether to allow attaching a debugger to the running server. The default value is `true`. | No |
 | libertyDebugPort | The debug port that you can attach a debugger to. The default value is `7777`. | No |
 | compileWait | Time in seconds to wait before processing Java changes. If you encounter compile errors while refactoring, increase this value to allow all files to be saved before compilation occurs. The default value is `0.5` seconds. | No |

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
@@ -53,7 +53,6 @@ class DevTask extends AbstractServerTask {
     // DevMode uses CLI Arguments if provided, otherwise it uses ServerExtension properties if one exists, fallback to default value if neither are provided.
     private static final int DEFAULT_VERIFY_TIMEOUT = 30;
     private static final int DEFAULT_SERVER_TIMEOUT = 30;
-    private static final int DEFAULT_APP_UPDATE_TIMEOUT = 5;
     private static final double DEFAULT_COMPILE_WAIT = 0.5;
     private static final int DEFAULT_DEBUG_PORT = 7777;
     private static final boolean DEFAULT_HOT_TESTS = false;
@@ -87,7 +86,7 @@ class DevTask extends AbstractServerTask {
 
     Integer libertyDebugPort;
 
-    @Option(option = 'debugPort', description = 'The debug port that you can attach a debugger to. The default value is 7777.')
+    @Option(option = 'libertyDebugPort', description = 'The debug port that you can attach a debugger to. The default value is 7777.')
     void setLibertyDebugPort(String libertyDebugPort) {
         try {
             this.libertyDebugPort = libertyDebugPort.toInteger();
@@ -111,24 +110,12 @@ class DevTask extends AbstractServerTask {
 
     private Integer verifyAppStartTimeout;
 
-    @Option(option = 'verifyAppStartTimeout', description = 'Maximum time to wait (in seconds) to verify that the application has started. The default value is 30 seconds.')
+    @Option(option = 'verifyAppStartTimeout', description = 'Maximum time to wait (in seconds) to verify that the application has started or updated before running tests. The default value is 30 seconds.')
     void setVerifyAppStartTimeout(String verifyAppStartTimeout) {
         try {
             this.verifyAppStartTimeout = verifyAppStartTimeout.toInteger();
         } catch (NumberFormatException e) {
             logger.error(String.format("Unexpected value: %s for dev mode option verifyAppStartTimeout. verifyAppStartTimeout should be a valid integer.", verifyAppStartTimeout));
-            throw e;
-        }
-    }
-
-    private Integer appUpdateTimeout;
-
-    @Option(option = 'appUpdateTimeout', description = 'Maximum time to wait (in seconds) to verify that the application has updated before running integration tests. The default value is 5 seconds.')
-    void setAppUpdateTimeout(String appUpdateTimeout) {
-        try {
-            this.appUpdateTimeout = appUpdateTimeout.toInteger();
-        } catch (NumberFormatException e) {
-            logger.error(String.format("Unexpected value: %s for dev mode option appUpdateTimeout. appUpdateTimeout should be a valid integer.", appUpdateTimeout));
             throw e;
         }
     }
@@ -389,10 +376,6 @@ class DevTask extends AbstractServerTask {
             clean = server.clean;
         }
 
-        if (appUpdateTimeout == null) {
-            appUpdateTimeout = DEFAULT_APP_UPDATE_TIMEOUT;
-        }
-
         if (compileWait == null) {
             compileWait = DEFAULT_COMPILE_WAIT;
         }
@@ -481,7 +464,7 @@ class DevTask extends AbstractServerTask {
         util = new DevTaskUtil(
                 serverDirectory, sourceDirectory, testSourceDirectory, configDirectory,
                 resourceDirs, hotTests.booleanValue(), skipTests.booleanValue(), artifactId, serverStartTimeout.intValue(),
-                verifyAppStartTimeout.intValue(), appUpdateTimeout.intValue(), compileWait.doubleValue(), libertyDebug.booleanValue()
+                verifyAppStartTimeout.intValue(), verifyAppStartTimeout.intValue(), compileWait.doubleValue(), libertyDebug.booleanValue()
         );
 
 //            Use the gradle compile task instead of using the DevUtil compile

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
@@ -62,14 +62,14 @@ class DevTask extends AbstractServerTask {
 
     private Boolean hotTests;
 
-    @Option(option = 'hotTests', description = 'If set to true, run tests automatically after every change. The default value is false.')
+    @Option(option = 'hotTests', description = 'If this option is enabled, run tests automatically after every change. The default value is false.')
     void setHotTests(boolean hotTests) {
         this.hotTests = hotTests;
     }
 
     private Boolean skipTests;
 
-    @Option(option = 'skipTests', description = 'If set to true, do not run any tests in dev mode. The default value is false.')
+    @Option(option = 'skipTests', description = 'If this option is enabled, do not run any tests in dev mode. The default value is false.')
     void setSkipTests(boolean skipTests) {
         this.skipTests = skipTests;
     }


### PR DESCRIPTION
- Add readme for dev mode.  Fixes #354 
- Change `debugPort` to `libertyDebugPort` to be consistent with `libertyDebug` parameter
- Use `verifyAppStartTimeout` parameter value for both `verifyAppStartTimeout` and `appUpdateTimeout` to make it simpler for users