### PR TITLE
Use the binary scanner support in ci.common

### DIFF
--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
@@ -33,6 +33,7 @@ import org.xml.sax.SAXException
 import io.openliberty.tools.common.plugins.util.InstallFeatureUtil
 import io.openliberty.tools.common.plugins.config.ServerConfigXmlDocument
 import io.openliberty.tools.common.plugins.config.XmlDocument
+import io.openliberty.tools.common.plugins.util.BinaryScannerUtil
 import io.openliberty.tools.common.plugins.util.DevUtil
 import io.openliberty.tools.common.plugins.util.PluginExecutionException
 import io.openliberty.tools.common.plugins.util.PluginScenarioException
@@ -49,19 +50,6 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
     private static final String BINARY_SCANNER_MAVEN_ARTIFACT_ID = "binaryAppScanner";
     private static final String BINARY_SCANNER_MAVEN_TYPE = "jar";
     private static final String BINARY_SCANNER_MAVEN_VERSION = "latest.release";
-
-    private static final String BINARY_SCANNER_CONFLICT_MESSAGE1 = "A working set of features could not be generated due to conflicts " +
-            "between configured features and the application's API usage: %s. Review and update your server configuration and " +
-            "application to ensure they are not using conflicting features and APIs from different levels of MicroProfile, " +
-            "Java EE, or Jakarta EE. Refer to the following set of suggested features for guidance: %s";
-    private static final String BINARY_SCANNER_CONFLICT_MESSAGE2 = "A working set of features could not be generated due to conflicts " +
-            "between configured features: %s. Review and update your server configuration to ensure it is not using conflicting " +
-            "features from different levels of MicroProfile, Java EE, or Jakarta EE. Refer to the following set of " +
-            "suggested features for guidance: %s";
-    private static final String BINARY_SCANNER_CONFLICT_MESSAGE3 = "A working set of features could not be generated due to conflicts " +
-            "in the application’s API usage: %s. Review and update your application to ensure it is not using conflicting APIs " +
-            "from different levels of MicroProfile, Java EE, or Jakarta EE.";
-    private static final String BINARY_SCANNER_CONFLICT_MESSAGE4 = "[None available]"; // format should match JVM Set.toString()
 
     private File binaryScanner;
     private URLClassLoader binaryScannerClassLoader = null;
@@ -83,6 +71,7 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
     @TaskAction
     void generateFeatures() {
         binaryScanner = getBinaryScannerJarFromRepository();
+        BinaryScannerHandler binaryScannerHandler = new BinaryScannerHandler(binaryScanner);
 
         if (classFiles != null && !classFiles.isEmpty()) {
             logger.debug("Generate features for the following class files: " + classFiles);
@@ -126,8 +115,19 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
         Set<String> scannedFeatureList;
         try {
             Set<String> directories = getClassesDirectories();
-            String[] binaryInputs = getBinaryInputs(classFiles, directories);
-            scannedFeatureList = runBinaryScanner(existingFeatures, binaryInputs);
+            String eeVersion = getEEVersion(project);
+            String mpVersion = getMPVersion(project);
+            scannedFeatureList = binaryScannerHandler.runBinaryScanner(existingFeatures, classFiles, directories, eeVersion, mpVersion);
+        } catch (BinaryScannerUtil.NoRecommendationException noRecommendation) {
+            logger.error(String.format(BinaryScannerUtil.BINARY_SCANNER_CONFLICT_MESSAGE3, noRecommendation.getConflicts()));
+            return;
+        } catch (BinaryScannerUtil.RecommendationSetException showRecommendation) {
+            if (showRecommendation.isExistingFeaturesConflict()) {
+                logger.error(String.format(BinaryScannerUtil.BINARY_SCANNER_CONFLICT_MESSAGE2, showRecommendation.getConflicts(), showRecommendation.getSuggestions()));
+            } else {
+                logger.error(String.format(BinaryScannerUtil.BINARY_SCANNER_CONFLICT_MESSAGE1, showRecommendation.getConflicts(), showRecommendation.getSuggestions()));
+            }
+            return;
         } catch (InvocationTargetException x) {
             // TODO Figure out what to do when there is a problem not caught in runBinaryScanner()
             logger.error("Exception:"+x.getClass().getName());
@@ -137,16 +137,6 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
                 logger.warn("Caused by exception message:"+x.getCause().getMessage());
             }
             logger.error(x.getMessage());
-            return;
-        } catch (NoRecommendationException noRecommendation) {
-            logger.error(String.format(BINARY_SCANNER_CONFLICT_MESSAGE3, noRecommendation.getConflicts()));
-            return;
-        } catch (RecommendationSetException showRecommendation) {
-            if (showRecommendation.isExistingFeaturesConflict()) {
-                logger.error(String.format(BINARY_SCANNER_CONFLICT_MESSAGE2, showRecommendation.getConflicts(), showRecommendation.getSuggestions()));
-            } else {
-                logger.error(String.format(BINARY_SCANNER_CONFLICT_MESSAGE1, showRecommendation.getConflicts(), showRecommendation.getSuggestions()));
-            }
             return;
         }
 
@@ -262,134 +252,6 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
         return;
     }
 
