### PR TITLE
Fix for bad .classpath file output location

### DIFF
--- a/src/main/groovy/io/openliberty/tools/gradle/Liberty.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/Liberty.groovy
@@ -139,7 +139,7 @@ class Liberty implements Plugin<Project> {
                 file.whenMerged {
                     entries.each {
                         source ->
-                            if (source.kind == 'src' && source.hasProperty('output')) {
+                            if (source.kind == 'src' && source.hasProperty('output') && source.output == 'bin/main') {
                                 source.output = warTaskOutput
                             }
                     }


### PR DESCRIPTION
Only the main source output path is modified now.

Make sure you delete `.gradle`, `.classpath`, and clean the project when testing the change in VSCode/Eclipse.

Fixes #563 and #565 