### PR TITLE
Skip libertyCreate when installing features on server.xml change

### DIFF
--- a/docs/installFeature.md
+++ b/docs/installFeature.md
@@ -19,7 +19,7 @@ The `libertyFeature` dependency configuration can install features in Liberty ru
 You need to include `group`, `name`, and `version` values that describes the artifacts to use. An `ext` value for the ESA file type is not required.
 
 ### dependsOn
-`installFeature` depends on `installLiberty`. If no specific features are requested, `installFeature` depends on `libertyCreate` to evaluate the set of features in the server configuration file.
+`installFeature` depends on `libertyCreate` to evaluate the set of features in the server configuration file.
 
 ### Properties
 

--- a/docs/libertyCreate.md
+++ b/docs/libertyCreate.md
@@ -8,7 +8,7 @@ The `libertyCreate` task is used to create a named Liberty server instance.
 
 ### finalizedBy
 
-`libertyCreate` is finalized by `installFeature` if features are configured in the `build.gradle` file.
+`libertyCreate` is finalized by `installFeature`.
 
 ### Properties
 

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
@@ -471,6 +471,11 @@ class DevTask extends AbstractServerTask {
                 // Call the installFeature gradle task using the temporary serverDir directory that DevMode uses
                 ProjectConnection gradleConnection = initGradleProjectConnection();
                 BuildLauncher gradleBuildLauncher = gradleConnection.newBuild();
+
+                // Exclude libertyCreate from the task dependencies, so that it will not update the server features
+                // before the features are installed.
+                gradleBuildLauncher.withArguments("--exclude-task", "libertyCreate");
+
                 try {
                     runGradleTask(gradleBuildLauncher, "installFeature", "--serverDir=${serverDir.getAbsolutePath()}");
                     this.existingFeatures.addAll(features);


### PR DESCRIPTION
Fixes #416 

When running installFeature on server.xml change, exclude libertyCreate from the task dependencies so that it will not update the server features before the features are installed.