### PR TITLE
Debug problem with logger

### DIFF
--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractFeatureTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractFeatureTask.groovy
@@ -46,17 +46,17 @@ public class AbstractFeatureTask extends AbstractServerTask {
 
         @Override
         public void debug(String msg) {
-            logger.debug(msg)
+           logger.debug(msg)
         }
 
         @Override
         public void debug(String msg, Throwable e) {
-            logger.debug(msg, e)
+           logger.debug(msg, (Throwable) e)
         }
 
         @Override
         public void debug(Throwable e) {
-            logger.debug(e)
+            logger.debug("Throwable exception received: "+e.getMessage(), (Throwable) e)
         }
 
         @Override

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
@@ -268,12 +268,12 @@ class DevTask extends AbstractServerTask {
 
         @Override
         public void debug(String msg, Throwable e) {
-            logger.debug(msg, e);
+            logger.debug(msg, (Throwable) e)
         }
 
         @Override
         public void debug(Throwable e) {
-            logger.debug(e);
+            logger.debug("Throwable exception received: "+e.getMessage(), (Throwable) e)
         }
 
         @Override


### PR DESCRIPTION
Changed the calls to the logger to avoid a NPE that was happening.

1) I explicitly cast the variable to Throwable to ensure the correct debug() method is getting called.
2) I changed to call the debug(String, Throwable) method since I think groovy was mistakenly calling the debug(String) method. That would mean e.toString() was called implicitly, and that method can return null.

Note that the two dev tests (DevTest and PollingDevTest) are still failing, but it is no longer due to problems with the debug() method or NPEs. There are assertions failing. I will need to get the dev folks to look at that.