### PR TITLE
Gradle 7 fix for ServerFeatureUtil

### DIFF
--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractFeatureTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractFeatureTask.groovy
@@ -195,6 +195,7 @@ public class AbstractFeatureTask extends AbstractServerTask {
         return featuresToInstall
     }
 
+    @Internal
     protected ServerFeatureUtil getServerFeatureUtil() {
         if (servUtil == null) {
             servUtil = new ServerFeatureTaskUtil();

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
@@ -277,7 +277,7 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
 
     private getEEVersion(Object project) {
         String eeVersion = null
-        project.configurations.compile.allDependencies.each {
+        project.configurations.compileClasspath.allDependencies.each {
             dependency ->
                 if (dependency.group.equals("javax") && dependency.name.equals("javaee-api")) {
                     if (dependency.version.startsWith("8.")) {
@@ -298,7 +298,7 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
 
     private getMPVersion(Object project) {
         String mpVersion = null
-        project.configurations.compile.allDependencies.each {
+        project.configurations.compileClasspath.allDependencies.each {
             if (it.group.equals("org.eclipse.microprofile") &&
                     it.name.equals("microprofile")) {
                 if (it.version.startsWith("1")) {


### PR DESCRIPTION
Fixes the following error when running `generateFeatures` or `installFeature` with Gradle 7:
```
FAILURE: Build failed with an exception.

* What went wrong:
A problem was found with the configuration of task ':installFeature' (type 'InstallFeatureTask').
  - In plugin 'liberty' type 'io.openliberty.tools.gradle.tasks.InstallFeatureTask' property 'serverFeatureUtil' is missing an input or output annotation.
    
    Reason: A property without annotation isn't considered during up-to-date checking.
    
    Possible solutions:
      1. Add an input or output annotation.
      2. Mark it as @Internal.
    
    Please refer to https://docs.gradle.org/7.3.1/userguide/validation_problems.html#missing_annotation for more details about this problem.

```

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>