### PR TITLE
Move binary scanner maven artifact constants to ci.common

### DIFF
--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
@@ -40,11 +40,6 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
     protected static final String GENERATED_FEATURES_COMMENT = "The following features were generated based on API usage detected in your application";
     protected static final String NO_NEW_FEATURES_COMMENT = "No additional features generated";
 
-    private static final String BINARY_SCANNER_MAVEN_GROUP_ID = "com.ibm.websphere.appmod.tools";
-    private static final String BINARY_SCANNER_MAVEN_ARTIFACT_ID = "binary-app-scanner";
-    private static final String BINARY_SCANNER_MAVEN_TYPE = "jar";
-    private static final String BINARY_SCANNER_MAVEN_VERSION = "[21.0.0.4-SNAPSHOT,)";
-
     private static final boolean DEFAULT_OPTIMIZE = true;
 
     private File binaryScanner;

--- a/src/test/resources/dev-test/basic-dev-project/build.gradle
+++ b/src/test/resources/dev-test/basic-dev-project/build.gradle
@@ -12,9 +12,9 @@ buildscript {
     repositories {
         mavenLocal()
         mavenCentral()
-        // sonatype repo for getting the latest binary scanner jar snapshot
+        // Sonatype repo for getting the latest binary scanner jar snapshot
         maven {
-            url "https://oss.sonatype.org/content/repositories"
+            url 'https://oss.sonatype.org/content/repositories/snapshots/'
         }
     }
     dependencies {

--- a/src/test/resources/generate-features-test/basic-dev-project/build.gradle
+++ b/src/test/resources/generate-features-test/basic-dev-project/build.gradle
@@ -12,9 +12,9 @@ buildscript {
     repositories {
         mavenLocal()
         mavenCentral()
-        // sonatype repo for getting the latest binary scanner jar snapshot
+        // Sonatype repo for getting the latest binary scanner jar snapshot
         maven {
-            url "https://oss.sonatype.org/content/repositories"
+            url 'https://oss.sonatype.org/content/repositories/snapshots/'
         }
     }
     dependencies {


### PR DESCRIPTION
See https://github.com/OpenLiberty/ci.common/pull/343

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>