### PR TITLE
user logger instead of log

### DIFF
--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
@@ -713,7 +713,7 @@ class DevTask extends AbstractServerTask {
         } catch (PluginScenarioException e) {
             if (e.getMessage() != null) {
                 // a proper message is included in the exception if the server has been stopped by another process
-                log.info(e.getMessage());
+                logger.info(e.getMessage());
             }
             return; // enter shutdown hook
         }


### PR DESCRIPTION
Fixes #394 

`log.info` was not a recognized command.  Use `logger.info` to fix `TaskExecutionException`. 

Output when another process runs `gradle libertyStop` now looks like this:
```
> Task :libertyDev
Source compilation was successful.
Tests compilation was successful.

[AUDIT   ] CWWKE0055I: Server shutdown requested on Friday, December 13, 2019 at 11:58 AM. The server defaultServer is shutting down.
[AUDIT   ] CWWKE1100I: Waiting for up to 30 seconds for the server to quiesce.
[AUDIT   ] CWWKT0017I: Web application removed (default_host): http://192.168.0.19:9080/metrics/
[AUDIT   ] CWWKT0017I: Web application removed (default_host): http://192.168.0.19:9080/
[AUDIT   ] CWWKT0017I: Web application removed (default_host): http://192.168.0.19:9080/ibm/api/
[AUDIT   ] CWWKZ0009I: The application demo-devmode has stopped successfully.
[AUDIT   ] CWWKE0036I: The server defaultServer stopped after 38.965 seconds.

> Task :libertyDev
The server has stopped. Exiting dev mode.
:libertyDev (Thread[Execution worker for ':',5,main]) completed. Took 50.472 secs.
BUILD SUCCESSFUL in 51s
1 actionable task: 1 executed
```