### PR TITLE
Remove PollingDevTest from Windows build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,6 +37,6 @@ build_script:
         set GRADLE_OPTS="-Dorg.gradle.jvmargs='-XX:MaxMetaspaceSize=512m'"
         gradlew.bat clean install check -Ptest.exclude="**/*15*,**/Polling*,**/TestLoose*" -Druntime=%RUNTIME% -DruntimeVersion=%RUNTIME_VERSION% --stacktrace --info --no-daemon
         gradlew.bat wrapper --gradle-version 4.10
-        gradlew.bat check -Ptest.include="**/*15*,**/Polling*" -Druntime=%RUNTIME% -DruntimeVersion=%RUNTIME_VERSION% --stacktrace --info --no-daemon
+        gradlew.bat check -Ptest.include="**/*15*" -Druntime=%RUNTIME% -DruntimeVersion=%RUNTIME_VERSION% --stacktrace --info --no-daemon
 
 test: off


### PR DESCRIPTION
Related to #497 

I updated that issue to show an error that is happening when running the PollingDevTest on the Gradle 4.10 wrapper.