### PR TITLE
Use ci.common 1.8.7-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     implementation gradleApi()
     implementation localGroovy()
     implementation ('io.openliberty.tools:liberty-ant-tasks:1.9.3')
-    implementation ('io.openliberty.tools:ci.common:1.8.6')
+    implementation ('io.openliberty.tools:ci.common:1.8.7-SNAPSHOT')
     implementation group: 'commons-io', name: 'commons-io', version: '2.5'
     provided group: 'com.ibm.websphere.appserver.api', name: 'com.ibm.websphere.appserver.spi.kernel.embeddable', version: '1.0.0'
     testImplementation 'junit:junit:4.11'


### PR DESCRIPTION
Use ci.common 1.8.7-SNAPSHOT so that https://github.com/OpenLiberty/ci.common/pull/160 is included