### PR TITLE
Update instructions to use 3.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'io.openliberty.tools:liberty-gradle-plugin:3.0-SNAPSHOT'
+        classpath 'io.openliberty.tools:liberty-gradle-plugin:3.0'
     }
 }
 ```


### PR DESCRIPTION
Update instructions to use 3.0 release instead of 3.0-SNAPSHOT