### PR TITLE
Adding earlib configuration support for loose-ear applications

### DIFF
--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DeployTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DeployTask.groovy
@@ -351,8 +351,6 @@ class DeployTask extends AbstractServerTask {
             }
         }
 
-        task.getProject().configurations.earlib.getResolvedConfiguration().getFirstLevelModuleDependencies()
-
         logger.info(MessageFormat.format("Number of deploy dependencies for " + task.project.name + " : " + completeDeployDeps.size()))
         for (Map.Entry<File, Dependency> entry : completeDeployDeps){
             Dependency dependency = entry.getValue();

--- a/src/test/groovy/io/openliberty/tools/gradle/TestLooseEarApplicationEarlibs.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/TestLooseEarApplicationEarlibs.groovy
@@ -1,0 +1,140 @@
+package io.openliberty.tools.gradle;
+
+import org.junit.AfterClass
+import org.junit.BeforeClass
+import org.junit.Test
+
+import java.io.File;
+import java.io.FileInputStream;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+public class TestLooseEarApplicationEarlibs extends AbstractIntegrationTest{
+    static File resourceDir = new File("build/resources/test/loose-ear-earlibs-test")
+    static File buildDir = new File(integTestDir, "/test-loose-ear-application-earlibs")
+    static String buildFilename = "build.gradle"
+
+    @BeforeClass
+    public static void setup() {
+        createDir(buildDir)
+        createTestProject(buildDir, resourceDir, buildFilename)
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        runTasks(buildDir, 'libertyStop')
+    }
+
+    @Test
+    public void test_loose_config_file_exists() {
+        try {
+            runTasks(buildDir, 'deploy')
+        } catch (Exception e) {
+            throw new AssertionError ("Fail on task deploy. " + e)
+        }
+        assert new File('build/testBuilds/test-loose-ear-application-earlibs/SampleEAR/build/wlp/usr/servers/ejbServer/apps/SampleEAR.ear.xml').exists() : 'looseApplication config file was not copied over to the liberty runtime'
+    }
+/*
+  Expected output to the XML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <archive>
+        <dir sourceOnDisk="/Users/mbowersox/git/ci.gradle/build/testBuilds/loose-ear-earlibs-test/SampleEAR/src/main/application" targetInArchive="/"/>
+        <file sourceOnDisk="/Users/mbowersox/git/ci.gradle/build/testBuilds/loose-ear-earlibs-test/SampleEAR/build/tmp/ear/application.xml" targetInArchive="/META-INF/application.xml"/>
+        <archive targetInArchive="/SampleEJB.jar">
+            <dir sourceOnDisk="/Users/mbowersox/git/ci.gradle/build/testBuilds/loose-ear-earlibs-test/SampleEJB/build/classes/java/main" targetInArchive="/"/>
+            <file sourceOnDisk="/Users/mbowersox/git/ci.gradle/build/testBuilds/loose-ear-earlibs-test/SampleEAR/build/tmp/META-INF/MANIFEST.MF" targetInArchive="/META-INF/MANIFEST.MF"/>
+        </archive>
+        <archive targetInArchive="/SampleWAR.war">
+            <dir sourceOnDisk="/Users/mbowersox/git/ci.gradle/build/testBuilds/loose-ear-earlibs-test/SampleWAR/build/classes/java/main" targetInArchive="/WEB-INF/classes"/>
+            <file sourceOnDisk="/Users/mbowersox/git/ci.gradle/build/testBuilds/loose-ear-earlibs-test/SampleEAR/build/tmp/META-INF/MANIFEST.MF" targetInArchive="/META-INF/MANIFEST.MF"/>
+        </archive>
+        <archive targetInArchive="/SampleWAR2.war">
+            <dir sourceOnDisk="/Users/mbowersox/git/ci.gradle/build/testBuilds/loose-ear-earlibs-test/SampleWAR2/build/classes/java/main" targetInArchive="/WEB-INF/classes"/>
+            <file sourceOnDisk="/Users/mbowersox/git/ci.gradle/build/testBuilds/loose-ear-earlibs-test/SampleEAR/build/tmp/META-INF/MANIFEST.MF" targetInArchive="/META-INF/MANIFEST.MF"/>
+        </archive>
+        <file sourceOnDisk="/Users/mbowersox/git/ci.gradle/build/testBuilds/loose-ear-earlibs-test/SampleEAR/build/tmp/META-INF/MANIFEST.MF" targetInArchive="/META-INF/MANIFEST.MF"/>
+    </archive>
+
+
+*/
+    @Test
+    public void test_loose_config_file_contents_are_correct(){
+        File on = new File("build/testBuilds/test-loose-ear-application-earlibs/SampleEAR/build/wlp/usr/servers/ejbServer/apps/SampleEAR.ear.xml");
+        FileInputStream input = new FileInputStream(on);
+
+        // get input XML Document
+        DocumentBuilderFactory inputBuilderFactory = DocumentBuilderFactory.newInstance();
+        inputBuilderFactory.setIgnoringComments(true);
+        inputBuilderFactory.setCoalescing(true);
+        inputBuilderFactory.setIgnoringElementContentWhitespace(true);
+        inputBuilderFactory.setValidating(false);
+        DocumentBuilder inputBuilder = inputBuilderFactory.newDocumentBuilder();
+        Document inputDoc=inputBuilder.parse(input);
+
+        // parse input XML Document
+        XPath xPath = XPathFactory.newInstance().newXPath();
+        String expression = "/archive/dir";
+        NodeList nodes = (NodeList) xPath.compile(expression).evaluate(inputDoc, XPathConstants.NODESET);
+        Assert.assertEquals("Number of <dir/> element ==>", 0, nodes.getLength());
+
+        expression = "/archive/archive";
+        nodes = (NodeList) xPath.compile(expression).evaluate(inputDoc, XPathConstants.NODESET);
+        Assert.assertEquals("Number of <archive/> element ==>", 3, nodes.getLength());
+
+        String sampleEJB = "/SampleEJB.jar"
+        String sampleWAR = "/SampleWAR.war"
+        String sampleWAR2 = "/SampleWAR2.war"
+        
+
+        Assert.assertTrue(
+                sampleWAR.equals(nodes.item(0).getAttributes().getNamedItem("targetInArchive").getNodeValue()) ||
+                    sampleWAR2.equals(nodes.item(0).getAttributes().getNamedItem("targetInArchive").getNodeValue()) ||
+                        sampleEJB.equals(nodes.item(0).getAttributes().getNamedItem("targetInArchive").getNodeValue()))
+
+        Assert.assertTrue(
+                sampleWAR.equals(nodes.item(1).getAttributes().getNamedItem("targetInArchive").getNodeValue()) ||
+                    sampleWAR2.equals(nodes.item(1).getAttributes().getNamedItem("targetInArchive").getNodeValue()) ||
+                        sampleEJB.equals(nodes.item(1).getAttributes().getNamedItem("targetInArchive").getNodeValue()))
+
+        Assert.assertTrue(
+                sampleWAR.equals(nodes.item(2).getAttributes().getNamedItem("targetInArchive").getNodeValue()) ||
+                    sampleWAR2.equals(nodes.item(2).getAttributes().getNamedItem("targetInArchive").getNodeValue()) ||
+                        sampleEJB.equals(nodes.item(2).getAttributes().getNamedItem("targetInArchive").getNodeValue()))
+
+        expression = "/archive/file";
+        nodes = (NodeList) xPath.compile(expression).evaluate(inputDoc, XPathConstants.NODESET);
+        Assert.assertEquals("Number of <file/> element ==>", 2, nodes.getLength());
+
+    }
+
+    @Test
+    public void test_start_with_timeout_success() {
+        try {
+            runTasks(buildDir, 'libertyStart')
+            Assert.assertTrue(getURLResponseCode("http://localhost:9080/SampleWAR") == 200);
+            Assert.assertTrue(getURLResponseCode("http://localhost:9080/SampleWAR2") == 200);
+        } catch (Exception e) {
+            throw new AssertionError ("Fail on task libertyStart. "+ e)
+        }
+    }
+
+    private int getURLResponseCode(String address){
+        URL url = new URL(address);
+        HttpURLConnection connection = (HttpURLConnection)url.openConnection();
+        connection.setRequestMethod("GET");
+        connection.connect();
+        return connection.getResponseCode();
+    }
+}

--- a/src/test/resources/loose-ear-earlibs-test/SampleEAR/build.gradle
+++ b/src/test/resources/loose-ear-earlibs-test/SampleEAR/build.gradle
@@ -23,8 +23,9 @@ repositories {
 }
 
 dependencies {
-    deploy project(':ejb-ejb')
-    deploy project(path:':ejb-war', configuration:'archives')
+    deploy project(':SampleEJB')
+    earlib project(path:':SampleWAR', configuration:'archives')
+    earlib project(path:':SampleWAR2', configuration:'archives')
     testImplementation group: 'commons-httpclient', name: 'commons-httpclient', version:'3.1'
     testImplementation group: 'junit', name: 'junit', version:'4.12'
     libertyRuntime group: runtimeGroup, name: runtimeArtifactId, version: runtimeVersion
@@ -33,8 +34,9 @@ dependencies {
 ear {
     archiveName = baseName + '.' + extension
     deploymentDescriptor {
-        module ('ejb-ejb.jar', 'ejb')
-        webModule ('ejb-war.war', '/ejb-war')
+        module ('SampleEJB.jar', 'ejb')
+        webModule ('SampleWAR.war', '/SampleWAR')
+        webModule ('SampleWAR2.war', '/SampleWAR2')
     }
 }
 
@@ -51,4 +53,4 @@ liberty {
 
 clean.dependsOn 'libertyStop'
 deploy.dependsOn 'ear'
-ear.dependsOn ':ejb-war:jar', ':ejb-war:war'
+ear.dependsOn ':SampleEJB:jar', ':SampleWAR:war', ':SampleWAR2:war'

--- a/src/test/resources/loose-ear-earlibs-test/SampleEAR/src/main/liberty/config/server.xml
+++ b/src/test/resources/loose-ear-earlibs-test/SampleEAR/src/main/liberty/config/server.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="jee7sample test server">
+
+    <!-- Enable features -->
+    <featureManager>
+        <feature>javaee-7.0</feature>
+    </featureManager>
+        
+    <keyStore password="keyPassword"/>
+    <basicRegistry id="basic" realm="BasicRealm">
+        <user name="admin" password="password" />
+    </basicRegistry>
+
+    <!-- To access this server from a remote client add a host attribute to the following element, e.g. host="*" -->
+    <httpEndpoint id="defaultHttpEndpoint"
+                  httpPort="9080"
+                  httpsPort="9443" />
+                  
+</server>

--- a/src/test/resources/loose-ear-earlibs-test/SampleEJB/build.gradle
+++ b/src/test/resources/loose-ear-earlibs-test/SampleEJB/build.gradle
@@ -1,0 +1,11 @@
+
+description = 'EJB Module'
+
+dependencies {
+    testImplementation group: 'junit', name: 'junit', version:'4.12'
+    compileOnly group: 'javax', name: 'javaee-api', version:'7.0'
+}
+
+jar {
+    archiveName = baseName + '.' + extension
+}

--- a/src/test/resources/loose-ear-earlibs-test/SampleEJB/src/main/java/wasdev/sample/ejb/SampleStatelessBean.java
+++ b/src/test/resources/loose-ear-earlibs-test/SampleEJB/src/main/java/wasdev/sample/ejb/SampleStatelessBean.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corporation 2017.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package wasdev.sample.ejb;
+
+import javax.ejb.Stateless;
+
+@Stateless
+public class SampleStatelessBean {
+
+    public String hello() {
+        return "Hello EJB World.";
+    }
+}

--- a/src/test/resources/loose-ear-earlibs-test/SampleWAR/build.gradle
+++ b/src/test/resources/loose-ear-earlibs-test/SampleWAR/build.gradle
@@ -1,0 +1,16 @@
+
+apply plugin: 'war'
+
+jar.enabled = false
+description = 'WAR Module'
+dependencies {
+    implementation group: 'commons-io', name: 'commons-io', version: '2.5', transitive:true
+    testImplementation group: 'junit', name: 'junit', version:'4.12'
+    providedCompile group: 'javax', name: 'javaee-api', version:'7.0'
+    providedCompile project(':SampleEJB')
+}
+
+war {
+    archiveName = baseName + '.' + extension
+}
+

--- a/src/test/resources/loose-ear-earlibs-test/SampleWAR/src/main/java/wasdev/sample/ejb/web/EJBServlet.java
+++ b/src/test/resources/loose-ear-earlibs-test/SampleWAR/src/main/java/wasdev/sample/ejb/web/EJBServlet.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corporation 2017.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package wasdev.sample.ejb.web;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.ejb.EJB;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import wasdev.sample.ejb.SampleStatelessBean;
+
+/**
+ * A servlet which injects a stateless EJB
+ */
+@WebServlet({"/", "/sampleServlet"})
+public class EJBServlet extends HttpServlet {
+    private static final long serialVersionUID = 1L;
+
+    @EJB
+    SampleStatelessBean statelessBean;
+
+    @Override
+    protected void doGet(HttpServletRequest request,
+                         HttpServletResponse response) throws IOException {
+        PrintWriter writer = response.getWriter();
+
+        // Call hello method on a stateless session bean
+        String message = statelessBean.hello();
+
+        writer.println(message);
+    }
+}

--- a/src/test/resources/loose-ear-earlibs-test/SampleWAR2/build.gradle
+++ b/src/test/resources/loose-ear-earlibs-test/SampleWAR2/build.gradle
@@ -1,0 +1,16 @@
+
+apply plugin: 'war'
+
+jar.enabled = false
+description = 'WAR Module'
+dependencies {
+    implementation group: 'commons-io', name: 'commons-io', version: '2.5', transitive:true
+    testImplementation group: 'junit', name: 'junit', version:'4.12'
+    providedCompile group: 'javax', name: 'javaee-api', version:'7.0'
+    providedCompile project(':SampleEJB')
+}
+
+war {
+    archiveName = baseName + '.' + extension
+}
+

--- a/src/test/resources/loose-ear-earlibs-test/SampleWAR2/src/main/java/wasdev/sample/ejb/web/EJBServlet.java
+++ b/src/test/resources/loose-ear-earlibs-test/SampleWAR2/src/main/java/wasdev/sample/ejb/web/EJBServlet.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corporation 2017.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package wasdev.sample.ejb.web;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.ejb.EJB;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import wasdev.sample.ejb.SampleStatelessBean;
+
+/**
+ * A servlet which injects a stateless EJB
+ */
+@WebServlet({"/", "/sampleServlet2"})
+public class EJBServlet extends HttpServlet {
+    private static final long serialVersionUID = 1L;
+
+    @EJB
+    SampleStatelessBean statelessBean;
+
+    @Override
+    protected void doGet(HttpServletRequest request,
+                         HttpServletResponse response) throws IOException {
+        PrintWriter writer = response.getWriter();
+
+        // Call hello method on a stateless session bean
+        String message = statelessBean.hello();
+
+        writer.println(message);
+    }
+}

--- a/src/test/resources/loose-ear-earlibs-test/build.gradle
+++ b/src/test/resources/loose-ear-earlibs-test/build.gradle
@@ -1,0 +1,19 @@
+allprojects  {
+    group = 'sample'
+    version = '1.0'
+}
+
+subprojects {
+    apply plugin: 'java'
+    
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
+    tasks.withType(JavaCompile) {
+        options.encoding = 'UTF-8'
+    }
+    
+    repositories {
+        mavenLocal()
+        mavenCentral()
+    }
+}

--- a/src/test/resources/loose-ear-earlibs-test/settings.gradle
+++ b/src/test/resources/loose-ear-earlibs-test/settings.gradle
@@ -1,0 +1,10 @@
+rootProject.name = 'loose-ear-earlibs-test'
+include ':SampleEAR'
+include ':SampleEJB'
+include ':SampleWAR'
+include ':SampleWAR2'
+
+project(':SampleEAR').projectDir = "$rootDir/SampleEAR" as File
+project(':SampleEJB').projectDir = "$rootDir/SampleEJB" as File
+project(':SampleWAR').projectDir = "$rootDir/SampleWAR" as File
+project(':SampleWAR2').projectDir = "$rootDir/SampleWAR2" as File


### PR DESCRIPTION
The `deploy` task will now recognize dependencies in the `earlib` configuration used by the `ear` plugin when creating a loose-ear application.
Fixes #440 