### PR TITLE
Use project root for gradle connection

### DIFF
--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
@@ -515,13 +515,13 @@ class DevTask extends AbstractServerTask {
         }
     }
 
-    static ProjectConnection initGradleProjectConnection() {
-        return initGradleConnection('.');
+    ProjectConnection initGradleProjectConnection() {
+        return initGradleConnection(project.getRootDir());
     }
 
-    static ProjectConnection initGradleConnection(String path) {
+    static ProjectConnection initGradleConnection(File rootDir) {
         ProjectConnection connection = GradleConnector.newConnector()
-                .forProjectDirectory(new File(path))
+                .forProjectDirectory(rootDir)
                 .connect();
 
         return connection;


### PR DESCRIPTION
libertyDev can fail when calling other gradle tasks because it uses '.' for the gradle connection. Instead, it should use the actual project root.