### PR TITLE
Check dependencies for javax.javaee-api to get Java EE version for binary scanner

### DIFF
--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
@@ -274,21 +274,15 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
         String eeVersion = null
         project.configurations.compile.allDependencies.each {
             dependency ->
-                if (dependency.group.equals("io.openliberty.features")) {
-                    if (dependency.name.equals("javaee-7.0")) {
+                if (dependency.group.equals("javax") && dependency.name.equals("javaee-api")) {
+                    if (dependency.version.startsWith("7.")) {
                         eeVersion = "ee7"
-                    } else if (dependency.name.equals("javaee-8.0")) {
-                        eeVersion = "ee8"
-                    } else if (dependency.name.equals("javaeeClient-7.0")) {
-                        eeVersion = "ee7"
-                    } else if (dependency.name.equals("javaeeClient-8.0")) {
-                        eeVersion = "ee8"
-                    } else if (dependency.name.equals("jakartaee-8.0")) {
+                    } else if (dependency.version.startsWith("8.")) {
                         eeVersion = "ee8"
                     }
                 } else if (dependency.group.equals("jakarta.platform") &&
                         dependency.name.equals("jakarta.jakartaee-api") &&
-                        dependency.version.equals("8.0.0")) {
+                        dependency.version.startsWith("8.")) {
                     eeVersion = "ee8";
                 }
         }

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
@@ -275,10 +275,12 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
         project.configurations.compile.allDependencies.each {
             dependency ->
                 if (dependency.group.equals("javax") && dependency.name.equals("javaee-api")) {
-                    if (dependency.version.startsWith("7.")) {
-                        eeVersion = "ee7"
-                    } else if (dependency.version.startsWith("8.")) {
+                    if (dependency.version.startsWith("8.")) {
                         eeVersion = "ee8"
+                    } else if (dependency.version.startsWith("7.")) {
+                        eeVersion = "ee7"
+                    } else if (dependency.version.startsWith("6.")) {
+                        eeVersion = "ee6"
                     }
                 } else if (dependency.group.equals("jakarta.platform") &&
                         dependency.name.equals("jakarta.jakartaee-api") &&


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/ci.maven/issues/1350
Signed-off-by: Paul Gooderham <turkeyonmarblerye@gmail.com>