### PR TITLE
Use ci.common 1.8.17-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ compileTestGroovy {
 }
 
 def libertyAntVersion = "1.9.8"
-def libertyCommonVersion = "1.8.16"
+def libertyCommonVersion = "1.8.17-SNAPSHOT"
 
 dependencies {
     implementation gradleApi()


### PR DESCRIPTION
To include https://github.com/OpenLiberty/ci.common/pull/294 and https://github.com/OpenLiberty/ci.common/pull/295