### PR TITLE
Skip installFeatures during deploy

### DIFF
--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
@@ -727,7 +727,8 @@ class DevTask extends AbstractServerTask {
             try {
                 if (container) {
                     gradleBuildLauncher.addArguments(CONTAINER_PROPERTY_ARG)
-                    // skip installFeature since that will be called separately by DevUtil.restartServer() if needed
+                    // Skip installFeature since it is not needed here in container mode.
+                    // Container mode should call installFeature separately with the containerName parameter where needed.
                     gradleBuildLauncher.addArguments("--exclude-task", "installFeature");
                 }
                 runGradleTask(gradleBuildLauncher, 'deploy');

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
@@ -727,6 +727,8 @@ class DevTask extends AbstractServerTask {
             try {
                 if (container) {
                     gradleBuildLauncher.addArguments(CONTAINER_PROPERTY_ARG)
+                    // skip installFeature since that will be called separately by DevUtil.restartServer() if needed
+                    gradleBuildLauncher.addArguments("--exclude-task", "installFeature");
                 }
                 runGradleTask(gradleBuildLauncher, 'deploy');
             } catch (BuildException e) {


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/ci.gradle/issues/578

Skip installFeatures during deploy when in container mode since it is not needed.  Container mode expects RUN features.sh in the Dockerfile if the user wants to install features.