### PR TITLE
Incorporate feedback from the design review

### DIFF
--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractServerTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractServerTask.groovy
@@ -301,6 +301,10 @@ abstract class AbstractServerTask extends AbstractTask {
             serverEnvPath = server.serverEnvFile.getCanonicalPath()
         }
 
+        if (container != null && container.booleanValue()) {
+            // Set PROJECT_ROOT_NAME so it will be written in config file.
+            server.var."io.openliberty.tools.projectRoot" = project.getProjectDir().getAbsolutePath()
+        }
         // generate a config file on the server with any Liberty configuration variables specified via project properties
         if ((server.var != null && !server.var.isEmpty()) || (server.defaultVar != null && !server.defaultVar.isEmpty()) || 
              !varProjectProps.isEmpty() || !defaultVarProjectProps.isEmpty()) {
@@ -783,9 +787,6 @@ abstract class AbstractServerTask extends AbstractTask {
             String key = entry.getKey()
             existingVarNames.add(key)
             configDocument.createVariableWithValue(entry.getKey(), entry.getValue(), false)
-        }
-        if (container != null && container.booleanValue()) {
-            configDocument.createVariableWithValue(PROJECT_ROOT_NAME, project.getProjectDir().getAbsolutePath(), false)
         }
 
         for (Map.Entry<String, String> entry : defaultVarProjectProps.entrySet()) {

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractServerTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractServerTask.groovy
@@ -59,7 +59,7 @@ abstract class AbstractServerTask extends AbstractTask {
     private static final Pattern pattern = Pattern.compile(LIBERTY_CONFIG_GRADLE_PROPS)
 
     protected final String PLUGIN_VARIABLE_CONFIG_XML = "configDropins/overrides/liberty-plugin-variable-config.xml"
-    protected final String PROJECT_ROOT_NAME = "io.openliberty.projectRoot";
+    protected final String PROJECT_ROOT_NAME = "io.openliberty.tools.projectRoot";
 
     protected Properties bootstrapProjectProps = new Properties()
     protected Properties envProjectProps = new Properties()
@@ -283,13 +283,6 @@ abstract class AbstractServerTask extends AbstractTask {
             }
             Files.copy(server.bootstrapPropertiesFile.toPath(), bootstrapFile.toPath(), StandardCopyOption.REPLACE_EXISTING)
             bootStrapPropertiesPath = server.bootstrapPropertiesFile.getCanonicalPath()
-        }
-
-        if (container != null && container.booleanValue()) {
-            // Define the variable used in the loose app. configuration file.
-            if (!serverDirectory.isEmpty()) {
-                appendToBootstrap(bootstrapFile, PROJECT_ROOT_NAME+" = "+project.getProjectDir().getAbsolutePath())
-            }
         }
 
         // envProjectProps and serverEnvFile take precedence over server.env from configDirectory
@@ -711,22 +704,6 @@ abstract class AbstractServerTask extends AbstractTask {
         }
     }
 
-    protected void appendToBootstrap(File bootstrapFile, String line) throws IOException {
-        logger.debug("bootstrapFile name:"+bootstrapFile.getName()+" new line:"+line)
-        PrintWriter writer = null;
-        try {
-            FileWriter fwriter = new FileWriter(bootstrapFile, true);
-            writer = new PrintWriter(fwriter);
-            writer.println();
-            writer.println(HEADER);
-            writer.println(line);
-        } finally {
-            if (writer != null) {
-                writer.close();
-            }
-        }
-    }
-
     private void writeJvmOptions(File file, List<String> options, List<String> projectProperties) throws IOException {
         if (! projectProperties.isEmpty()) {
             if (options == null) {
@@ -806,6 +783,9 @@ abstract class AbstractServerTask extends AbstractTask {
             String key = entry.getKey()
             existingVarNames.add(key)
             configDocument.createVariableWithValue(entry.getKey(), entry.getValue(), false)
+        }
+        if (container != null && container.booleanValue()) {
+            configDocument.createVariableWithValue(PROJECT_ROOT_NAME, project.getProjectDir().getAbsolutePath(), false)
         }
 
         for (Map.Entry<String, String> entry : defaultVarProjectProps.entrySet()) {


### PR DESCRIPTION
In the Maven case when we set up the loose app. we can also set a project property to define the variable value in liberty-plugin-variable-config.xml. This is good for locality of code. 

In the Gradle case each task works independently so we do it differently. We must configure the loose app. in the deploy task and configure the variable value in the AbstractServerTask definition. 

If you think the implementations should match better I can change the Maven code to look more like the Gradle code.