### PR TITLE
Add polling option for dev mode

### DIFF
--- a/docs/libertyDev.md
+++ b/docs/libertyDev.md
@@ -47,6 +47,8 @@ The following are optional command line parameters supported by this task.
 | compileWait | Time in seconds to wait before processing Java changes. If you encounter compile errors while refactoring, increase this value to allow all files to be saved before compilation occurs. The default value is `0.5` seconds. | No |
 | serverStartTimeout | Maximum time to wait (in seconds) to verify that the server has started. The value must be an integer greater than or equal to 0. The default value is `30` seconds. | No |
 | verifyAppStartTimeout | Maximum time to wait (in seconds) to verify that the application has started or updated before running tests. The value must be an integer greater than or equal to 0. The default value is `30` seconds. | No |
+| polling | If this option is enabled, poll for file changes instead of using file system notifications. The default value is `false`. | No |
+| pollingInterval | Polling interval in milliseconds. The default value is `100` milliseconds. This parameter is only used if `polling` is enabled. | No |
 
 ### Properties
 

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
@@ -162,7 +162,7 @@ class DevTask extends AbstractServerTask {
 
     private Long pollingInterval;
 
-    @Option(option = 'pollingInterval', description = 'Polling interval in milliseconds. The default value is 100 seconds. This parameter is only used if polling is enabled.')
+    @Option(option = 'pollingInterval', description = 'Polling interval in milliseconds. The default value is 100 milliseconds. This parameter is only used if polling is enabled.')
     void setPollingInterval(String pollingInterval) {
         try {
             this.pollingInterval = pollingInterval.toLong();

--- a/src/test/groovy/io/openliberty/tools/gradle/PollingDevTest.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/PollingDevTest.groovy
@@ -1,0 +1,47 @@
+/*
+ * (C) Copyright IBM Corporation 2020.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openliberty.tools.gradle;
+
+import static org.junit.Assert.*;
+
+import java.io.BufferedWriter;
+import org.apache.commons.io.FileUtils;
+import java.io.File;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.AfterClass;
+import org.junit.Test;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+class PollingDevTest extends DevTest {
+
+    @BeforeClass
+    public static void setup() throws IOException, InterruptedException, FileNotFoundException {
+        createDir(buildDir);
+        createTestProject(buildDir, resourceDir, buildFilename);
+        runDevModePolling();
+    }
+    
+    private static void runDevModePolling() throws IOException, InterruptedException, FileNotFoundException {
+        System.out.println("Starting dev mode with polling...");
+        startProcess("--polling", true);
+        System.out.println("Started dev mode with polling");
+    }
+    
+}


### PR DESCRIPTION
Add a polling option for scenarios where file system notifications are not available, e.g. on mounted directories in Docker on Windows.

Gradle equivalent of https://github.com/OpenLiberty/ci.maven/pull/736 which is for https://github.com/OpenLiberty/ci.maven/issues/617