### PR TITLE
Get existing features for feature gen from the source config dir

### DIFF
--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractFeatureTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractFeatureTask.groovy
@@ -185,14 +185,9 @@ public class AbstractFeatureTask extends AbstractServerTask {
         return featuresToInstall
     }
 
-    private void createNewServerFeatureUtil() {
-        servUtil = new ServerFeatureTaskUtil();
-        return;
-    }
-
     protected ServerFeatureUtil getServerFeatureUtil() {
         if (servUtil == null) {
-            createNewServerFeatureUtil();
+            servUtil = new ServerFeatureTaskUtil();
         }
         return servUtil;
     }

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractFeatureTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractFeatureTask.groovy
@@ -1,19 +1,22 @@
 /**
-* (C) Copyright IBM Corporation 2021.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * (C) Copyright IBM Corporation 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.openliberty.tools.gradle.tasks
+
+import com.ibm.wsspi.kernel.embeddable.Server
+import io.openliberty.tools.common.plugins.util.ServerFeatureUtil
 
 import java.util.Set
 
@@ -34,34 +37,69 @@ public class AbstractFeatureTask extends AbstractServerTask {
     // DevMode uses this option to provide the location of the
     // temporary serverDir it uses after a change to the server.xml
     private String serverDirectoryParam;
-    
+
     public boolean installFeaturesFromAnt;
 
     private InstallFeatureUtil util;
+
+    private ServerFeatureUtil servUtil;
 
     @Option(option = 'serverDir', description = '(Optional) Server directory to get the list of features from.')
     void setServerDirectoryParam(String serverDir) {
         this.serverDirectoryParam = serverDir;
     }
 
+    private class ServerFeatureTaskUtil extends ServerFeatureUtil {
+
+        @Override
+        void debug(String msg) {
+            logger.debug(msg);
+        }
+
+        @Override
+        void error(String msg, Throwable throwable) {
+            logger.error(msg, e);
+        }
+
+        @Override
+        void debug(String msg, Throwable throwable) {
+            logger.debug(msg, (Throwable) e);
+        }
+
+        @Override
+        void debug(Throwable throwable) {
+            logger.debug("Throwable exception received: " + e.getMessage(), (Throwable) e);
+        }
+
+        @Override
+        void warn(String msg) {
+            logger.warn(msg);
+        }
+
+        @Override
+        void info(String msg) {
+            logger.lifecycle(msg);
+        }
+    }
+
     private class InstallFeatureTaskUtil extends InstallFeatureUtil {
-        public InstallFeatureTaskUtil(File installDir, String from, String to, Set<String> pluginListedEsas, List<ProductProperties> propertiesList, String openLibertyVerion, String containerName)  throws PluginScenarioException, PluginExecutionException {
+        public InstallFeatureTaskUtil(File installDir, String from, String to, Set<String> pluginListedEsas, List<ProductProperties> propertiesList, String openLibertyVerion, String containerName) throws PluginScenarioException, PluginExecutionException {
             super(installDir, from, to, pluginListedEsas, propertiesList, openLibertyVerion, containerName)
         }
 
         @Override
         public void debug(String msg) {
-           logger.debug(msg)
+            logger.debug(msg)
         }
 
         @Override
         public void debug(String msg, Throwable e) {
-           logger.debug(msg, (Throwable) e)
+            logger.debug(msg, (Throwable) e)
         }
 
         @Override
         public void debug(Throwable e) {
-            logger.debug("Throwable exception received: "+e.getMessage(), (Throwable) e)
+            logger.debug("Throwable exception received: " + e.getMessage(), (Throwable) e)
         }
 
         @Override
@@ -121,18 +159,17 @@ public class AbstractFeatureTask extends AbstractServerTask {
     protected Set<String> getSpecifiedFeatures(String containerName) throws PluginExecutionException {
         InstallFeatureUtil util = getInstallFeatureUtil(null, containerName);
         // if createNewInstallFeatureUtil failed to create a new InstallFeatureUtil instance, then features are installed via ant
-        if(installFeaturesFromAnt) {
+        if (installFeaturesFromAnt) {
             Set<String> featuresInstalledFromAnt;
-            if(server.features.name != null) {
+            if (server.features.name != null) {
                 featuresInstalledFromAnt = new HashSet<String>(server.features.name);
                 return featuresInstalledFromAnt;
-            }
-            else {
+            } else {
                 featuresInstalledFromAnt = new HashSet<String>();
                 return featuresInstalledFromAnt;
             }
         }
-        
+
         def pluginListedFeatures = getPluginListedFeatures(false)
         def dependencyFeatures = getDependencyFeatures()
         def serverFeatures = null;
@@ -145,14 +182,26 @@ public class AbstractFeatureTask extends AbstractServerTask {
         }
 
         Set<String> featuresToInstall = InstallFeatureUtil.combineToSet(pluginListedFeatures, dependencyFeatures, serverFeatures)
-        return featuresToInstall 
+        return featuresToInstall
+    }
+
+    private void createNewServerFeatureUtil() {
+        servUtil = new ServerFeatureTaskUtil();
+        return;
+    }
+
+    protected ServerFeatureUtil getServerFeatureUtil() {
+        if (servUtil == null) {
+            createNewServerFeatureUtil();
+        }
+        return servUtil;
     }
 
     private void createNewInstallFeatureUtil(Set<String> pluginListedEsas, List<ProductProperties> propertiesList, String openLibertyVerion, String containerName) throws PluginExecutionException {
         try {
             util = new InstallFeatureTaskUtil(getInstallDir(project), server.features.from, server.features.to, pluginListedEsas, propertiesList, openLibertyVerion, containerName)
         } catch (PluginScenarioException e) {
-            logger.debug("Exception received: "+e.getMessage(),(Throwable)e)
+            logger.debug("Exception received: " + e.getMessage(), (Throwable) e)
             logger.debug("Installing features from installUtility.")
             installFeaturesFromAnt = true
             return
@@ -180,5 +229,6 @@ public class AbstractFeatureTask extends AbstractServerTask {
         createNewInstallFeatureUtil(pluginListedEsas, propertiesList, openLibertyVerion, containerName)
         return util
     }
+
 
 }

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
@@ -45,7 +45,7 @@ import io.openliberty.tools.common.plugins.util.ProjectModule
 import java.util.concurrent.TimeUnit
 import java.util.Map.Entry
 
-class DevTask extends AbstractServerTask {
+class DevTask extends AbstractFeatureTask {
 
     private static final String LIBERTY_HOSTNAME = "liberty.hostname";
     private static final String LIBERTY_HTTP_PORT = "liberty.http.port";
@@ -303,7 +303,7 @@ class DevTask extends AbstractServerTask {
                     false /* recompileDependencies only supported in ci.maven */, packagingType, buildFile, null /* parent build files */, generateFeatures, null /* compileArtifactPaths */, null /* testArtifactPaths */
                 );
 
