### PR TITLE
After writing server.xml ensure <server> element is on a new line.

### DIFF
--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
@@ -15,6 +15,7 @@
  */
 package io.openliberty.tools.gradle.tasks
 
+import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.util.Set
 import java.net.URL;
@@ -251,9 +252,13 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
             return;
         }
         try {
-            if (doc.findFMComment(FEATURES_FILE_MESSAGE) == null) {
-                doc.createFMComment(FEATURES_FILE_MESSAGE);
-                doc.writeXMLDocument(serverXml);    
+            if (doc.createFMComment(FEATURES_FILE_MESSAGE)) {
+                doc.writeXMLDocument(serverXml);
+                // look for "<?xml version="1.0" ... ?><server .../>" and add a newline
+                byte[] contents = Files.readAllBytes(serverXml.toPath());
+                String xmlContents = new String(contents, StandardCharsets.UTF_8);
+                xmlContents = xmlContents.replace("?><", "?>"+System.getProperty("line.separator")+"<");
+                Files.write(serverXml.toPath(), xmlContents.getBytes());
             }
         } catch (IOException | TransformerException e) {
             log.debug("Exception adding comment to server.xml", e);

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
@@ -33,6 +33,7 @@ import org.xml.sax.SAXException
 
 import io.openliberty.tools.common.plugins.util.InstallFeatureUtil
 import io.openliberty.tools.common.plugins.config.ServerConfigXmlDocument
+import io.openliberty.tools.common.plugins.config.XmlDocument
 import io.openliberty.tools.common.plugins.util.DevUtil
 import io.openliberty.tools.common.plugins.util.PluginExecutionException
 import io.openliberty.tools.common.plugins.util.PluginScenarioException
@@ -254,11 +255,7 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
         try {
             if (doc.createFMComment(FEATURES_FILE_MESSAGE)) {
                 doc.writeXMLDocument(serverXml);
-                // look for "<?xml version="1.0" ... ?><server .../>" and add a newline
-                byte[] contents = Files.readAllBytes(serverXml.toPath());
-                String xmlContents = new String(contents, StandardCharsets.UTF_8);
-                xmlContents = xmlContents.replace("?><", "?>"+System.getProperty("line.separator")+"<");
-                Files.write(serverXml.toPath(), xmlContents.getBytes());
+                XmlDocument.addNewlineBeforeFirstElement(serverXml);
             }
         } catch (IOException | TransformerException e) {
             log.debug("Exception adding comment to server.xml", e);

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
@@ -15,7 +15,6 @@
  */
 package io.openliberty.tools.gradle.tasks
 
-import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.util.Set
 import java.net.URL;


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/ci.maven/issues/1301

It would be more efficient to fix the file when it is written in the method in ci.common but I think this requirement could be more application specific and should be closer to where the file is used.