### PR TITLE
Redeploy Spring Boot jars

### DIFF
--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
@@ -591,6 +591,10 @@ class DevTask extends AbstractServerTask {
             try {
                 if (dir.equals(sourceDirectory)) {
                     runGradleTask(gradleBuildLauncher, 'compileJava', 'processResources');
+
+                    if("springboot".equals(getPackagingType())) {
+                        redeployApp();
+                    }
                 }
 
                 if (dir.equals(testSourceDirectory)) {


### PR DESCRIPTION
After recompiling a source change, if it is a Spring Boot project, call `deploy` so that any Spring Boot jars are redeployed.