### PR TITLE
Disable feature generation if the binary scanner jar cannot be found

### DIFF
--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
@@ -42,7 +42,7 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
     protected static final String NO_NEW_FEATURES_COMMENT = "No additional features generated";
 
     private static final String BINARY_SCANNER_MAVEN_GROUP_ID = "com.ibm.websphere.appmod.tools";
-    private static final String BINARY_SCANNER_MAVEN_ARTIFACT_ID = "binary-app-scanner";
+    private static final String BINARY_SCANNER_MAVEN_ARTIFACT_ID = "binary-app-scanner-test";
     private static final String BINARY_SCANNER_MAVEN_TYPE = "jar";
     private static final String BINARY_SCANNER_MAVEN_VERSION = "[21.0.0.4-SNAPSHOT,)";
 
@@ -199,14 +199,19 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
      * Downloads it first from connected repositories such as Maven Central if a newer release is available than the cached version.
      * Note: Maven updates artifacts daily by default based on the last updated timestamp. Users should use 'mvn -U' to force updates if needed.
      *
-     * @return The File object of the binary scanner jar in the local cache.
-     * @throws PluginExecutionException
+     * @return The File object of the binary-app-scanner.jar in the local cache.
+     * @throws PluginExecutionException indicates the binary-app-scanner.jar could not be found
      */
     private File getBinaryScannerJarFromRepository() throws PluginExecutionException {
         try {
             return ArtifactDownloadUtil.downloadBuildArtifact(project, BINARY_SCANNER_MAVEN_GROUP_ID, BINARY_SCANNER_MAVEN_ARTIFACT_ID, BINARY_SCANNER_MAVEN_TYPE, BINARY_SCANNER_MAVEN_VERSION);
         } catch (Exception e) {
-            throw new PluginExecutionException("Could not retrieve the binary scanner jar. Ensure you have a connection to Maven Central or another repository that contains the jar configured in your build.gradle: " + e.getMessage(), e);
+            throw new PluginExecutionException("Could not retrieve the artifact " + BINARY_SCANNER_MAVEN_GROUP_ID + "."
+                    + BINARY_SCANNER_MAVEN_ARTIFACT_ID
+                    + " needed for liberty:generate-features. Ensure you have a connection to Maven Central or another repository that contains the "
+                    + BINARY_SCANNER_MAVEN_GROUP_ID + "." + BINARY_SCANNER_MAVEN_ARTIFACT_ID
+                    + ".jar configured in your build.gradle",
+                    e);
         }
     }
 

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
@@ -208,7 +208,7 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
         } catch (Exception e) {
             throw new PluginExecutionException("Could not retrieve the artifact " + BINARY_SCANNER_MAVEN_GROUP_ID + "."
                     + BINARY_SCANNER_MAVEN_ARTIFACT_ID
-                    + " needed for liberty:generate-features. Ensure you have a connection to Maven Central or another repository that contains the "
+                    + " needed for generateFeatures. Ensure you have a connection to Maven Central or another repository that contains the "
                     + BINARY_SCANNER_MAVEN_GROUP_ID + "." + BINARY_SCANNER_MAVEN_ARTIFACT_ID
                     + ".jar configured in your build.gradle",
                     e);

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
@@ -42,7 +42,7 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
     protected static final String NO_NEW_FEATURES_COMMENT = "No additional features generated";
 
     private static final String BINARY_SCANNER_MAVEN_GROUP_ID = "com.ibm.websphere.appmod.tools";
-    private static final String BINARY_SCANNER_MAVEN_ARTIFACT_ID = "binary-app-scanner-test";
+    private static final String BINARY_SCANNER_MAVEN_ARTIFACT_ID = "binary-app-scanner";
     private static final String BINARY_SCANNER_MAVEN_TYPE = "jar";
     private static final String BINARY_SCANNER_MAVEN_VERSION = "[21.0.0.4-SNAPSHOT,)";
 


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/ci.maven/issues/1291
Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>

Error message displayed if the binary-app-scanner.jar cannot be found on startup of dev mode:
```
kathrynkodama@MacBook-Pro demo-devmode-scan % gradle libertyDev 
> Task :compileJava UP-TO-DATE
> Task :processResources NO-SOURCE

BUILD SUCCESSFUL in 4s
1 actionable task: 1 up-to-date
> Task :generateFeatures FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':generateFeatures'.
> Could not resolve all dependencies for configuration ':detachedConfiguration1'.
   > Could not find any version that matches com.ibm.websphere.appmod.tools:binary-app-scanner-test:[21.0.0.4-SNAPSHOT,).
     Versions that do not match: resolver-status.properties
     Searched in the following locations:
       - file:/Users/kathrynkodama/.m2/repository/com/ibm/websphere/appmod/tools/binary-app-scanner-test/
       - https://repo.maven.apache.org/maven2/com/ibm/websphere/appmod/tools/binary-app-scanner-test/maven-metadata.xml
       - https://oss.sonatype.org/content/repositories/snapshots/com/ibm/websphere/appmod/tools/binary-app-scanner-test/maven-metadata.xml
     Required by:
         project :

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.9.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD FAILED in 2s
1 actionable task: 1 executed

> Task :libertyDev
Could not retrieve the artifact com.ibm.websphere.appmod.tools.binary-app-scanner-test needed for 
liberty:generate-features. Ensure you have a connection to Maven Central or another repository that contains 
the com.ibm.websphere.appmod.tools.binary-app-scanner-test.jar configured in your build.gradle.
Disabling the automatic generation of features.

> Task :installLiberty
> Task :libertyCreate
```

Error message displayed if the binary-app-scanner.jar cannot be found during the inner loop of dev mode:
```
Setting automatic generation of features to: [ On ]
Generating optimized features list...

> Task :generateFeatures FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':generateFeatures'.
> Could not resolve all dependencies for configuration ':detachedConfiguration1'.
   > Could not find any version that matches com.ibm.websphere.appmod.tools:binary-app-scanner-test:[21.0.0.4-SNAPSHOT,).
     Versions that do not match: resolver-status.properties
     Searched in the following locations:
       - file:/Users/kathrynkodama/.m2/repository/com/ibm/websphere/appmod/tools/binary-app-scanner-test/
       - https://repo.maven.apache.org/maven2/com/ibm/websphere/appmod/tools/binary-app-scanner-test/maven-metadata.xml
       - https://oss.sonatype.org/content/repositories/snapshots/com/ibm/websphere/appmod/tools/binary-app-scanner-test/maven-metadata.xml
     Required by:
         project :

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.9.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD FAILED in 4s
1 actionable task: 1 executed

> Task :libertyDev
Could not retrieve the artifact com.ibm.websphere.appmod.tools.binary-app-scanner-test needed for liberty:generate-features. Ensure you have a connection to Maven Central or another repository that contains the com.ibm.websphere.appmod.tools.binary-app-scanner-test.jar configured in your build.gradle.
Disabling the automatic generation of features.
Setting automatic generation of features to: [ Off ]
```