### PR TITLE
libertyCreate depends on installFeature depends on installLiberty

### DIFF
--- a/docs/installFeature.md
+++ b/docs/installFeature.md
@@ -19,7 +19,7 @@ The `libertyFeature` dependency configuration can install features in Liberty ru
 You need to include `group`, `name`, and `version` values that describes the artifacts to use. An `ext` value for the ESA file type is not required.
 
 ### dependsOn
-`installFeature` depends on `installLiberty`. If no specific features are requested, `installFeature` depends on `libertyCreate` to evaluate the set of features in the server configuration file.
+`installFeature` depends on `installLiberty`.
 
 ### Properties
 

--- a/docs/libertyCreate.md
+++ b/docs/libertyCreate.md
@@ -4,11 +4,7 @@ The `libertyCreate` task is used to create a named Liberty server instance.
 
 ### dependsOn
 
-`libertyCreate` depends on `installLiberty`.
-
-### finalizedBy
-
-`libertyCreate` is finalized by `installFeature` if features are configured in the `build.gradle` file.
+`libertyCreate` depends on `installFeature`.
 
 ### Properties
 

--- a/src/main/groovy/io/openliberty/tools/gradle/LibertyTasks.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/LibertyTasks.groovy
@@ -46,9 +46,7 @@ public class LibertyTasks {
         }
 
         project.libertyCreate {
-            dependsOn 'installLiberty'
-            // Run install features if configured
-            finalizedBy 'installFeature'
+            dependsOn 'installFeature'
         }
 
         project.libertyStart {
@@ -66,7 +64,7 @@ public class LibertyTasks {
         }
 
         project.installFeature {
-            dependsOn 'libertyCreate'
+            dependsOn 'installLiberty'
         }
 
         project.cleanDirs {


### PR DESCRIPTION
Fixes #416

#398 caused installFeature to depend on libertyCreate, and libertyCreate to be finalized by installFeature. So the server is created before the features are installed, which causes the error seen in #416

Instead, the order should be: install Liberty runtime, then install features, then create the server.

So libertyCreate should depend on installFeature, and installFeature should depend on installLiberty.