### PR TITLE
Skip message on normal exit, use ci.common 1.8.2-SNAPSHOT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ env:
     - RUNTIME=ol RUNTIME_VERSION=19.0.0.9
     - RUNTIME=ol RUNTIME_VERSION=19.0.0.6
 before_install:
-#    - echo 'Installing ci.common lib ....'
-#    - git clone https://github.com/OpenLiberty/ci.common.git ./ci.common
-#    - cd ./ci.common
-#    - mvn clean install
-#    - cd ..
+    - echo 'Installing ci.common lib ....'
+    - git clone https://github.com/OpenLiberty/ci.common.git ./ci.common
+    - cd ./ci.common
+    - mvn clean install
+    - cd ..
 #    - echo 'Installing ci.ant lib ....'
 #    - git clone https://github.com/OpenLiberty/ci.ant.git ./ci.ant
 #    - cd ./ci.ant

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,11 +21,11 @@ install:
 
 before_build:
     - cmd: |
-#        echo "Installing ci.common lib ...."
-#        git clone https://github.com/OpenLiberty/ci.common.git ci.common
-#        cd ci.common
-#        mvn clean install
-#        cd..
+        echo "Installing ci.common lib ...."
+        git clone https://github.com/OpenLiberty/ci.common.git ci.common
+        cd ci.common
+        mvn clean install
+        cd..
 #        echo "Installing ci.ant lib ...."
 #        git clone https://github.com/OpenLiberty/ci.ant.git ci.ant
 #        cd ci.ant

--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     compile gradleApi()
     compile localGroovy()
     compile ('io.openliberty.tools:liberty-ant-tasks:1.9.3')
-    compile ('io.openliberty.tools:ci.common:1.8.1')
+    compile ('io.openliberty.tools:ci.common:1.8.2-SNAPSHOT')
     compile group: 'commons-io', name: 'commons-io', version: '2.5'
     provided group: 'com.ibm.websphere.appserver.api', name: 'com.ibm.websphere.appserver.spi.kernel.embeddable', version: '1.0.0'
     testCompile 'junit:junit:4.11'

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
@@ -705,8 +705,11 @@ class DevTask extends AbstractServerTask {
         // configuration parameter is not specified.
         try {
             util.watchFiles(buildFile, outputDirectory, testOutputDirectory, executor, artifactPaths, serverXMLFile);
-        } catch (PluginScenarioException e) { // this exception is caught when the server has been stopped by another process
-            logger.info(e.getMessage());
+        } catch (PluginScenarioException e) {
+            if (e.getMessage() != null) {
+                // a proper message is included in the exception if the server has been stopped by another process
+                log.info(e.getMessage());
+            }
             return; // enter shutdown hook
         }
     }


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/ci.gradle/issues/378

- With https://github.com/OpenLiberty/ci.common/pull/119, DevUtil will throw PluginScenarioException with empty message if dev mode exits normally by user input.  Only print the exception message if it is not null.