### PR TITLE
Fix using the plugin with gradle v7

### DIFF
--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
@@ -163,6 +163,8 @@ class DevTask extends AbstractServerTask {
         this.pollingTest = pollingTest;
     }
 
+    @Optional
+    @Input
     private Boolean container = null;
 
     @Option(option = 'container', description = 'Run the server in a Docker container instead of locally. The default value is false for the libertyDev task, and true for the libertyDevc task.')


### PR DESCRIPTION
Gradle v7 is failing with the message:
Type 'DevTask' property 'container' is missing an input or output annotation.