### PR TITLE
Update to enable the restart server function

### DIFF
--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractServerTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractServerTask.groovy
@@ -301,9 +301,10 @@ abstract class AbstractServerTask extends AbstractTask {
             serverEnvPath = server.serverEnvFile.getCanonicalPath()
         }
 
-        if (container != null && container.booleanValue()) {
-            // Set PROJECT_ROOT_NAME so it will be written in config file.
-            server.var."io.openliberty.tools.projectRoot" = project.getProjectDir().getAbsolutePath()
+        if (container != null && container.booleanValue() ||
+            System.getProperty(PROJECT_ROOT_NAME) != null) { // property set by CreateTask
+            // Set PROJECT_ROOT_NAME so it will be written in config dropin file.
+            server.var."${PROJECT_ROOT_NAME}" = project.getProjectDir().getAbsolutePath()
         }
         // generate a config file on the server with any Liberty configuration variables specified via project properties
         if ((server.var != null && !server.var.isEmpty()) || (server.defaultVar != null && !server.defaultVar.isEmpty()) || 

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractServerTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractServerTask.groovy
@@ -301,8 +301,8 @@ abstract class AbstractServerTask extends AbstractTask {
             serverEnvPath = server.serverEnvFile.getCanonicalPath()
         }
 
-        if (container != null && container.booleanValue() ||
-            System.getProperty(PROJECT_ROOT_NAME) != null) { // property set by CreateTask
+        if (container != null && container.booleanValue() ||  // option used by DevTask
+            System.getProperty(PROJECT_ROOT_NAME) != null) {  // property used when calling CreateTask
             // Set PROJECT_ROOT_NAME so it will be written in config dropin file.
             server.var."${PROJECT_ROOT_NAME}" = project.getProjectDir().getAbsolutePath()
         }

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
@@ -620,7 +620,11 @@ class DevTask extends AbstractServerTask {
             BuildLauncher gradleBuildLauncher = gradleConnection.newBuild();
 
             try {
-                runGradleTask(gradleBuildLauncher, 'deploy');
+                if (container) {
+                    runGradleTask(gradleBuildLauncher, 'deploy', '--container');
+                } else {
+                    runGradleTask(gradleBuildLauncher, 'deploy');
+                }
             } catch (BuildException e) {
                 throw new PluginExecutionException(e);
             } finally {
@@ -646,9 +650,12 @@ class DevTask extends AbstractServerTask {
         public void libertyDeploy() {
             ProjectConnection gradleConnection = initGradleProjectConnection();
             BuildLauncher gradleBuildLauncher = gradleConnection.newBuild();
-
             try {
-                runGradleTask(gradleBuildLauncher, 'deploy');
+                if (container) {
+                    runGradleTask(gradleBuildLauncher, 'deploy', '--container');
+                } else {
+                    runGradleTask(gradleBuildLauncher, 'deploy');
+                }
             } catch (BuildException e) {
                 throw new PluginExecutionException(e);
             } finally {
@@ -664,7 +671,9 @@ class DevTask extends AbstractServerTask {
             // need to force liberty-create to re-run
             // else it will just say up-to-date and skip the task
             gradleBuildLauncher.withArguments('--rerun-tasks');
-
+            if (container) {
+                System.setProperty(PROJECT_ROOT_NAME, "true") // no --container in CreateTask
+            }
             try {
                 runGradleTask(gradleBuildLauncher, 'libertyCreate');
             } catch (BuildException e) {


### PR DESCRIPTION
Pass the container option when you redeploy and use the io.openliberty.tools.projectRoot variable name as a Java System property to pass the container option to the liberty create task.
When copying the source files check the Java System property in addition to the container option.
https://github.com/OpenLiberty/ci.maven/issues/800