### PR TITLE
Describe limitation and work around when using Windows, Java 8 and gradle clean

### DIFF
--- a/docs/clean.md
+++ b/docs/clean.md
@@ -7,6 +7,7 @@ The `cleanDirs` task deletes server specific files including:
   
 Note that the `cleanDirs` task is different from the `clean` task from the Java plugin. `cleanDirs` cleans the server directories whereas `clean` removes the `build` directory. If a server is running during a `clean`, some files may remain and require a second `clean`. Adding a ```clean dependsOn 'libertyStop'``` to your `build.gradle` file can help prevent this. The Liberty `cleanDirs` task automatically depends on the `libertyStop` task.
 
+Note also that if you use Java 8 on the Windows operating system beware of the following. Using the `clean` task after using the `installFeatures` or `libertyDev` task may generate an error trying to delete some of the jars in the build directory. If this happens execute `gradle --stop` to stop the daemon and then try again. To avoid the error use the `--no-daemon` option on all your gradle commands.
 ### dependsOn
 `cleanDirs` depends on `libertyStop` to ensure a successful clean.
 

--- a/docs/clean.md
+++ b/docs/clean.md
@@ -7,7 +7,8 @@ The `cleanDirs` task deletes server specific files including:
   
 Note that the `cleanDirs` task is different from the `clean` task from the Java plugin. `cleanDirs` cleans the server directories whereas `clean` removes the `build` directory. If a server is running during a `clean`, some files may remain and require a second `clean`. Adding a ```clean dependsOn 'libertyStop'``` to your `build.gradle` file can help prevent this. The Liberty `cleanDirs` task automatically depends on the `libertyStop` task.
 
-Note also that if you use Java 8 on the Windows operating system beware of the following. Using the `clean` task after using the `installFeatures` or `libertyDev` task may generate an error trying to delete some of the jars in the build directory. If this happens execute `gradle --stop` to stop the daemon and then try again. To avoid the error use the `--no-daemon` option on all your gradle commands.
+If you use Java 8 on Windows, note that using the `clean` task after `installFeatures` or `libertyDev` may show an error trying to delete some jars in the build directory. If this happens, run `gradle --stop` to stop the Gradle daemon and then try again. To avoid the error, use the `--no-daemon` option on all of your Gradle commands.
+
 ### dependsOn
 `cleanDirs` depends on `libertyStop` to ensure a successful clean.
 


### PR DESCRIPTION
This is a continuation of the work for issue #406. 