-    private Set<String> runBinaryScanner(Set<String> currentFeatureSet, String[] binaryInputs)
-            throws PluginExecutionException, NoRecommendationException, RecommendationSetException, InvocationTargetException {
-        Set<String> featureList = null;
-        if (binaryScanner != null && binaryScanner.exists()) {
-            try {
-                ClassLoader cl = getScannerClassLoader();
-                Class driveScan = cl.loadClass("com.ibm.ws.report.binary.cmdline.DriveScan");
-                // args: String[], String, String, List, java.util.Locale
-                java.lang.reflect.Method driveScanMavenFeatureList = driveScan.getMethod("driveScanMavenFeatureList", String[].class, String.class, String.class, List.class, java.util.Locale.class);
-                if (driveScanMavenFeatureList == null) {
-                    logger.debug("Error finding binary scanner method using reflection");
-                    return null;
-                }
- 
-                String eeVersion = getEEVersion(project); 
-                String mpVersion = getMPVersion(project);
-                List<String> currentFeatures;
-                if (currentFeatureSet == null) {
-                    currentFeatures = new ArrayList<String>();
-                } else {
-                    currentFeatures = new ArrayList<String>(currentFeatureSet);
-                }
-                logger.debug("The following messages are from the application binary scanner used to generate Liberty features");
-                featureList = (Set<String>) driveScanMavenFeatureList.invoke(null, binaryInputs, eeVersion, mpVersion, currentFeatures, java.util.Locale.getDefault());
-                logger.debug("End of messages from application binary scanner. Features recommended :");
-                for (String s : featureList) {logger.debug(s);};
-            } catch (InvocationTargetException  ite) {
-                // This is the exception from the JVM that indicates there was an exception in the method we
-                // called through reflection. We must extract the actual exception from the 'cause' field.
-                // A RuntimeException means the currentFeatureSet contains conflicts.
-                // A FeatureConflictException means the binary files scanned conflict with each other or with
-                // the currentFeatureSet parameter.
-                Throwable scannerException = ite.getCause();
-                if (scannerException instanceof RuntimeException) {
-                    // The list of features from the app is passed in but it contains conflicts
-                    String problemMessage = scannerException.getMessage();
-                    if (problemMessage == null || problemMessage.isEmpty()) {
-                        logger.debug("RuntimeException from binary scanner without descriptive message", scannerException);
-                        logger.error("Error scanning the application for Liberty features.");
-                    } else {
-                        Set<String> conflicts = parseScannerMessage(problemMessage);
-                        Set<String> sampleFeatureList = null;
-                        try {
-                            sampleFeatureList = runBinaryScanner(null, getBinaryInputs(null, getClassesDirectories()));
-                        } catch (InvocationTargetException retryException) {
-                            // binary scanner should not return a RuntimeException since there is no list of app features passed in
-                            sampleFeatureList = getNoSampleFeatureList();
-                        }
-                        throw new RecommendationSetException(true, conflicts, sampleFeatureList);
-                    }
-                } else if (scannerException.getClass().getName().endsWith("FeatureConflictException")) {
-                    // The scanned files conflict with each other or with current features
-                    Set<String> conflicts = getConflicts(scannerException);
-                    Set<String> sampleFeatureList = null;
-                    if (currentFeatureSet != null) {
-                        try {
-                            sampleFeatureList = runBinaryScanner(null, getBinaryInputs(null, getClassesDirectories()));
-                        } catch (InvocationTargetException retryException) {
-                            Throwable scannerSecondException = retryException.getCause();
-                            if (scannerSecondException.getClass().getName().endsWith("FeatureConflictException")) {
-                                // Even after removing the server.xml feature list there are still conflicts in the binaries
-                                throw new NoRecommendationException(conflicts);
-                            } else {
-                                logger.debug("Unexpected failure on retry call to binary scanner", scannerSecondException);
-                                logger.debug("Passed directories to binary scanner:"+getClassesDirectories());
-                                sampleFeatureList = getNoSampleFeatureList();
-                            }
-                        }
-                        throw new RecommendationSetException(false, conflicts, sampleFeatureList);
-                    } else {
-                        throw ite;
-                    }
-                }
-            } catch (MalformedURLException|ClassNotFoundException|NoSuchMethodException|IllegalAccessException x){
-                // TODO Figure out what to do when there is a problem scanning the features
-                logger.error("Exception:"+x.getClass().getName());
-                Object o = x.getCause();
-                if (o != null) {
-                    logger.warn("Caused by exception:"+x.getCause().getClass().getName());
-                    logger.warn("Caused by exception message:"+x.getCause().getMessage());
-                }
-                logger.error(x.getMessage());
-            }
-        } else {
-            if (binaryScanner == null) {
-                throw new PluginExecutionException("The binary scanner jar location is not defined.");
-            } else {
-                throw new PluginExecutionException("Could not find the binary scanner jar at " + binaryScanner.getAbsolutePath());
-            }
-        }
-        return featureList;
-    }
-
-    private Set getNoSampleFeatureList() {
-        Set sampleFeatureList = new HashSet<String>();
-        sampleFeatureList.add(BINARY_SCANNER_CONFLICT_MESSAGE4)
-        return sampleFeatureList
-    }
-
-    private ClassLoader getScannerClassLoader() throws MalformedURLException {
-        if (binaryScannerClassLoader == null) {
-            ClassLoader cl = this.getClass().getClassLoader();
-            URL[] u = new URL[1];
-            u[0] = binaryScanner.toURI().toURL();
-            binaryScannerClassLoader = new URLClassLoader(u, cl);
-        }
-        return binaryScannerClassLoader;
-    }
-
-    private String[] getBinaryInputs(List<String> classFiles, Set<String> classDirectories) throws PluginExecutionException {
-        Collection<String> resultSet;
-        if (classFiles != null && !classFiles.isEmpty()) {
-            resultSet = classFiles;
-        } else {
-            if (classDirectories == null || classDirectories.isEmpty()) {
-                throw new PluginExecutionException("Error collecting list of directories to send to binary scanner, list is null or empty.");
-            }
-            resultSet = classDirectories;
-        }
-
-        for (String s : resultSet) {
-            logger.debug("Binary scanner input: " + s);
-        }
-
-        String[] result = resultSet.toArray(new String[resultSet.size()]);
-        return result;
-    }
-
     private Set<String> getClassesDirectories() {
         Set<String> classesDirectories = new ArrayList<String>();
         project.sourceSets.main.getOutput().getClassesDirs().each {
@@ -399,86 +261,73 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
     }
 
     private getEEVersion(Object project) {
-        return null;
+        String eeVersion = null
+        project.configurations.compile.allDependencies.each {
+            dependency -> 
+                if (dependency.group.equals("io.openliberty.features")) {
+                    if (dependency.name.equals("javaee-7.0")) {
+                        eeVersion = "ee7"
+                    } else if (dependency.name.equals("javaee-8.0")) {
+                        eeVersion = "ee8"
+                    } else if (dependency.name.equals("javaeeClient-7.0")) {
+                        eeVersion = "ee7"
+                    } else if (dependency.name.equals("javaeeClient-8.0")) {
+                        eeVersion = "ee8"
+                    } else if (dependency.name.equals("jakartaee-8.0")) {
+                        eeVersion = "ee8"
+                    }
+                } else if (dependency.group.equals("jakarta.platform") &&
+                    dependency.name.equals("jakarta.jakartaee-api") &&
+                    dependency.version.equals("8.0.0")) {
+                        eeVersion = "ee8";
+                }
+        }
+        return eeVersion;
     }
 
     private getMPVersion(Object project) {
-        return null;
-    }
-
-    @SuppressWarnings("unchecked")
-    private Set<String> getConflicts(Throwable scannerResponse) {
-        try {
-            ClassLoader cl = getScannerClassLoader();
-            @SuppressWarnings("rawtypes")
-            Class featureConflictException = cl.loadClass("com.ibm.ws.report.exceptions.FeatureConflictException");
-            java.lang.reflect.Method conflictFeatureList = featureConflictException.getMethod("getFeatures");
-            if (conflictFeatureList == null) {
-                logger.debug("Error finding FeatureConflictException method getFeatures using reflection");
-                return null;
-            }
-            return (Set<String>) conflictFeatureList.invoke(scannerResponse);
-        } catch (ClassNotFoundException | MalformedURLException | NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException x) {
-            //TODO maybe nothing
-            logger.error("Exception:"+x.getClass().getName());
-            logger.error("Message:"+x.getMessage());
-            Object o = x.getCause();
-            if (o != null) {
-                logger.warn("Caused by exception:"+x.getCause().getClass().getName());
-                logger.warn("Caused by exception message:"+x.getCause().getMessage());
-            }
-        }
-        return null;
-    }
-
-    private Set<String> parseScannerMessage(String messages) {
-        Set<String> features = new HashSet<String>();
-        String[] messageArray = messages.split("\n");
-        for (String message : messageArray) {
-            if (message.startsWith("CWMIG12083")) {
-                String [] messageParts = message.split(" ");
-                if (messageParts.length > 4) { // should be 20
-                    features.add(messageParts[2]);
-                    features.add(messageParts[messageParts.length-2]);
+        String mpVersion = null
+        project.configurations.compile.allDependencies.each {
+            if (it.group.equals("org.eclipse.microprofile") &&
+                it.name.equals("microprofile")) {
+                if (it.version.startsWith("1")) {
+                    mpVersion =  "mp1"
+                } else if (it.version.startsWith("2")) {
+                    mpVersion =  "mp2"
+                } else if (it.version.startsWith("3")) {
+                    mpVersion =  "mp3"
+                } else if (it.version.startsWith("4")) {
+                    mpVersion =  "mp4"
                 }
             }
         }
-        return features;
+        return mpVersion;
     }
 
-    // A class to pass the list of conflicts back to the caller.
-    private class NoRecommendationException extends Exception {
-        private static final long serialVersionUID = 1L;
-        Set<String> conflicts;
-        NoRecommendationException(Set<String> conflictSet) {
-            conflicts = conflictSet;
+    // Define the logging functions of the binary scanner handler and make it available in this plugin
+    private class BinaryScannerHandler extends BinaryScannerUtil {
+        BinaryScannerHandler(File scannerFile) {
+            super(scannerFile);
         }
-        public Set<String> getConflicts() {
-            return conflicts;
+        @Override
+        public void debug(String msg) {
+            logger.debug(msg);
         }
-    }
-
-    // A class that encapsulates a list of conflicting features, a suggested list of replacements
-    // and a flag that indicates whether the conflicts were found in the features existing in the
-    // app's server config or if the conflicts exist in the binary files we examined.
-    private class RecommendationSetException extends Exception {
-        private static final long serialVersionUID = 1L;
-        boolean existingFeaturesConflict;
-        Set<String> conflicts;
-        Set<String> suggestions;
-        RecommendationSetException(boolean existing, Set<String> conflictSet, Set<String> suggestionSet) {
-            existingFeaturesConflict = existing;
-            conflicts = conflictSet;
-            suggestions = suggestionSet;
+        @Override
+        public void debug(String msg, Throwable t) {
+            logger.debug(msg, t);
         }
-        public boolean isExistingFeaturesConflict() {
-            return existingFeaturesConflict;
+        @Override
+        public void error(String msg) {
+            logger.error(msg);
         }
-        public Set<String> getConflicts() {
-            return conflicts;
+        @Override
+        public void warn(String msg) {
+            logger.warn(msg);
         }
-        public Set<String> getSuggestions() {
-            return suggestions;
+        @Override
+        public void info(String msg) {
+            logger.info(msg);
         }
     }
 }

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
@@ -15,10 +15,7 @@
  */
 package io.openliberty.tools.gradle.tasks
 
-import java.nio.file.Files
 import java.util.Set
-import java.net.URL;
-import java.net.URLClassLoader;
 import java.lang.reflect.InvocationTargetException;
 
 import javax.xml.parsers.ParserConfigurationException
@@ -52,7 +49,6 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
     private static final String BINARY_SCANNER_MAVEN_VERSION = "latest.release";
 
     private File binaryScanner;
-    private URLClassLoader binaryScannerClassLoader = null;
 
     GenerateFeaturesTask() {
         configure({

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
@@ -323,7 +323,7 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
         }
         @Override
         public void info(String msg) {
-            logger.info(msg);
+            logger.lifecycle(msg);
         }
     }
 }


### PR DESCRIPTION
Hopefully no change in behaviour except to get the EE and MicroProfile version from build file if umbrella feature is used. Matches the support in ci.maven. If we want to change how the EE/MP version is set or obtained we should probably track that in a separate issue and fix in both LMP and LGP.
Fixes https://github.com/OpenLiberty/ci.maven/issues/1309