### PR TITLE
Propogate system properties to the test jvm

### DIFF
--- a/docs/libertyDev.md
+++ b/docs/libertyDev.md
@@ -63,20 +63,3 @@ Tests can read the following system properties to obtain information about the L
 | liberty.http.port | The port used for client HTTP requests. |
 | liberty.https.port | The port used for client HTTP requests secured with SSL (HTTPS). |
 
-In order to properly propagate the system properties from the Gradle JVM running dev mode to the JVM(s) running your tests, you must configure your `build.gradle` to set the system properties for the test JVM(s).
-
-This can be done by setting specific properties for the test JVM.
-```groovy
-test {
-    systemProperty 'liberty.hostname', System.getProperty('liberty.hostname')
-    systemProperty 'liberty.http.port', System.getProperty('liberty.http.port')
-    systemProperty 'liberty.https.port', System.getProperty('liberty.https.port')
-}
-```
-
-Or by propagating all system properties from the Gradle JVM to the test JVM.
-```groovy
-test {
-    systemProperties = System.properties
-}
-```

--- a/docs/libertyDev.md
+++ b/docs/libertyDev.md
@@ -63,3 +63,20 @@ Tests can read the following system properties to obtain information about the L
 | liberty.http.port | The port used for client HTTP requests. |
 | liberty.https.port | The port used for client HTTP requests secured with SSL (HTTPS). |
 
+The liberty gradle plugin automatically propagates the system properties in the table above from the Gradle JVM to the JVM(s) running your tests. If you wish to add your own additional system properties you must configure your `build.gradle` file to set the system properties for the test JVM(s).
+
+This can be done by setting specific properties for the test JVM.
+```groovy
+test {
+    systemProperty 'example.property.1', System.getProperty('example.property.1')
+    systemProperty 'example.property.2', System.getProperty('example.property.2')
+    systemProperty 'example.property.3', System.getProperty('example.property.3')
+}
+```
+
+Or by propagating all system properties from the Gradle JVM to the test JVM.
+```groovy
+test {
+    systemProperties = System.properties
+}
+```

--- a/docs/libertyDev.md
+++ b/docs/libertyDev.md
@@ -63,7 +63,7 @@ Tests can read the following system properties to obtain information about the L
 | liberty.http.port | The port used for client HTTP requests. |
 | liberty.https.port | The port used for client HTTP requests secured with SSL (HTTPS). |
 
-The liberty gradle plugin automatically propagates the system properties in the table above from the Gradle JVM to the JVM(s) running your tests. If you wish to add your own additional system properties you must configure your `build.gradle` file to set the system properties for the test JVM(s).
+The Liberty Gradle plugin automatically propagates the system properties in the table above from the Gradle JVM to the JVM(s) running your tests. If you wish to add your own additional system properties you must configure your `build.gradle` file to set the system properties for the test JVM(s).
 
 This can be done by setting specific properties for the test JVM.
 ```groovy

--- a/src/main/groovy/io/openliberty/tools/gradle/Liberty.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/Liberty.groovy
@@ -26,6 +26,7 @@ import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.execution.TaskExecutionGraph
 import org.gradle.api.GradleException
+import org.gradle.api.tasks.testing.Test
 
 import java.util.Properties
 
@@ -61,6 +62,26 @@ class Liberty implements Plugin<Project> {
             Liberty.checkEtcServerEnvProperties(project)
 
             setEclipseClasspath(project)
+        }
+
+        // Dev-mode needs to propagate these system properties from the gradle JVM
+        // to the JVM that will be used to run the tests.
+        def propagatedSystemProperties = [
+                "liberty.hostname",
+                "liberty.http.port",
+                "liberty.https.port",
+                "microshed_hostname",
+                "microshed_http_port",
+                "microshed_https_port",
+                "wlp.user.dir"
+        ];
+        project.tasks.withType(Test) { testTask ->
+            propagatedSystemProperties.each { propertyKey ->
+                def propertyValue = System.getProperty(propertyKey);
+                if (propertyValue != null) {
+                    testTask.systemProperty(propertyKey, propertyValue);
+                }
+            }
         }
     }
 

--- a/src/main/groovy/io/openliberty/tools/gradle/Liberty.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/Liberty.groovy
@@ -67,13 +67,13 @@ class Liberty implements Plugin<Project> {
         // Dev-mode needs to propagate these system properties from the gradle JVM
         // to the JVM that will be used to run the tests.
         def propagatedSystemProperties = [
-                "liberty.hostname",
-                "liberty.http.port",
-                "liberty.https.port",
-                "microshed_hostname",
-                "microshed_http_port",
-                "microshed_https_port",
-                "wlp.user.dir"
+            "liberty.hostname",
+            "liberty.http.port",
+            "liberty.https.port",
+            "microshed_hostname",
+            "microshed_http_port",
+            "microshed_https_port",
+            "wlp.user.dir"
         ];
         project.tasks.withType(Test) { testTask ->
             propagatedSystemProperties.each { propertyKey ->


### PR DESCRIPTION
Automatically propagate system properties from the gradle jvm to the jvm running tests. #408 