-            ServerFeature servUtil = getServerFeatureUtil();
+            ServerFeatureUtil servUtil = getServerFeatureUtil();
             this.libertyDirPropertyFiles = AbstractServerTask.getLibertyDirectoryPropertyFiles(installDirectory, userDirectory, serverDirectory);
             this.existingFeatures = servUtil.getServerFeatures(serverDirectory, libertyDirPropertyFiles);
 
@@ -534,7 +534,7 @@ class DevTask extends AbstractServerTask {
                 }
 
             }
-
+            // TODO should we regenerate features here?
             if (restartServer) {
                 // - stop Server
                 // - create server or runBoostMojo
@@ -611,7 +611,7 @@ class DevTask extends AbstractServerTask {
 
         @Override
         public void checkConfigFile(File configFile, File serverDir) {
-            ServerFeature servUtil = getServerFeatureUtil();
+            ServerFeatureUtil servUtil = getServerFeatureUtil();
             Set<String> features = servUtil.getServerFeatures(serverDir, libertyDirPropertyFiles);
 
             if (features == null) {
@@ -988,6 +988,7 @@ class DevTask extends AbstractServerTask {
                 :deploy
              */
             if (!container) {
+                // TODO should generate features run here? If so should it run regardless of whether it is a container or not
                 addLibertyRuntimeProperties(gradleBuildLauncher);               
                 runGradleTask(gradleBuildLauncher, 'libertyCreate');
                 // suppress extra install feature warnings (one would have shown up already from the libertyCreate task on the line above)
@@ -1155,46 +1156,4 @@ class DevTask extends AbstractServerTask {
         buildLauncher.run();
     }
 
-    private static ServerFeature serverFeatureUtil;
-
-    private ServerFeature getServerFeatureUtil() {
-        if (serverFeatureUtil == null) {
-            serverFeatureUtil = new ServerFeature();
-        }
-        return serverFeatureUtil;
-    }
-
-    private class ServerFeature extends ServerFeatureUtil {
-
-        @Override
-        public void debug(String msg) {
-            logger.debug(msg);
-        }
-
-        @Override
-        public void debug(String msg, Throwable e) {
-            logger.debug(msg, (Throwable) e);
-        }
-
-        @Override
-        public void debug(Throwable e) {
-            logger.debug("Exception received: "+e.getMessage(), (Throwable) e);
-        }
-
-        @Override
-        public void warn(String msg) {
-            logger.warn(msg);
-        }
-
-        @Override
-        public void info(String msg) {
-            logger.info(msg);
-        }
-
-        @Override
-        public void error(String msg, Throwable e) {
-            logger.error(msg, e);
-        }
-
-    }
 }

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
@@ -160,7 +160,7 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
                 logger.debug("Xml document we'll try to update after generate features doc="+doc+" file="+serverXml);
                 addGenerationCommentToConfig(doc, serverXml);
 
-                logger.info("Generated the following additional features: " + missingLibertyFeatures);
+                logger.lifecycle("Generated the following features: " + missingLibertyFeatures); // use logger.lifecycle so that message appears without --info tag on
             } catch(ParserConfigurationException | TransformerException | IOException e) {
                 logger.debug("Exception creating the server features file", e);
                 logger.error("Error attempting to create the server feature file. Ensure your id has write permission to the server installation directory.");

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
@@ -15,26 +15,20 @@
  */
 package io.openliberty.tools.gradle.tasks
 
-import java.util.Set
-import java.lang.reflect.InvocationTargetException;
 
-import javax.xml.parsers.ParserConfigurationException
-import javax.xml.transform.TransformerException
-
-import org.gradle.api.artifacts.ResolveException
-import org.gradle.api.logging.LogLevel
+import io.openliberty.tools.common.plugins.config.ServerConfigXmlDocument
+import io.openliberty.tools.common.plugins.config.XmlDocument
+import io.openliberty.tools.common.plugins.util.BinaryScannerUtil
+import io.openliberty.tools.common.plugins.util.PluginExecutionException
+import io.openliberty.tools.common.plugins.util.ServerFeatureUtil
+import io.openliberty.tools.gradle.utils.ArtifactDownloadUtil
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.options.Option
 import org.xml.sax.SAXException
 
-import io.openliberty.tools.common.plugins.util.InstallFeatureUtil
-import io.openliberty.tools.common.plugins.config.ServerConfigXmlDocument
-import io.openliberty.tools.common.plugins.config.XmlDocument
-import io.openliberty.tools.common.plugins.util.BinaryScannerUtil
-import io.openliberty.tools.common.plugins.util.DevUtil
-import io.openliberty.tools.common.plugins.util.PluginExecutionException
-import io.openliberty.tools.common.plugins.util.PluginScenarioException
-import io.openliberty.tools.gradle.utils.ArtifactDownloadUtil
+import javax.xml.parsers.ParserConfigurationException
+import javax.xml.transform.TransformerException
+import java.lang.reflect.InvocationTargetException
 
 class GenerateFeaturesTask extends AbstractFeatureTask {
 
@@ -76,7 +70,10 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
         }
 
         initializeConfigDirectory();
-        def serverDirectory = getServerDir(project);
+
+        // TODO add support for env variables
+        // commented out for now as the current logic depends on the server dir existing and specifying features with env variables is an edge case
+        /* def serverDirectory = getServerDir(project);
         def libertyDirPropertyFiles;
         try {
             libertyDirPropertyFiles = getLibertyDirectoryPropertyFiles(getInstallDir(project), getUserDir(project), serverDirectory);
@@ -84,29 +81,23 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
             logger.debug("Exception reading the server property files", e);
             logger.error("Error attempting to generate server feature list. Ensure your user account has read permission to the property files in the server installation directory.");
             return;
-        }
-        // get existing installed server features
-        InstallFeatureUtil util;
-        try {
-            util = getInstallFeatureUtil(new HashSet<String>(), null);
-        } catch (PluginScenarioException e) {
-            logger.debug("Exception creating the server utility object", e);
-            logger.error("Error attempting to generate server feature list.");
-            return;
-        }
+        } */
+
+        // get existing server features from source directory
+        ServerFeatureUtil servUtil = getServerFeatureUtil();
 
         final boolean optimize = (classFiles == null || classFiles.isEmpty()) ? true : false;
         Set<String> generatedFiles = new HashSet<String>();
-        generatedFiles.add(GENERATED_FEATURES_FILE_NAME);    
+        generatedFiles.add(GENERATED_FEATURES_FILE_NAME);
 
-        util.setLowerCaseFeatures(false);
+        servUtil.setLowerCaseFeatures(false);
         // if optimizing, ignore generated files when passing in existing features to binary scanner
-        Set<String> existingFeatures = util.getServerFeatures(serverDirectory, libertyDirPropertyFiles, optimize ? generatedFiles : null);
+        Set<String> existingFeatures = servUtil.getServerFeatures(server.configDirectory, server.serverXmlFile, new HashMap<String,File>(), optimize ? generatedFiles : null);
         if (existingFeatures == null) {
             existingFeatures = new HashSet<String>();
         }
         logger.debug("Existing features:" + existingFeatures);
-        util.setLowerCaseFeatures(true);
+        servUtil.setLowerCaseFeatures(true);
 
         Set<String> scannedFeatureList;
         try {
@@ -140,11 +131,11 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
         if (scannedFeatureList != null) {
             missingLibertyFeatures.addAll(scannedFeatureList);
 
-            util.setLowerCaseFeatures(false);
+            servUtil.setLowerCaseFeatures(false);
             // get set of user defined features so they can be omitted from the generated file that will be written
-            Set<String> userDefinedFeatures = optimize ? existingFeatures : util.getServerFeatures(serverDirectory, libertyDirPropertyFiles, generatedFiles);
+            Set<String> userDefinedFeatures = optimize ? existingFeatures : servUtil.getServerFeatures(server.configDirectory, server.serverXmlFile, new HashMap<String,File>(), generatedFiles);
             logger.debug("User defined features:" + userDefinedFeatures);
-            util.setLowerCaseFeatures(true);
+            servUtil.setLowerCaseFeatures(true);
             if (userDefinedFeatures != null) {
                 missingLibertyFeatures.removeAll(userDefinedFeatures);
             }


### PR DESCRIPTION
See https://github.com/OpenLiberty/ci.maven/pull/1312

Have generate features get existing user specified features from the source directory rather than the target directory.

Added `ServerFeatureTaskUtil` to `AbstractFeatureTask`. 
To reduce code duplication and have dev mode make use of `ServerFeatureTaskUtil`:
`DevTask` now extends `AbstractFeatureTask` which extends `AbstractServerTask`
(previously was: `DevTask` extends `AbstractServerTask`)
 
Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>