### PR TITLE
Fixing Gradle 6.0 warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ repositories {
     mavenLocal()
     mavenCentral()
     maven {
-        url 'http://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/maven/repository/'
+        url 'https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/maven/repository/'
     }
     maven {
         url 'https://oss.sonatype.org/content/repositories/snapshots/'
@@ -59,14 +59,14 @@ compileTestGroovy {
 }
 
 dependencies {
-    compile gradleApi()
-    compile localGroovy()
-    compile ('io.openliberty.tools:liberty-ant-tasks:1.9.3')
-    compile ('io.openliberty.tools:ci.common:1.8.3-SNAPSHOT')
-    compile group: 'commons-io', name: 'commons-io', version: '2.5'
+    implementation gradleApi()
+    implementation localGroovy()
+    implementation ('io.openliberty.tools:liberty-ant-tasks:1.9.3')
+    implementation ('io.openliberty.tools:ci.common:1.8.3-SNAPSHOT')
+    implementation group: 'commons-io', name: 'commons-io', version: '2.5'
     provided group: 'com.ibm.websphere.appserver.api', name: 'com.ibm.websphere.appserver.spi.kernel.embeddable', version: '1.0.0'
-    testCompile 'junit:junit:4.11'
-    testCompile gradleTestKit()
+    testImplementation 'junit:junit:4.11'
+    testImplementation gradleTestKit()
 }
 
 sourceSets.main.compileClasspath += configurations.provided

--- a/docs/undeploy.md
+++ b/docs/undeploy.md
@@ -1,6 +1,6 @@
 ## undeploy task
 
-The `undeploy` task supports undeployment of one or more applications from the WebSphere Liberty server.
+The `undeploy` task supports undeployment of one or more applications from the WebSphere Liberty server. When an application is undeployed the task will verify that it has stopped.
 
 ### dependsOn
 `undeploy` depends on `libertyStart` for a running server. 

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractServerTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractServerTask.groovy
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2017, 2019.
+ * (C) Copyright IBM Corporation 2017, 2020.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.tasks.bundling.War
+import org.gradle.api.tasks.Internal
 import org.gradle.plugins.ear.Ear
 
 import java.nio.file.Files
@@ -69,8 +70,8 @@ abstract class AbstractServerTask extends AbstractTask {
     protected List<String> combinedJvmOptions = null
     protected Map<String,String> combinedEnvProperties = null
 
-    def server
-    def springBootBuildTask
+    protected def server
+    protected def springBootBuildTask
 
     private enum PropertyType {
         BOOTSTRAP("liberty.server.bootstrapProperties"),
@@ -821,6 +822,7 @@ abstract class AbstractServerTask extends AbstractTask {
         }
     }
 
+    @Internal
     protected String getPackagingType() throws Exception{
       if (project.plugins.hasPlugin("war") || !project.tasks.withType(War).isEmpty()) {
           if (project.plugins.hasPlugin("org.springframework.boot")) {
@@ -849,6 +851,7 @@ abstract class AbstractServerTask extends AbstractTask {
       return false
     }
 
+    @Internal
     protected List<File> getApplicationFilesFromConfiguration() {
         List<File> appFiles = new ArrayList<File>()
 

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractTask.groovy
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2017, 2019.
+ * (C) Copyright IBM Corporation 2017, 2020.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,11 +21,12 @@ import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.Task
+import org.gradle.api.tasks.Internal
 
 abstract class AbstractTask extends DefaultTask {
 
     //params that get built with installLiberty
-    def params
+    protected def params
     protected boolean isWindows = System.properties['os.name'].toLowerCase().indexOf("windows") >= 0
     protected String springBootVersion
     protected Task springBootTask
@@ -100,30 +101,22 @@ abstract class AbstractTask extends DefaultTask {
         }
         return task
     }
-
+    @Internal
     protected boolean isLibertyInstalled(Project project) {
         File installDir = getInstallDir(project)
         return (installDir.exists() && new File(installDir, "lib/ws-launch.jar").exists())
     }
 
-    final String  COM_IBM_WEBSPHERE_PRODUCTID_KEY = "com.ibm.websphere.productId"
-    final String COM_IBM_WEBSPHERE_PRODUCTVERSION_KEY = "com.ibm.websphere.productVersion"
+    private final String  COM_IBM_WEBSPHERE_PRODUCTID_KEY = "com.ibm.websphere.productId"
+    private final String COM_IBM_WEBSPHERE_PRODUCTVERSION_KEY = "com.ibm.websphere.productVersion"
 
-    protected boolean isOpenLiberty() {
-        getLibertyInstallProperties().getProperty(COM_IBM_WEBSPHERE_PRODUCTID_KEY).contains("io.openliberty")
-    }
-
+    @Internal
     protected boolean isClosedLiberty() {
         getLibertyInstallProperties().getProperty(COM_IBM_WEBSPHERE_PRODUCTID_KEY).contains("com.ibm.websphere.appserver")
     }
 
-    protected String getInstallVersion() {
-        getLibertyInstallProperties().getProperty(COM_IBM_WEBSPHERE_PRODUCTVERSION_KEY)
-    }
-
+    @Internal
     protected Properties getLibertyInstallProperties() {
-        String COM_IBM_WEBSPHERE_PRODUCTID_KEY = "com.ibm.websphere.productId"
-        String COM_IBM_WEBSPHERE_PRODUCTVERSION_KEY = "com.ibm.websphere.productVersion"
         File propertiesDir = new File(getInstallDir(project), "lib/versions")
         File wlpProductInfoProperties = new File(propertiesDir, "WebSphereApplicationServer.properties")
         File olProductInfoProperties = new File(propertiesDir, "openliberty.properties")

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/CreateTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/CreateTask.groovy
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2014, 2019.
+ * (C) Copyright IBM Corporation 2014, 2020.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import org.gradle.api.logging.LogLevel
 
 class CreateTask extends AbstractServerTask {
 
-    final String DEFAULT_PATH = project.projectDir.toString() + '/src/main/liberty/config/'
+    private final String DEFAULT_PATH = project.projectDir.toString() + '/src/main/liberty/config/'
 
     CreateTask() {
         configure({

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DeployTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DeployTask.groovy
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2014, 2019.
+ * (C) Copyright IBM Corporation 2014, 2020.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,21 +113,21 @@ class DeployTask extends AbstractServerTask {
     }
 
     private void installProjectArchive(Task task, String appsDir) {
-        String baseName
+        String archiveBaseName
         String fileName
         if("springboot".equals(getPackagingType())) {
-            baseName = springBootTask.baseName
+            archiveBaseName = springBootTask.baseName
             installSpringBootFeatureIfNeeded()
             String targetThinAppPath = invokeThinOperation(appsDir)
             fileName = targetThinAppPath.substring(targetThinAppPath.lastIndexOf("/") + 1)
-            validateAppConfig(targetThinAppPath.substring(targetThinAppPath.lastIndexOf("/") + 1), baseName, appsDir)
+            validateAppConfig(targetThinAppPath.substring(targetThinAppPath.lastIndexOf("/") + 1), archiveBaseName, appsDir)
         } else {
-            baseName = task.baseName
+            archiveBaseName = task.baseName
             fileName = getArchiveName(task)
             Files.copy(task.archivePath.toPath(), new File(getServerDir(project), "/" + appsDir + "/" + getArchiveName(task)).toPath(), StandardCopyOption.REPLACE_EXISTING)
-            validateAppConfig(getArchiveName(task), task.baseName, appsDir)
+            validateAppConfig(getArchiveName(task), archiveBaseName, appsDir)
         }
-        validateAppConfig(fileName, baseName, appsDir)
+        validateAppConfig(fileName, archiveBaseName, appsDir)
         verifyAppStarted(fileName, appsDir)
     }
 

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/InstallLibertyTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/InstallLibertyTask.groovy
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2014, 2019.
+ * (C) Copyright IBM Corporation 2014, 2020.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import javax.xml.parsers.*
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.artifacts.Configuration
@@ -37,10 +38,10 @@ import org.gradle.api.GradleException
 
 class InstallLibertyTask extends AbstractTask {
     protected Properties libertyRuntimeProjectProps = new Properties()
-    String detachedCoords
-    String detachedConfigFilePath
+    protected String detachedCoords
+    protected String detachedConfigFilePath
     // default to install the latest Open Liberty kernel from Maven Central repository
-    String defaultRuntime = "io.openliberty:openliberty-kernel:[19.0.0.9,)"
+    protected String defaultRuntime = "io.openliberty:openliberty-kernel:[19.0.0.9,)"
 
     InstallLibertyTask() {
         configure({
@@ -247,6 +248,7 @@ class InstallLibertyTask extends AbstractTask {
         }
     }
 
+    @Internal
     protected String getLibertyRuntimeCoordinates() {
         String runtimeCoords = null
         Configuration config = project.configurations.getByName('libertyRuntime')
@@ -258,69 +260,70 @@ class InstallLibertyTask extends AbstractTask {
              }
         }
         return runtimeCoords
-     }
+    }
 
-     protected String getUpdatedLibertyRuntimeCoordinates(String coords) {
-         boolean useDefault = true
-         String updatedCoords = defaultRuntime
-         if (coords != null) {
-             updatedCoords = coords
-             useDefault = false
-         } else {
-             logger.debug 'Liberty runtime coordinates were null. Using default coordinates: ' + updatedCoords
-         }
+    protected String getUpdatedLibertyRuntimeCoordinates(String coords) {
+        boolean useDefault = true
+        String updatedCoords = defaultRuntime
+        if (coords != null) {
+            updatedCoords = coords
+            useDefault = false
+        } else {
+            logger.debug 'Liberty runtime coordinates were null. Using default coordinates: ' + updatedCoords
+        }
 
-         String[] coordinates = updatedCoords.split(":")
+        String[] coordinates = updatedCoords.split(":")
 
-         if (project.liberty.runtime != null && !project.liberty.runtime.isEmpty()) {
-             String propGroupId = project.liberty.runtime.getProperty("group")
-             if (propGroupId != null) {
-                 coordinates[0] = propGroupId
-             }
+        if (project.liberty.runtime != null && !project.liberty.runtime.isEmpty()) {
+            String propGroupId = project.liberty.runtime.getProperty("group")
+            if (propGroupId != null) {
+                coordinates[0] = propGroupId
+            }
 
-             String propArtifactId = project.liberty.runtime.getProperty("name")
-             if (propArtifactId != null) {
-                 coordinates[1] = propArtifactId
-             }
+            String propArtifactId = project.liberty.runtime.getProperty("name")
+            if (propArtifactId != null) {
+                coordinates[1] = propArtifactId
+            }
 
-             String propVersion = project.liberty.runtime.getProperty("version")
-             if (propVersion != null) {
-                 coordinates[2] = propVersion
-             }
-         }
+            String propVersion = project.liberty.runtime.getProperty("version")
+            if (propVersion != null) {
+                coordinates[2] = propVersion
+            }
+        }
 
-         // check for overridden liberty runtime properties in project properties
-         if (!libertyRuntimeProjectProps.isEmpty()) {
-             String propGroupId = libertyRuntimeProjectProps.getProperty("group")
-             if (propGroupId != null) {
-                 coordinates[0] = propGroupId
-             }
+        // check for overridden liberty runtime properties in project properties
+        if (!libertyRuntimeProjectProps.isEmpty()) {
+            String propGroupId = libertyRuntimeProjectProps.getProperty("group")
+            if (propGroupId != null) {
+                coordinates[0] = propGroupId
+            }
 
-             String propArtifactId = libertyRuntimeProjectProps.getProperty("name")
-             if (propArtifactId != null) {
-                 coordinates[1] = propArtifactId
-             }
+            String propArtifactId = libertyRuntimeProjectProps.getProperty("name")
+            if (propArtifactId != null) {
+                coordinates[1] = propArtifactId
+            }
 
-             String propVersion = libertyRuntimeProjectProps.getProperty("version")
-             if (propVersion != null) {
-                 coordinates[2] = propVersion
-             }
-         }
+            String propVersion = libertyRuntimeProjectProps.getProperty("version")
+            if (propVersion != null) {
+                coordinates[2] = propVersion
+            }
+        }
 
-         updatedCoords = coordinates[0] + ':' + coordinates[1] + ':' + coordinates[2]
-         if ( (useDefault && !updatedCoords.equals(defaultRuntime)) ||
-              (!useDefault && !updatedCoords.equals(coords)) ) {
-            logger.debug 'Updated Liberty runtime coordinates: ' + updatedCoords
-         }
+        updatedCoords = coordinates[0] + ':' + coordinates[1] + ':' + coordinates[2]
+        if ( (useDefault && !updatedCoords.equals(defaultRuntime)) ||
+            (!useDefault && !updatedCoords.equals(coords)) ) {
+                logger.debug 'Updated Liberty runtime coordinates: ' + updatedCoords
+        }
 
-         return updatedCoords
-     }
+        return updatedCoords
+    }
 
-     protected String getDefaultLibertyRuntimeCoordinates() {
+    @Internal
+    protected String getDefaultLibertyRuntimeCoordinates() {
 
-         // check for overrides in liberty.runtime properties
-         return getUpdatedLibertyRuntimeCoordinates(defaultRuntime)
-     }
+        // check for overrides in liberty.runtime properties
+        return getUpdatedLibertyRuntimeCoordinates(defaultRuntime)
+    }
 
     private void loadLibertyRuntimeProperties() {
         Set<Entry<Object, Object>> entries = project.getProperties().entrySet()

--- a/src/test/groovy/io/openliberty/tools/gradle/LibertyApplicationConfigurationM2DefaultTest.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/LibertyApplicationConfigurationM2DefaultTest.groovy
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corporation 2019.
+ * (C) Copyright IBM Corporation 2019, 2020.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ class LibertyApplicationConfigurationM2DefaultTest extends AbstractIntegrationTe
         createTestProject(buildDir, resourceDir, buildFilename)
         try {
             //Installing the war built by the other gradle project in the src dir
-            runTasks(new File(buildDir, 'test-maven-war'), 'install')
+            runTasks(new File(buildDir, 'test-maven-war'), 'publishToMavenLocal')
             //Then installing that war from m2 to the apps directory through the libertyApp configuration
             runTasks(buildDir, 'deploy')
         } catch (Exception e) {

--- a/src/test/groovy/io/openliberty/tools/gradle/LibertyApplicationConfigurationM2Test.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/LibertyApplicationConfigurationM2Test.groovy
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corporation 2019.
+ * (C) Copyright IBM Corporation 2019, 2020.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ class LibertyApplicationConfigurationM2Test extends AbstractIntegrationTest {
         createTestProject(buildDir, resourceDir, buildFilename)
         try {
             //Installing the war built by the other gradle project in the src dir
-            runTasks(new File(buildDir, 'test-maven-war'), 'install')
+            runTasks(new File(buildDir, 'test-maven-war'), 'publishToMavenLocal')
             //Then installing that war from m2 to the apps directory through the libertyApp configuration
             runTasks(buildDir, 'deploy')
         } catch (Exception e) {

--- a/src/test/resources/app-configuration-m2-default-test/test-maven-war/build.gradle
+++ b/src/test/resources/app-configuration-m2-default-test/test-maven-war/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'war'
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 
 group = 'test'
 version = '1.0-SNAPSHOT'
@@ -17,7 +17,7 @@ repositories {
 }
 
 dependencies {
-    compile group: 'org.apache.httpcomponents', name: 'httpcore', version:'4.4.6'
-    compile group: 'org.apache.httpcomponents', name: 'httpclient', version:'4.5.2'
+    implementation group: 'org.apache.httpcomponents', name: 'httpcore', version:'4.4.6'
+    implementation group: 'org.apache.httpcomponents', name: 'httpclient', version:'4.5.2'
     providedCompile group: 'javax.servlet', name: 'javax.servlet-api', version:'3.1.0'
 }

--- a/src/test/resources/app-configuration-m2-default-test/test-maven-war/build.gradle
+++ b/src/test/resources/app-configuration-m2-default-test/test-maven-war/build.gradle
@@ -16,6 +16,14 @@ repositories {
     mavenLocal()
 }
 
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            artifact war
+        }
+    }
+}
+
 dependencies {
     implementation group: 'org.apache.httpcomponents', name: 'httpcore', version:'4.4.6'
     implementation group: 'org.apache.httpcomponents', name: 'httpclient', version:'4.5.2'

--- a/src/test/resources/app-configuration-m2-test/test-maven-war/build.gradle
+++ b/src/test/resources/app-configuration-m2-test/test-maven-war/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'war'
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 
 group = 'test'
 version = '1.0-SNAPSHOT'
@@ -17,7 +17,7 @@ repositories {
 }
 
 dependencies {
-    compile group: 'org.apache.httpcomponents', name: 'httpcore', version:'4.4.6'
-    compile group: 'org.apache.httpcomponents', name: 'httpclient', version:'4.5.2'
+    implementation group: 'org.apache.httpcomponents', name: 'httpcore', version:'4.4.6'
+    implementation group: 'org.apache.httpcomponents', name: 'httpclient', version:'4.5.2'
     providedCompile group: 'javax.servlet', name: 'javax.servlet-api', version:'3.1.0'
 }

--- a/src/test/resources/app-configuration-m2-test/test-maven-war/build.gradle
+++ b/src/test/resources/app-configuration-m2-test/test-maven-war/build.gradle
@@ -16,8 +16,18 @@ repositories {
     mavenLocal()
 }
 
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            artifact war
+        }
+    }
+}
+
 dependencies {
     implementation group: 'org.apache.httpcomponents', name: 'httpcore', version:'4.4.6'
     implementation group: 'org.apache.httpcomponents', name: 'httpclient', version:'4.5.2'
     providedCompile group: 'javax.servlet', name: 'javax.servlet-api', version:'3.1.0'
 }
+
+publishToMavenLocal.dependsOn war

--- a/src/test/resources/arquillian-tests/build.gradle
+++ b/src/test/resources/arquillian-tests/build.gradle
@@ -33,8 +33,6 @@ allprojects {
         }
     }
 
-    check.dependsOn.remove(test)
-
     task copyArquillianXml(type: Copy) {
         from '../src/test-profile-resources'
         into '../build/resources/test'
@@ -68,12 +66,12 @@ dependencyManagement {
 }
 
 dependencies {
-    compile ('javax.enterprise:cdi-api:1.2')
+    implementation ('javax.enterprise:cdi-api:1.2')
    
-    testCompile "io.openliberty.tools:ci.common:1.7"
-    testCompile group: "io.openliberty.arquillian", name: "arquillian-liberty-managed-junit", version: "1.1.6"
-    testCompile ('org.jboss.shrinkwrap:shrinkwrap-api')
-    testCompile files("${System.properties['java.home']}/../lib/tools.jar")
+    testImplementation "io.openliberty.tools:ci.common:1.7"
+    testImplementation group: "io.openliberty.arquillian", name: "arquillian-liberty-managed-junit", version: "1.1.6"
+    testImplementation ('org.jboss.shrinkwrap:shrinkwrap-api')
+    testImplementation files("${System.properties['java.home']}/../lib/tools.jar")
 
     arqManaged "io.openliberty.arquillian:arquillian-liberty-managed:1.0.6"
     arqRemote "io.openliberty.arquillian:arquillian-liberty-remote:1.0.6"
@@ -81,7 +79,7 @@ dependencies {
     libertyRuntime group: runtimeGroup, name: runtimeArtifactId, version: runtimeVersion
 
     if(JavaVersion.current().isJava11()) {
-        compile "javax.annotation:javax.annotation-api:1.3.2"
+        implementation "javax.annotation:javax.annotation-api:1.3.2"
     }
 }
 

--- a/src/test/resources/arquillian-tests/skipWithXmlManaged/build.gradle
+++ b/src/test/resources/arquillian-tests/skipWithXmlManaged/build.gradle
@@ -16,7 +16,7 @@ buildscript {
 project.buildDir = '../build'
 
 dependencies {
-    compile 'io.openliberty.arquillian:arquillian-liberty-managed:1.0.2'
+    implementation 'io.openliberty.arquillian:arquillian-liberty-managed:1.0.2'
 }
 
 task configArq (type:ConfigureArquillianTask) {

--- a/src/test/resources/arquillian-tests/skipWithXmlRemote/build.gradle
+++ b/src/test/resources/arquillian-tests/skipWithXmlRemote/build.gradle
@@ -16,7 +16,7 @@ buildscript {
 project.buildDir = '../build'
 
 dependencies {
-    compile 'io.openliberty.arquillian:arquillian-liberty-remote:1.0.2'
+    implementation 'io.openliberty.arquillian:arquillian-liberty-remote:1.0.2'
 }
 
 task configArq (type:ConfigureArquillianTask) {

--- a/src/test/resources/arquillian-tests/skipWithoutXmlManaged/build.gradle
+++ b/src/test/resources/arquillian-tests/skipWithoutXmlManaged/build.gradle
@@ -16,7 +16,7 @@ buildscript {
 project.buildDir = '../build'
 
 dependencies {
-    compile 'io.openliberty.arquillian:arquillian-liberty-managed:1.0.2'
+    implementation 'io.openliberty.arquillian:arquillian-liberty-managed:1.0.2'
 }
 
 task configArq (type:ConfigureArquillianTask) {

--- a/src/test/resources/arquillian-tests/skipWithoutXmlRemote/build.gradle
+++ b/src/test/resources/arquillian-tests/skipWithoutXmlRemote/build.gradle
@@ -16,7 +16,7 @@ buildscript {
 project.buildDir = '../build'
 
 dependencies {
-    compile 'io.openliberty.arquillian:arquillian-liberty-remote:1.0.2'
+    implementation 'io.openliberty.arquillian:arquillian-liberty-remote:1.0.2'
 }
 
 task configArq (type:ConfigureArquillianTask) {

--- a/src/test/resources/arquillian-tests/verifyMainAppManaged/build.gradle
+++ b/src/test/resources/arquillian-tests/verifyMainAppManaged/build.gradle
@@ -16,7 +16,7 @@ buildscript {
 project.buildDir = '../build'
 
 dependencies {
-    compile 'io.openliberty.arquillian:arquillian-liberty-managed:1.0.2'
+    implementation 'io.openliberty.arquillian:arquillian-liberty-managed:1.0.2'
 }
 
 task configArq (type:ConfigureArquillianTask) {

--- a/src/test/resources/liberty-package-test/liberty-package-looseApplication.gradle
+++ b/src/test/resources/liberty-package-test/liberty-package-looseApplication.gradle
@@ -68,11 +68,11 @@ configurations{
 }
 
 dependencies {
-    compile group: 'javax.persistence', name: 'persistence-api', version:'1.0.2'
-    compile group: 'javax.transaction', name: 'javax.transaction-api', version:'1.2'
-    testCompile group: 'junit', name: 'junit', version:'4.12'
-    testCompile group: 'org.apache.cxf', name: 'cxf-rt-rs-client', version:'3.1.1'
-    testCompile group: 'org.glassfish', name: 'javax.json', version:'1.0.4'
+    implementation group: 'javax.persistence', name: 'persistence-api', version:'1.0.2'
+    implementation group: 'javax.transaction', name: 'javax.transaction-api', version:'1.2'
+    testImplementation group: 'junit', name: 'junit', version:'4.12'
+    testImplementation group: 'org.apache.cxf', name: 'cxf-rt-rs-client', version:'3.1.1'
+    testImplementation group: 'org.glassfish', name: 'javax.json', version:'1.0.4'
     providedCompile group: 'javax.servlet', name: 'javax.servlet-api', version:'3.1.0'
     derby group: 'org.apache.derby', name: 'derby', version: '10.13.1.1'
     libertyRuntime group: 'com.ibm.websphere.appserver.runtime', name: 'wlp-kernel', version: runtimeVersion

--- a/src/test/resources/loose-ear-test/build.gradle
+++ b/src/test/resources/loose-ear-test/build.gradle
@@ -1,6 +1,4 @@
 allprojects  {
-    apply plugin: 'maven'
-
     group = 'sample'
     version = '1.0'
 }

--- a/src/test/resources/loose-ear-test/ejb-ear/build.gradle
+++ b/src/test/resources/loose-ear-test/ejb-ear/build.gradle
@@ -25,8 +25,8 @@ repositories {
 dependencies {
     deploy project(':ejb-ejb')
     deploy project(path:':ejb-war', configuration:'archives')
-    testCompile group: 'commons-httpclient', name: 'commons-httpclient', version:'3.1'
-    testCompile group: 'junit', name: 'junit', version:'4.12'
+    testImplementation group: 'commons-httpclient', name: 'commons-httpclient', version:'3.1'
+    testImplementation group: 'junit', name: 'junit', version:'4.12'
     libertyRuntime group: runtimeGroup, name: runtimeArtifactId, version: runtimeVersion
 }
 

--- a/src/test/resources/loose-ear-test/ejb-ejb/build.gradle
+++ b/src/test/resources/loose-ear-test/ejb-ejb/build.gradle
@@ -2,7 +2,7 @@
 description = 'EJB Module'
 
 dependencies {
-    testCompile group: 'junit', name: 'junit', version:'4.12'
+    testImplementation group: 'junit', name: 'junit', version:'4.12'
     compileOnly group: 'javax', name: 'javaee-api', version:'7.0'
 }
 

--- a/src/test/resources/loose-ear-test/ejb-war/build.gradle
+++ b/src/test/resources/loose-ear-test/ejb-war/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'war'
 jar.enabled = false
 description = 'WAR Module'
 dependencies {
-    testCompile group: 'junit', name: 'junit', version:'4.12'
+    testImplementation group: 'junit', name: 'junit', version:'4.12'
     providedCompile group: 'javax', name: 'javaee-api', version:'7.0'
     providedCompile project(':ejb-ejb')
 }

--- a/src/test/resources/sample.servlet-noWebAppConfig/getAppNamesFromConfigTest.gradle
+++ b/src/test/resources/sample.servlet-noWebAppConfig/getAppNamesFromConfigTest.gradle
@@ -15,7 +15,6 @@ buildscript {
     }
 }
 
-apply plugin: 'maven'
 apply plugin: 'war'
 apply plugin: 'liberty'
 
@@ -79,9 +78,9 @@ repositories {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.apache.cxf:cxf-rt-rs-client:3.1.1'
-    testCompile 'org.glassfish:javax.json:1.0.4'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.apache.cxf:cxf-rt-rs-client:3.1.1'
+    testImplementation 'org.glassfish:javax.json:1.0.4'
     providedCompile group: 'javax.servlet', name: 'javax.servlet-api', version:'3.1.0'
     libertyRuntime group: runtimeGroup, name: runtimeArtifactId, version: runtimeVersion
 }

--- a/src/test/resources/sample.servlet-noWebAppConfig/testAppListsWithObjects.gradle
+++ b/src/test/resources/sample.servlet-noWebAppConfig/testAppListsWithObjects.gradle
@@ -15,7 +15,6 @@ buildscript {
     }
 }
 
-apply plugin: 'maven'
 apply plugin: 'war'
 apply plugin: 'liberty'
 
@@ -79,9 +78,9 @@ repositories {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.apache.cxf:cxf-rt-rs-client:3.1.1'
-    testCompile 'org.glassfish:javax.json:1.0.4'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.apache.cxf:cxf-rt-rs-client:3.1.1'
+    testImplementation 'org.glassfish:javax.json:1.0.4'
     providedCompile group: 'javax.servlet', name: 'javax.servlet-api', version:'3.1.0'
     libertyRuntime group: runtimeGroup, name: runtimeArtifactId, version: runtimeVersion
 }

--- a/src/test/resources/sample.servlet-noWebAppConfig/testWarTasksWithDifferentDependencies.gradle
+++ b/src/test/resources/sample.servlet-noWebAppConfig/testWarTasksWithDifferentDependencies.gradle
@@ -15,7 +15,6 @@ buildscript {
     }
 }
 
-apply plugin: 'maven'
 apply plugin: 'war'
 apply plugin: 'liberty'
 
@@ -48,9 +47,9 @@ repositories {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.apache.cxf:cxf-rt-rs-client:3.1.1'
-    testCompile 'org.glassfish:javax.json:1.0.4'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.apache.cxf:cxf-rt-rs-client:3.1.1'
+    testImplementation 'org.glassfish:javax.json:1.0.4'
     providedCompile group: 'javax.servlet', name: 'javax.servlet-api', version:'3.1.0'
     war2 'org.apache.commons:commons-proxy:1.0'
     war4 'org.apache.commons:commons-text:1.1'

--- a/src/test/resources/sample.servlet-noWebAppConfig/verifyTimeoutSuccessListsOfAppsTest.gradle
+++ b/src/test/resources/sample.servlet-noWebAppConfig/verifyTimeoutSuccessListsOfAppsTest.gradle
@@ -15,7 +15,6 @@ buildscript {
     }
 }
 
-apply plugin: 'maven'
 apply plugin: 'war'
 apply plugin: 'liberty'
 
@@ -77,9 +76,9 @@ repositories {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.apache.cxf:cxf-rt-rs-client:3.1.1'
-    testCompile 'org.glassfish:javax.json:1.0.4'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.apache.cxf:cxf-rt-rs-client:3.1.1'
+    testImplementation 'org.glassfish:javax.json:1.0.4'
     providedCompile group: 'javax.servlet', name: 'javax.servlet-api', version:'3.1.0'
     libertyRuntime group: runtimeGroup, name: runtimeArtifactId, version: runtimeVersion
 }

--- a/src/test/resources/sample.servlet/TestStripVersion.gradle
+++ b/src/test/resources/sample.servlet/TestStripVersion.gradle
@@ -19,7 +19,6 @@ buildscript {
     }
 }
 
-apply plugin: 'maven'
 apply plugin: 'war'
 apply plugin: 'liberty'
 
@@ -56,7 +55,7 @@ repositories {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
     providedCompile group: 'javax.servlet', name: 'javax.servlet-api', version:'3.1.0'
     libertyRuntime group: runtimeGroup, name: runtimeArtifactId, version: runtimeVersion
 }

--- a/src/test/resources/sample.servlet/noAppsTemplateTest.gradle
+++ b/src/test/resources/sample.servlet/noAppsTemplateTest.gradle
@@ -28,9 +28,9 @@ task war2 (type: War) {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.apache.cxf:cxf-rt-rs-client:3.1.1'
-    testCompile 'org.glassfish:javax.json:1.0.4'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.apache.cxf:cxf-rt-rs-client:3.1.1'
+    testImplementation 'org.glassfish:javax.json:1.0.4'
     providedCompile group: 'javax.servlet', name: 'javax.servlet-api', version:'3.1.0'
     libertyRuntime group: runtimeGroup, name: runtimeArtifactId, version: runtimeVersion
 }

--- a/src/test/resources/sample.servlet/testAppConfig.gradle
+++ b/src/test/resources/sample.servlet/testAppConfig.gradle
@@ -15,7 +15,6 @@ buildscript {
     }
 }
 
-apply plugin: 'maven'
 apply plugin: 'war'
 apply plugin: 'liberty'
 
@@ -58,9 +57,9 @@ repositories {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.apache.cxf:cxf-rt-rs-client:3.1.1'
-    testCompile 'org.glassfish:javax.json:1.0.4'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.apache.cxf:cxf-rt-rs-client:3.1.1'
+    testImplementation 'org.glassfish:javax.json:1.0.4'
     providedCompile group: 'javax.servlet', name: 'javax.servlet-api', version:'3.1.0'
     libertyRuntime group: runtimeGroup, name: runtimeArtifactId, version: runtimeVersion
 }

--- a/src/test/resources/sample.servlet/testAppConfigFail.gradle
+++ b/src/test/resources/sample.servlet/testAppConfigFail.gradle
@@ -15,7 +15,6 @@ buildscript {
     }
 }
 
-apply plugin: 'maven'
 apply plugin: 'war'
 apply plugin: 'liberty'
 
@@ -61,7 +60,7 @@ repositories {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
     providedCompile group: 'javax.servlet', name: 'javax.servlet-api', version:'3.1.0'
     libertyRuntime group: runtimeGroup, name: runtimeArtifactId, version: runtimeVersion
 }

--- a/src/test/resources/sample.servlet/testConfigDropinsApp.gradle
+++ b/src/test/resources/sample.servlet/testConfigDropinsApp.gradle
@@ -15,7 +15,6 @@ buildscript {
     }
 }
 
-apply plugin: 'maven'
 apply plugin: 'war'
 apply plugin: 'liberty'
 
@@ -67,9 +66,9 @@ repositories {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.apache.cxf:cxf-rt-rs-client:3.1.1'
-    testCompile 'org.glassfish:javax.json:1.0.4'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.apache.cxf:cxf-rt-rs-client:3.1.1'
+    testImplementation 'org.glassfish:javax.json:1.0.4'
     providedCompile group: 'javax.servlet', name: 'javax.servlet-api', version:'3.1.0'
     libertyRuntime group: runtimeGroup, name: runtimeArtifactId, version: runtimeVersion
 }

--- a/src/test/resources/sample.servlet/testEtcOutputDir.gradle
+++ b/src/test/resources/sample.servlet/testEtcOutputDir.gradle
@@ -15,7 +15,6 @@ buildscript {
     }
 }
 
-apply plugin: 'maven'
 apply plugin: 'war'
 apply plugin: 'liberty'
 
@@ -80,9 +79,9 @@ repositories {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.apache.cxf:cxf-rt-rs-client:3.1.1'
-    testCompile 'org.glassfish:javax.json:1.0.4'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.apache.cxf:cxf-rt-rs-client:3.1.1'
+    testImplementation 'org.glassfish:javax.json:1.0.4'
     providedCompile group: 'javax.servlet', name: 'javax.servlet-api', version:'3.1.0'
     libertyRuntime group: runtimeGroup, name: runtimeArtifactId, version: runtimeVersion
 }

--- a/src/test/resources/sample.servlet/testLooseApplication.gradle
+++ b/src/test/resources/sample.servlet/testLooseApplication.gradle
@@ -19,7 +19,6 @@ buildscript {
     }
 }
 
-apply plugin: 'maven'
 apply plugin: 'war'
 apply plugin: 'liberty'
 
@@ -58,9 +57,9 @@ repositories {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
     providedCompile group: 'javax.servlet', name: 'javax.servlet-api', version:'3.1.0'
-    compile 'org.apache.commons:commons-text:1.1'
+    implementation 'org.apache.commons:commons-text:1.1'
     libertyRuntime group: runtimeGroup, name: runtimeArtifactId, version: runtimeVersion
 }
 

--- a/src/test/resources/sample.servlet/testLooseApplicationWithWarTask.gradle
+++ b/src/test/resources/sample.servlet/testLooseApplicationWithWarTask.gradle
@@ -20,7 +20,6 @@ buildscript {
 }
 
 apply plugin: 'java'
-apply plugin: 'maven'
 apply plugin: 'war'
 apply plugin: 'liberty'
 
@@ -49,9 +48,9 @@ repositories {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
     providedCompile group: 'javax.servlet', name: 'javax.servlet-api', version:'3.1.0'
-    compile 'org.apache.commons:commons-text:1.1'
+    implementation 'org.apache.commons:commons-text:1.1'
     libertyRuntime group: runtimeGroup, name: runtimeArtifactId, version: runtimeVersion
 }
 

--- a/src/test/resources/sample.servlet/testOutputDirs.gradle
+++ b/src/test/resources/sample.servlet/testOutputDirs.gradle
@@ -15,7 +15,6 @@ buildscript {
     }
 }
 
-apply plugin: 'maven'
 apply plugin: 'war'
 apply plugin: 'liberty'
 
@@ -75,9 +74,9 @@ repositories {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.apache.cxf:cxf-rt-rs-client:3.1.1'
-    testCompile 'org.glassfish:javax.json:1.0.4'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.apache.cxf:cxf-rt-rs-client:3.1.1'
+    testImplementation 'org.glassfish:javax.json:1.0.4'
     providedCompile group: 'javax.servlet', name: 'javax.servlet-api', version:'3.1.0'
     libertyRuntime group: runtimeGroup, name: runtimeArtifactId, version: runtimeVersion
 }

--- a/src/test/resources/sample.servlet/testPluginConfigFile.gradle
+++ b/src/test/resources/sample.servlet/testPluginConfigFile.gradle
@@ -18,7 +18,6 @@ buildscript {
     }
 }
 
-apply plugin: 'maven'
 apply plugin: 'war'
 apply plugin: 'liberty'
 
@@ -57,9 +56,9 @@ repositories {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
     providedCompile group: 'javax.servlet', name: 'javax.servlet-api', version:'3.1.0'
-    compile 'org.apache.commons:commons-text:1.1'
+    implementation 'org.apache.commons:commons-text:1.1'
     libertyRuntime group: runtimeGroup, name: runtimeArtifactId, version: runtimeVersion
 }
 

--- a/src/test/resources/sample.servlet/verifyLooseAppTestTimeoutSuccess.gradle
+++ b/src/test/resources/sample.servlet/verifyLooseAppTestTimeoutSuccess.gradle
@@ -15,7 +15,6 @@ buildscript {
     }
 }
 
-apply plugin: 'maven'
 apply plugin: 'war'
 apply plugin: 'liberty'
 
@@ -61,11 +60,11 @@ repositories {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.apache.cxf:cxf-rt-rs-client:3.1.1'
-    testCompile 'org.glassfish:javax.json:1.0.4'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.apache.cxf:cxf-rt-rs-client:3.1.1'
+    testImplementation 'org.glassfish:javax.json:1.0.4'
     providedCompile group: 'javax.servlet', name: 'javax.servlet-api', version:'3.1.0'
-    compile 'org.apache.commons:commons-text:1.1'
+    implementation 'org.apache.commons:commons-text:1.1'
     libertyRuntime group: runtimeGroup, name: runtimeArtifactId, version: runtimeVersion
 }
 

--- a/src/test/resources/sample.servlet/verifyTimeoutSuccessAppsTest.gradle
+++ b/src/test/resources/sample.servlet/verifyTimeoutSuccessAppsTest.gradle
@@ -15,7 +15,6 @@ buildscript {
     }
 }
 
-apply plugin: 'maven'
 apply plugin: 'liberty'
 apply plugin: 'war'
 
@@ -61,9 +60,9 @@ repositories {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.apache.cxf:cxf-rt-rs-client:3.1.1'
-    testCompile 'org.glassfish:javax.json:1.0.4'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.apache.cxf:cxf-rt-rs-client:3.1.1'
+    testImplementation 'org.glassfish:javax.json:1.0.4'
     providedCompile group: 'javax.servlet', name: 'javax.servlet-api', version:'3.1.0'
     libertyRuntime group: runtimeGroup, name: runtimeArtifactId, version: runtimeVersion
 }

--- a/src/test/resources/sample.servlet/verifyTimeoutSuccessDropinsTest.gradle
+++ b/src/test/resources/sample.servlet/verifyTimeoutSuccessDropinsTest.gradle
@@ -15,7 +15,6 @@ buildscript {
     }
 }
 
-apply plugin: 'maven'
 apply plugin: 'war'
 apply plugin: 'liberty'
 
@@ -65,9 +64,9 @@ repositories {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.apache.cxf:cxf-rt-rs-client:3.1.1'
-    testCompile 'org.glassfish:javax.json:1.0.4'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.apache.cxf:cxf-rt-rs-client:3.1.1'
+    testImplementation 'org.glassfish:javax.json:1.0.4'
     providedCompile group: 'javax.servlet', name: 'javax.servlet-api', version:'3.1.0'
     libertyRuntime group: runtimeGroup, name: runtimeArtifactId, version: runtimeVersion
 }

--- a/src/test/resources/sample.springboot/test_spring_boot_apps_15.gradle
+++ b/src/test/resources/sample.springboot/test_spring_boot_apps_15.gradle
@@ -24,8 +24,8 @@ repositories {
 	mavenCentral()
 }
 dependencies {
-	compile("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")
-	testCompile('org.springframework.boot:spring-boot-starter-test')
+	implementation("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")
+	testImplementation('org.springframework.boot:spring-boot-starter-test')
 	libertyRuntime group: runtimeGroup, name: runtimeArtifactId, version: runtimeVersion
 }
 

--- a/src/test/resources/sample.springboot/test_spring_boot_apps_15.gradle
+++ b/src/test/resources/sample.springboot/test_spring_boot_apps_15.gradle
@@ -24,8 +24,8 @@ repositories {
 	mavenCentral()
 }
 dependencies {
-	implementation("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")
-	testImplementation('org.springframework.boot:spring-boot-starter-test')
+	compile("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")
+	testCompile('org.springframework.boot:spring-boot-starter-test')
 	libertyRuntime group: runtimeGroup, name: runtimeArtifactId, version: runtimeVersion
 }
 

--- a/src/test/resources/sample.springboot/test_spring_boot_apps_20.gradle
+++ b/src/test/resources/sample.springboot/test_spring_boot_apps_20.gradle
@@ -24,8 +24,8 @@ repositories {
 	mavenCentral()
 }
 dependencies {
-	compile("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")
-	testCompile('org.springframework.boot:spring-boot-starter-test')
+	implementation("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")
+	testImplementation('org.springframework.boot:spring-boot-starter-test')
 	libertyRuntime group: runtimeGroup, name: runtimeArtifactId, version: runtimeVersion
 }
 

--- a/src/test/resources/sample.springboot/test_spring_boot_classifier_apps_15.gradle
+++ b/src/test/resources/sample.springboot/test_spring_boot_classifier_apps_15.gradle
@@ -24,8 +24,8 @@ repositories {
 	mavenCentral()
 }
 dependencies {
-	compile("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")
-	testCompile('org.springframework.boot:spring-boot-starter-test')
+	implementation("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")
+	testImplementation('org.springframework.boot:spring-boot-starter-test')
 	libertyRuntime group: runtimeGroup, name: runtimeArtifactId, version: runtimeVersion
 }
 

--- a/src/test/resources/sample.springboot/test_spring_boot_classifier_apps_15.gradle
+++ b/src/test/resources/sample.springboot/test_spring_boot_classifier_apps_15.gradle
@@ -24,8 +24,8 @@ repositories {
 	mavenCentral()
 }
 dependencies {
-	implementation("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")
-	testImplementation('org.springframework.boot:spring-boot-starter-test')
+	compile("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")
+	testCompile('org.springframework.boot:spring-boot-starter-test')
 	libertyRuntime group: runtimeGroup, name: runtimeArtifactId, version: runtimeVersion
 }
 

--- a/src/test/resources/sample.springboot/test_spring_boot_classifier_apps_20.gradle
+++ b/src/test/resources/sample.springboot/test_spring_boot_classifier_apps_20.gradle
@@ -24,8 +24,8 @@ repositories {
 	mavenCentral()
 }
 dependencies {
-	compile("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")
-	testCompile('org.springframework.boot:spring-boot-starter-test')
+	implementation("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")
+	testImplementation('org.springframework.boot:spring-boot-starter-test')
 	libertyRuntime group: runtimeGroup, name: runtimeArtifactId, version: runtimeVersion
 }
 

--- a/src/test/resources/sample.springboot/test_spring_boot_dropins_15.gradle
+++ b/src/test/resources/sample.springboot/test_spring_boot_dropins_15.gradle
@@ -24,8 +24,8 @@ repositories {
 	mavenCentral()
 }
 dependencies {
-	compile("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")
-	testCompile('org.springframework.boot:spring-boot-starter-test')
+	implementation("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")
+	testImplementation('org.springframework.boot:spring-boot-starter-test')
 	libertyRuntime group: runtimeGroup, name: runtimeArtifactId, version: runtimeVersion
 }
 

--- a/src/test/resources/sample.springboot/test_spring_boot_dropins_15.gradle
+++ b/src/test/resources/sample.springboot/test_spring_boot_dropins_15.gradle
@@ -24,8 +24,8 @@ repositories {
 	mavenCentral()
 }
 dependencies {
-	implementation("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")
-	testImplementation('org.springframework.boot:spring-boot-starter-test')
+	compile("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")
+	testCompile('org.springframework.boot:spring-boot-starter-test')
 	libertyRuntime group: runtimeGroup, name: runtimeArtifactId, version: runtimeVersion
 }
 

--- a/src/test/resources/sample.springboot/test_spring_boot_dropins_20.gradle
+++ b/src/test/resources/sample.springboot/test_spring_boot_dropins_20.gradle
@@ -24,8 +24,8 @@ repositories {
 	mavenCentral()
 }
 dependencies {
-	compile("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")
-	testCompile('org.springframework.boot:spring-boot-starter-test')
+	implementation("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")
+	testImplementation('org.springframework.boot:spring-boot-starter-test')
 	libertyRuntime group: runtimeGroup, name: runtimeArtifactId, version: runtimeVersion
 }
 

--- a/src/test/resources/sample.springboot/test_spring_boot_war_apps_20.gradle
+++ b/src/test/resources/sample.springboot/test_spring_boot_war_apps_20.gradle
@@ -24,8 +24,8 @@ repositories {
 	mavenCentral()
 }
 dependencies {
-	compile("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")
-	testCompile('org.springframework.boot:spring-boot-starter-test')
+	implementation("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")
+	testImplementation('org.springframework.boot:spring-boot-starter-test')
 	libertyRuntime group: runtimeGroup, name: runtimeArtifactId, version: runtimeVersion
 }
 

--- a/src/test/resources/sample.springboot/test_spring_boot_war_classifier_apps_20.gradle
+++ b/src/test/resources/sample.springboot/test_spring_boot_war_classifier_apps_20.gradle
@@ -24,8 +24,8 @@ repositories {
 	mavenCentral()
 }
 dependencies {
-	compile("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")
-	testCompile('org.springframework.boot:spring-boot-starter-test')
+	implementation("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")
+	testImplementation('org.springframework.boot:spring-boot-starter-test')
 	libertyRuntime group: runtimeGroup, name: runtimeArtifactId, version: runtimeVersion
 }
 

--- a/src/test/resources/sampleJSP.servlet/testCompileJSP.gradle
+++ b/src/test/resources/sampleJSP.servlet/testCompileJSP.gradle
@@ -58,10 +58,10 @@ repositories {
 }
 
 dependencies {
-    testCompile group: 'commons-logging', name: 'commons-logging', version:'1.0.4'
-    testCompile group: 'junit', name: 'junit', version:'4.9'
+    testImplementation group: 'commons-logging', name: 'commons-logging', version:'1.0.4'
+    testImplementation group: 'junit', name: 'junit', version:'4.9'
     providedCompile group: 'org.apache.geronimo.specs', name: 'geronimo-servlet_3.0_spec', version:'1.0'
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
     providedCompile group: 'javax.servlet', name: 'javax.servlet-api', version:'3.1.0'
     libertyRuntime group: runtimeGroup, name: runtimeArtifactId, version: runtimeVersion
 }

--- a/src/test/resources/server-config-files/testCreateLibertyFiles.gradle
+++ b/src/test/resources/server-config-files/testCreateLibertyFiles.gradle
@@ -16,7 +16,6 @@ buildscript {
 }
 
 apply plugin: 'java'
-apply plugin: 'maven'
 apply plugin: 'liberty'
 
 sourceCompatibility = 1.7
@@ -49,7 +48,7 @@ repositories {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
     libertyRuntime group: runtimeGroup, name: runtimeArtifactId, version: runtimeVersion
 }
 

--- a/src/test/resources/server-config-files/testCreateLibertyInlineProperties.gradle
+++ b/src/test/resources/server-config-files/testCreateLibertyInlineProperties.gradle
@@ -16,7 +16,6 @@ buildscript {
 }
 
 apply plugin: 'java'
-apply plugin: 'maven'
 apply plugin: 'liberty'
 
 sourceCompatibility = 1.7
@@ -55,7 +54,7 @@ repositories {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
     libertyRuntime group: runtimeGroup, name: runtimeArtifactId, version: runtimeVersion
 }
 

--- a/src/test/resources/server-config/testCreateLibertyConfigDir.gradle
+++ b/src/test/resources/server-config/testCreateLibertyConfigDir.gradle
@@ -16,7 +16,6 @@ buildscript {
 }
 
 apply plugin: 'java'
-apply plugin: 'maven'
 apply plugin: 'liberty'
 
 sourceCompatibility = 1.7
@@ -46,7 +45,7 @@ repositories {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
     libertyRuntime group: runtimeGroup, name: runtimeArtifactId, version: runtimeVersion
 }
 

--- a/src/test/resources/server-config/testCreateLibertyDefaultConfigDir.gradle
+++ b/src/test/resources/server-config/testCreateLibertyDefaultConfigDir.gradle
@@ -16,7 +16,6 @@ buildscript {
 }
 
 apply plugin: 'java'
-apply plugin: 'maven'
 apply plugin: 'liberty'
 
 sourceCompatibility = 1.7
@@ -33,7 +32,7 @@ repositories {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
     libertyRuntime group: runtimeGroup, name: runtimeArtifactId, version: runtimeVersion
 }
 


### PR DESCRIPTION
Most of the warnings shown when a build is run with `--warning-mode all` should be fixed. Deploy will still have a warning when run with `--warning-mode all`. I chose to keep using the `baseName` property from the war/ear tasks rather than the `archiveBaseName` property that is recommended. This is so builds on Gradle prior to 6.x will still work. I'm going to add the updated maven-publishing plugin config to the base build.gradle in a separate PR.

Changes:
- Removed unused maven plugins from test project build.gradle files
- Flagged getters as internal methods so Gradle would ignore them as task inputs
- Changed scopes of task variables so Gradle would ignore them as task inputs
- Updated dependency scopes for the plugin and test files
