### PR TITLE
Add support for recompileDependencies option

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ compileTestGroovy {
 }
 
 def libertyAntVersion = "1.9.8"
-def libertyCommonVersion = "1.8.15"
+def libertyCommonVersion = "1.8.16-SNAPSHOT"
 
 dependencies {
     implementation gradleApi()

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
@@ -121,6 +121,21 @@ class DevTask extends AbstractServerTask {
         }
     }
 
+    @Option(option = "recompileDependencies", description = 'Whether to recompile the entire project on a file change. The default value is false.')
+    void setRecompileDependencies(String recompileDependencies) {
+        if (recompileDependencies == null) {
+            log.debug(
+                "The recompileDependencies parameter was not explicitly set. The default value -DrecompileDependencies=false will be used.");
+            recompileDependencies = "false";
+        }
+        this.recompileDependencies = Boolean.parseBoolean(recompileDependencies)
+        if (this.recompileDependencies) {
+            log.info("The recompileDependencies parameter is set to \"true\". On a file change the entire project will be recompiled.");
+        } else {
+            log.info("The recompileDependencies parameter is set to \"false\". On a file change only the affected classes will be recompiled.");
+        }
+    }
+
     private Double compileWait;
 
     @Option(option = 'compileWait', description = 'Time in seconds to wait before processing Java changes and deletions. The default value is 0.5 seconds.')
@@ -280,13 +295,13 @@ class DevTask extends AbstractServerTask {
                     boolean  hotTests, boolean  skipTests, String artifactId, int serverStartTimeout,
                     int verifyAppStartTimeout, int appUpdateTimeout, double compileWait,
                     boolean libertyDebug, boolean pollingTest, boolean container, File dockerfile, File dockerBuildContext,
-                    String dockerRunOpts, int dockerBuildTimeout, boolean skipDefaultPorts, boolean keepTempDockerfile, String mavenCacheLocation
+                    String dockerRunOpts, int dockerBuildTimeout, boolean skipDefaultPorts, boolean keepTempDockerfile, String mavenCacheLocation, boolean recompileDeps
         ) throws IOException {
             super(buildDir, serverDirectory, sourceDirectory, testSourceDirectory, configDirectory, projectDirectory, /* multi module project directory */ projectDirectory,
                     resourceDirs, hotTests, skipTests, false /* skipUTs */, false /* skipITs */, artifactId,  serverStartTimeout,
                     verifyAppStartTimeout, appUpdateTimeout, ((long) (compileWait * 1000L)), libertyDebug,
                     true /* useBuildRecompile */, true /* gradle */, pollingTest, container, dockerfile, dockerBuildContext, dockerRunOpts, dockerBuildTimeout, skipDefaultPorts,
-                    null /* compileOptions not needed since useBuildRecompile is true */, keepTempDockerfile, mavenCacheLocation, null /* multi module upstream projects */
+                    null /* compileOptions not needed since useBuildRecompile is true */, keepTempDockerfile, mavenCacheLocation, null /* multi module upstream projects */, recompileDeps
                 );
 
             ServerFeature servUtil = getServerFeatureUtil();

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
@@ -78,6 +78,7 @@ class DevTask extends AbstractServerTask {
     private static final boolean DEFAULT_CONTAINER = false;
     private static final boolean DEFAULT_SKIP_DEFAULT_PORTS = false;
     private static final boolean DEFAULT_KEEP_TEMP_DOCKERFILE = false;
+    private static final boolean DEFAULT_RECOMPILE_DEPENDENCIES = false;
 
     protected final String CONTAINER_PROPERTY_ARG = '-P'+CONTAINER_PROPERTY+'=true';
 
@@ -121,18 +122,23 @@ class DevTask extends AbstractServerTask {
         }
     }
 
+    @Optional
+    @Input
+    Boolean recompileDependencies;
+
+    // Need to use a string value to allow someone to specify --recompileDependencies=false
     @Option(option = "recompileDependencies", description = 'Whether to recompile the entire project on a file change. The default value is false.')
     void setRecompileDependencies(String recompileDependencies) {
         if (recompileDependencies == null) {
-            log.debug(
+            logger.debug(
                 "The recompileDependencies parameter was not explicitly set. The default value -DrecompileDependencies=false will be used.");
             recompileDependencies = "false";
         }
         this.recompileDependencies = Boolean.parseBoolean(recompileDependencies)
         if (this.recompileDependencies) {
-            log.info("The recompileDependencies parameter is set to \"true\". On a file change the entire project will be recompiled.");
+            logger.info("The recompileDependencies parameter is set to \"true\". On a file change the entire project will be recompiled.");
         } else {
-            log.info("The recompileDependencies parameter is set to \"false\". On a file change only the affected classes will be recompiled.");
+            logger.info("The recompileDependencies parameter is set to \"false\". On a file change only the affected classes will be recompiled.");
         }
     }
 
@@ -859,6 +865,10 @@ class DevTask extends AbstractServerTask {
             pollingTest = DEFAULT_POLLING_TEST;
         }
 
+        if (recompileDependencies == null) {
+            recompileDependencies = DEFAULT_RECOMPILE_DEPENDENCIES;
+        }
+
         processContainerParams();
     }
 
@@ -946,7 +956,7 @@ class DevTask extends AbstractServerTask {
                 resourceDirs, hotTests.booleanValue(), skipTests.booleanValue(), artifactId, serverStartTimeout.intValue(),
                 verifyAppStartTimeout.intValue(), verifyAppStartTimeout.intValue(), compileWait.doubleValue(), 
                 libertyDebug.booleanValue(), pollingTest.booleanValue(), container.booleanValue(), dockerfile, dockerBuildContext, dockerRunOpts, 
-                dockerBuildTimeout, skipDefaultPorts.booleanValue(), keepTempDockerfile.booleanValue(), localMavenRepoForFeatureUtility
+                dockerBuildTimeout, skipDefaultPorts.booleanValue(), keepTempDockerfile.booleanValue(), localMavenRepoForFeatureUtility, recompileDependencies.booleanValue()
         );
 
         util.addShutdownHook(executor);


### PR DESCRIPTION
- Add support for `recompileDependencies` option for single module projects per https://github.com/OpenLiberty/ci.maven/issues/1174. `recompileDependencies` defaults to false.
- Use latest ci.common snapshot