### PR TITLE
verify message json format

### DIFF
--- a/src/test/groovy/io/openliberty/tools/gradle/DevTest.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/DevTest.groovy
@@ -278,7 +278,7 @@ class DevTest extends AbstractIntegrationTest {
 
         if (buildDir != null && buildDir.exists()) {
             try {
-                // FileUtils.deleteDirectory(buildDir);
+                FileUtils.deleteDirectory(buildDir);
             } catch (IOException e) {
                 // https://github.com/OpenLiberty/open-liberty/issues/10562 prevents a file from being deleted.
                 // Instead of failing here, just print an error until the above is fixed
@@ -287,9 +287,9 @@ class DevTest extends AbstractIntegrationTest {
             } 
         }
 
-        // if (logFile != null && logFile.exists()) {
-        //     assertTrue(logFile.delete());
-        // }
+        if (logFile != null && logFile.exists()) {
+            assertTrue(logFile.delete());
+        }
     }
 
     private static void stopProcess(boolean isDevMode) throws IOException, InterruptedException, FileNotFoundException {

--- a/src/test/groovy/io/openliberty/tools/gradle/DevTest.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/DevTest.groovy
@@ -142,6 +142,12 @@ class DevTest extends AbstractIntegrationTest {
     }
 
     @Test
+    /* simple double check. if failure, check parse in ci.common */
+    public void verifyJsonHost() throws Exception {
+        checkLogMessage(2000, "CWWKT0016I");
+    }
+
+    @Test
     public void configChangeTest() throws Exception {
         // configuration file change
         File srcServerXML = new File(buildDir, "src/main/liberty/config/server.xml");
@@ -272,7 +278,7 @@ class DevTest extends AbstractIntegrationTest {
 
         if (buildDir != null && buildDir.exists()) {
             try {
-                FileUtils.deleteDirectory(buildDir);
+                // FileUtils.deleteDirectory(buildDir);
             } catch (IOException e) {
                 // https://github.com/OpenLiberty/open-liberty/issues/10562 prevents a file from being deleted.
                 // Instead of failing here, just print an error until the above is fixed
@@ -281,9 +287,9 @@ class DevTest extends AbstractIntegrationTest {
             } 
         }
 
-        if (logFile != null && logFile.exists()) {
-            assertTrue(logFile.delete());
-        }
+        // if (logFile != null && logFile.exists()) {
+        //     assertTrue(logFile.delete());
+        // }
     }
 
     private static void stopProcess(boolean isDevMode) throws IOException, InterruptedException, FileNotFoundException {

--- a/src/test/groovy/io/openliberty/tools/gradle/DevTest.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/DevTest.groovy
@@ -144,7 +144,8 @@ class DevTest extends AbstractIntegrationTest {
     @Test
     /* simple double check. if failure, check parse in ci.common */
     public void verifyJsonHost() throws Exception {
-        checkLogMessage(2000, "CWWKT0016I");
+        checkLogMessage(2000, "CWWKT0016I");   // Verify web app code triggered
+        checkLogMessage(2000, "http:\\/\\/");  // Verify escape char seq passes
     }
 
     @Test

--- a/src/test/resources/dev-test/basic-dev-project/src/main/liberty/config/bootstrap.properties
+++ b/src/test/resources/dev-test/basic-dev-project/src/main/liberty/config/bootstrap.properties
@@ -1,2 +1,3 @@
 default.http.port = 9080
 default.https.port = 9443
+com.ibm.ws.logging.message.format=json


### PR DESCRIPTION
Fix was implemented in ci.common

dev-it/basic-dev-project logging format changed to json from start via bootstrap property
add to DevTest.groovy verify web app message appears, as parse fails on hostname esc chars in ci.common