### PR TITLE
add test case and fix logger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ env:
     - RUNTIME=ol RUNTIME_VERSION=20.0.0.1
     - RUNTIME=ol RUNTIME_VERSION=19.0.0.9
 before_install:
-#    - echo 'Installing ci.common lib ....'
-#    - git clone https://github.com/OpenLiberty/ci.common.git ./ci.common
-#    - cd ./ci.common
-#    - mvn clean install
-#    - cd ..
+    - echo 'Installing ci.common lib ....'
+    - git clone https://github.com/OpenLiberty/ci.common.git ./ci.common
+    - cd ./ci.common
+    - mvn clean install
+    - cd ..
 #    - echo 'Installing ci.ant lib ....'
 #    - git clone https://github.com/OpenLiberty/ci.ant.git ./ci.ant
 #    - cd ./ci.ant

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,11 +21,11 @@ install:
 
 before_build:
     - cmd: |
-#        echo "Installing ci.common lib ...."
-#        git clone https://github.com/OpenLiberty/ci.common.git ci.common
-#        cd ci.common
-#        mvn clean install
-#        cd..
+        echo "Installing ci.common lib ...."
+        git clone https://github.com/OpenLiberty/ci.common.git ci.common
+        cd ci.common
+        mvn clean install
+        cd..
 #        echo "Installing ci.ant lib ...."
 #        git clone https://github.com/OpenLiberty/ci.ant.git ci.ant
 #        cd ci.ant

--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     implementation gradleApi()
     implementation localGroovy()
     implementation ('io.openliberty.tools:liberty-ant-tasks:1.9.3')
-    implementation ('io.openliberty.tools:ci.common:1.8.3')
+    implementation ('io.openliberty.tools:ci.common:1.8.4-SNAPSHOT')
     implementation group: 'commons-io', name: 'commons-io', version: '2.5'
     provided group: 'com.ibm.websphere.appserver.api', name: 'com.ibm.websphere.appserver.spi.kernel.embeddable', version: '1.0.0'
     testImplementation 'junit:junit:4.11'

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractServerTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractServerTask.groovy
@@ -458,7 +458,7 @@ abstract class AbstractServerTask extends AbstractTask {
         File serverConfigFile = new File(getServerDir(project), 'server.xml')
         if (serverConfigFile != null && serverConfigFile.exists()) {
             try {
-                ServerConfigDocument scd = ServerConfigDocument.getInstance(CommonLogger.getInstance(), serverConfigFile, server.configDirectory, server.bootstrapPropertiesFile, convertPropertiesToMap(server.bootstrapProperties), server.serverEnvFile, false);
+                ServerConfigDocument scd = ServerConfigDocument.getInstance(CommonLogger.getInstance(project), serverConfigFile, server.configDirectory, server.bootstrapPropertiesFile, convertPropertiesToMap(server.bootstrapProperties), server.serverEnvFile, false);
                 if (scd != null && scd.getLocations().contains(fileName)) {
                     logger.debug("Application configuration is found in server.xml : " + fileName)
                     configured = true

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DeployTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DeployTask.groovy
@@ -466,7 +466,7 @@ class DeployTask extends AbstractServerTask {
                 File serverXML = new File(getServerDir(project).getCanonicalPath(), "server.xml")
 
                 try {
-                    scd = ServerConfigDocument.getInstance(CommonLogger.getInstance(), serverXML, server.configDirectory,
+                    scd = ServerConfigDocument.getInstance(CommonLogger.getInstance(project), serverXML, server.configDirectory,
                             server.bootstrapPropertiesFile, server.bootstrapProperties, server.serverEnvFile, false)
 
                     //appName will be set to a name derived from appFile if no name can be found.

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/StartTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/StartTask.groovy
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2014, 2019.
+ * (C) Copyright IBM Corporation 2014, 2020.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,7 +86,7 @@ class StartTask extends AbstractServerTask {
         File serverConfigFile = new File(getServerDir(project), 'server.xml')
         if (serverConfigFile != null && serverConfigFile.exists()) {
             try {
-                ServerConfigDocument scd = ServerConfigDocument.getInstance(CommonLogger.getInstance(), serverConfigFile, server.configDirectory, server.bootstrapPropertiesFile, convertPropertiesToMap(server.bootstrapProperties), server.serverEnvFile, false);
+                ServerConfigDocument scd = ServerConfigDocument.getInstance(CommonLogger.getInstance(project), serverConfigFile, server.configDirectory, server.bootstrapPropertiesFile, convertPropertiesToMap(server.bootstrapProperties), server.serverEnvFile, false);
                 if (scd != null) {
                     appNames = scd.getNames()
                     appNames += scd.getNamelessLocations().collect { String location ->

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/UndeployTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/UndeployTask.groovy
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2014, 2019.
+ * (C) Copyright IBM Corporation 2014, 2020.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,7 +80,7 @@ class UndeployTask extends AbstractServerTask {
             File serverXML = new File(getServerDir(project).getCanonicalPath(), "server.xml")
 
             try {
-                scd = ServerConfigDocument.getInstance(CommonLogger.getInstance(), serverXML, server.configDirectory,
+                scd = ServerConfigDocument.getInstance(CommonLogger.getInstance(project), serverXML, server.configDirectory,
                         server.bootstrapPropertiesFile, server.bootstrapProperties, server.serverEnvFile, false)
 
                 //appName will be set to a name derived from appFile if no name can be found.

--- a/src/main/groovy/io/openliberty/tools/gradle/utils/CommonLogger.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/utils/CommonLogger.groovy
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2019.
+ * (C) Copyright IBM Corporation 2019, 2020.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,10 @@ public class CommonLogger implements CommonLoggerI {
         logger = new CommonLogger(project)
     }
 
-    public static CommonLogger getInstance() {
+    public static CommonLogger getInstance(Project project) {
+        if (logger == null) {
+            CommonLogger.init(project)
+        }
         return logger
     }
 

--- a/src/test/resources/app-configuration-m2-default-test/src/main/liberty/config/server.env
+++ b/src/test/resources/app-configuration-m2-default-test/src/main/liberty/config/server.env
@@ -1,0 +1,1 @@
+APP_LOCATION=test-maven-war-1.0-SNAPSHOT.war

--- a/src/test/resources/app-configuration-m2-default-test/src/main/liberty/config/server.xml
+++ b/src/test/resources/app-configuration-m2-default-test/src/main/liberty/config/server.xml
@@ -25,7 +25,7 @@
     
     </httpEndpoint>
     
-    <variable name="appLocation" defaultValue="test-maven-war-1.0-SNAPSHOT.war"/>
+    <variable name="appLocation" defaultValue="${env.APP_LOCATION}"/>
     <application name="servlet" context-root="${appContext}" location="${appLocation}" type="war"></application>
     
 </server>


### PR DESCRIPTION
Fixes #426 

There were two problems I identified when recreating this issue. First, the logger that was passed to ServerConfigDocument.getInstance() in ci.common was null, which caused the NPE. Second, the resolveVariables method in ServerConfigDocument did not handle resolving variables that started with `env.`. 

I fixed the first problem in this PR. I added a test case for the second problem in this PR, and fixed the code in ci.common via PR https://github.com/OpenLiberty/ci.common/pull/125.