### PR TITLE
Added output to libertyPackage

### DIFF
--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractLibertyTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractLibertyTask.groovy
@@ -44,6 +44,7 @@ abstract class AbstractLibertyTask extends DefaultTask {
         return (project.liberty.userDir == null) ? new File(installDir, 'usr') : new File(project.liberty.userDir)
     }
 
+    @Internal
     protected boolean isUserDirSpecified() {
         return (project.liberty.userDir != null)
     }

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/PackageTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/PackageTask.groovy
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2014, 2019.
+ * (C) Copyright IBM Corporation 2014, 2021.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/PackageTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/PackageTask.groovy
@@ -15,6 +15,7 @@
  */
 package io.openliberty.tools.gradle.tasks
 
+import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.logging.LogLevel
 
@@ -69,11 +70,8 @@ class PackageTask extends AbstractServerTask {
     void packageServer() {
 
         def params = buildLibertyMap(project)
-        def fileType = getPackageFileType()
-        def projectBuildDir = getPackageDirectory()
-        def projectBuildName = getPackageName()
         
-        def packageFile = new File(projectBuildDir, projectBuildName + "." + fileType.getValue())
+        def packageFile = getPackageFile()
         params.put('archive', packageFile)
         logger.info 'Packaging ' + packageFile
 
@@ -88,6 +86,11 @@ class PackageTask extends AbstractServerTask {
         }
 
         executeServerCommand(project, 'package', params)
+    }
+
+    @OutputFile
+    public File getPackageFile() throws IOException {
+        return new File(getPackageDirectory(), getPackageName() + "." + getPackageFileType().getValue())
     }
 
     private static void createDir(File dir) {


### PR DESCRIPTION
- The file generated by `libertyPackage` is now an output for the task
- Marked `isUserDirSpecified()` as an internal method, fixes a Gradle 7 issue

Fixes #472 