### PR TITLE
Use Gradle compiler for recompiles

### DIFF
--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
@@ -156,7 +156,7 @@ class DevTask extends AbstractServerTask {
         ) throws IOException {
             super(serverDirectory, sourceDirectory, testSourceDirectory, configDirectory, resourceDirs,
                     hotTests, skipTests, false, false, artifactId,  serverStartTimeout,
-                    verifyAppStartTimeout, appUpdateTimeout, ((long) (compileWait * 1000L)), libertyDebug);
+                    verifyAppStartTimeout, appUpdateTimeout, ((long) (compileWait * 1000L)), libertyDebug, true);
 
             ServerFeature servUtil = getServerFeatureUtil();
             this.existingFeatures = servUtil.getServerFeatures(serverDirectory);

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
@@ -467,9 +467,6 @@ class DevTask extends AbstractServerTask {
                 verifyAppStartTimeout.intValue(), verifyAppStartTimeout.intValue(), compileWait.doubleValue(), libertyDebug.booleanValue()
         );
 
-//            Use the gradle compile task instead of using the DevUtil compile
-//            util.setUseMavenOrGradleCompile(true);
-
         util.addShutdownHook(executor);
 
         util.startServer();


### PR DESCRIPTION
Use the Gradle compiler for recompiling. Gradle tests depend on compile, so by using Gradle to compile during changes and then run tests (which invokes compile again), it will not recompile the second time. Also, Gradle does not appear to have the conflict with the Java LS described in OpenLiberty/ci.maven#686.

Depends on https://github.com/OpenLiberty/ci.common/pull/113