### PR TITLE
Remove isClasspathResolved method to keep consistent with ci.common

### DIFF
--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
@@ -808,12 +808,6 @@ class DevTask extends AbstractServerTask {
             }
             return getLooseAppConfigFile(container, appsDir);
         }
-
-        @Override
-        public boolean isClasspathResolved(File buildFile) {
-            /* not needed for Gradle */
-            return true;
-        }
     }
 
     public void runInstallFeatureTask(BuildLauncher gradleBuildLauncher, List<String> options) throws BuildException {


### PR DESCRIPTION
Reverts `isClasspathResolved` method introduced in #1255
See https://github.com/OpenLiberty/ci.common/pull/312
Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>