### PR TITLE
Set project.name when rebuilding project

### DIFF
--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
@@ -275,6 +275,7 @@ class DevTask extends AbstractServerTask {
                 newProject = builder
                         .withProjectDir(project.rootDir)
                         .withGradleUserHomeDir(project.gradle.gradleUserHomeDir)
+                        .withName(project.name)
                         .build();
 
                 // need this for gradle to evaluate the project


### PR DESCRIPTION
Fixes #386 