### PR TITLE
Stop server on libertyRun shutdown hook

### DIFF
--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/RunTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/RunTask.groovy
@@ -30,6 +30,16 @@ class RunTask extends AbstractServerTask {
 
     @TaskAction
     void run() {
+        addShutdownHook {
+            if (isLibertyInstalledAndValid(project)) {
+                if (getServerDir(project).exists()) {
+                    ServerTask serverTaskStop = createServerTask(project, "stop");
+                    serverTaskStop.setUseEmbeddedServer(server.embedded)
+                    serverTaskStop.execute()
+                }
+            }
+        }
+
         if (server.embedded) {
             ServerTask serverTaskRun = createServerTask(project, "run");
             serverTaskRun.setUseEmbeddedServer(server.embedded)
@@ -44,9 +54,7 @@ class RunTask extends AbstractServerTask {
             pb.environment().put('WLP_USER_DIR', getUserDir(project).getCanonicalPath())
 
             def run_process = pb.redirectErrorStream(true).start()
-            addShutdownHook {
-                run_process.waitFor()
-            }
+
             run_process.inputStream.eachLine {
                 println it
             }


### PR DESCRIPTION
Addresses #610

With this PR, the following scenarios result after pressing Ctrl+C.  When the server stops, a server stopped message can be seen in Liberty's messages.log.

1. liberty.server.embedded = false, with daemon : server stops after 10 seconds
2. liberty.server.embedded = false, --no-daemon : server stops right away
3. **liberty.server.embedded = true, with daemon : server keeps running, shutdown hook never gets called**
4. liberty.server.embedded = true, --no-daemon : server stops right away

Somehow with case 3, the shutdown hook is never called (until you stop the Gradle daemon with `gradle --stop`).  I even verified this with a debugger.  @cherylking @mattbsox Any suggestions, or should we leave that as a manual step to call libertyStop in that scenario (or even `gradle --stop`, since sometimes `libertyStop` thinks the embedded server is not running afterwards)?