### PR TITLE
Use ci.common 1.8.10-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ compileTestGroovy {
 }
 
 def libertyAntVersion = "1.9.5"
-def libertyCommonVersion = "1.8.9"
+def libertyCommonVersion = "1.8.10-SNAPSHOT"
 
 dependencies {
     implementation gradleApi()


### PR DESCRIPTION
Needed for https://github.com/OpenLiberty/ci.maven/issues/965 to include https://github.com/OpenLiberty/ci.common/pull/197