### PR TITLE
Increase appveyor metaspace size

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,6 +34,7 @@ before_build:
 
 build_script:
     - cmd: |
+        set GRADLE_OPTS="-Dorg.gradle.jvmargs='-XX:MaxMetaspaceSize=512m'"
         gradlew.bat clean install check -Ptest.exclude="**/*15*","**/*LibertyTest*","**/*OldLibertyTest*","**/*LibertyMultiServerTest*" -Druntime=%RUNTIME% -DruntimeVersion=%RUNTIME_VERSION% --stacktrace --info --no-daemon
         gradlew.bat wrapper --gradle-version 4.10
         gradlew.bat clean install check -Ptest.include="**/*15*" -Druntime=%RUNTIME% -DruntimeVersion=%RUNTIME_VERSION% --stacktrace --info --no-daemon


### PR DESCRIPTION
Fixes the OutOfMemory errors in Windows Appveyor tests caused by PR https://github.com/OpenLiberty/ci.gradle/pull/398