### PR TITLE
Allow generateFeatures=false

### DIFF
--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
@@ -250,11 +250,14 @@ class DevTask extends AbstractServerTask {
         this.keepTempDockerfile = keepTempDockerfile;
     }
 
-    private Boolean generateFeatures;
+    @Optional
+    @Input
+    Boolean generateFeatures;
 
-    @Option(option = 'generateFeatures', description = 'If true, scan the application binary files to determine which Liberty features should be used.')
-    void setGenerateFeatures(boolean generateFeatures) {
-        this.generateFeatures = generateFeatures;
+    // Need to use a string value to allow someone to specify --generateFeatures=false
+    @Option(option = 'generateFeatures', description = 'If true, scan the application binary files to determine which Liberty features should be used. The default value is true.')
+    void setGenerateFeatures(String generateFeatures) {
+        this.generateFeatures = Boolean.parseBoolean(generateFeatures);
     }
 
     @Optional
@@ -900,7 +903,7 @@ class DevTask extends AbstractServerTask {
         }
 
         if (generateFeatures == null) {
-            setGenerateFeatures(DEFAULT_GENERATE_FEATURES);
+            generateFeatures = DEFAULT_GENERATE_FEATURES;
         }
 
         processContainerParams();


### PR DESCRIPTION
Part of https://github.com/OpenLiberty/ci.maven/issues/1263

Use a String param for generateFeatures flag so that it can allow for "generateFeatures=false" (because boolean params do not support any value, only --generateFeatures or nothing).

(This is similar to the libertyDebug parameter's implementation)