### PR TITLE
Enable Windows testing with GitHub Actions + Log Artifacts

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -10,15 +10,37 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  cache:
+    name: Cache Maven and Gradle packages
     runs-on: ${{ matrix.os }}
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, windows-latest]
+    steps:
+    - name: Cache Maven packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+    - name: Cache Gradle packages
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+          ${{ runner.os }}-
+  build-windows:
+    runs-on: windows-latest
+    name: ${{ matrix.RUNTIME }} ${{ matrix.RUNTIME_VERSION }}, Java ${{ matrix.java }}, Windows
+    needs: cache
     strategy:
       fail-fast: false
       matrix:
         # test against latest update of each major Java version, as well as specific updates of LTS versions:
-        os: [ubuntu-18.04, windows-latest]
         RUNTIME: [ol, wlp]
         RUNTIME_VERSION: [21.0.0.3, 20.0.0.12]
         java: [11, 8]
@@ -27,9 +49,56 @@ jobs:
           RUNTIME_VERSION: 20.0.0.12
         - java: 8
           RUNTIME: wlp
-          os: windows-latest
-
-    name: ${{ matrix.RUNTIME }} ${{ matrix.RUNTIME_VERSION }}, Java ${{ matrix.java }}, ${{ matrix.os }}
+    steps:
+    - name: Setup Java ${{ matrix.java }}
+      uses: joschi/setup-jdk@v2
+      with:
+        java-version: ${{ matrix.java }}
+    - name: Checkout ci.gradle
+      uses: actions/checkout@v2
+    - name: Clone ci.ant, ci.common, ci.gradle repos to C drive
+      run: |
+        cp -r D:/a/ci.gradle/ci.gradle C:/ci.gradle
+        git clone https://github.com/OpenLiberty/ci.common/ C:/ci.common
+        git clone https://github.com/OpenLiberty/ci.ant C:/ci.ant
+    - name: Install ci.ant and ci.common
+      run: |
+        cd C:/ci.ant
+        mvn clean install
+        cd C:/ci.common
+        mvn clean install
+    - name: Run tests with Gradle on Windows
+      working-directory: C:/ci.gradle
+      # LibertyTest is excluded because test0_run hangs
+      run: ./gradlew clean install check -P"test.exclude"="**/*15*,**/Polling*,**/TestLoose*,**/LibertyTest*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" ${GRADLE_OPTS} --stacktrace --info --no-daemon
+      timeout-minutes: 60
+      env:
+        GRADLE_OPTS: "-Dorg.gradle.jvmargs='-XX:MaxMetaspaceSize=512m'"
+    - name: Copy build/report/tests/test for upload
+      if: ${{ always() }}
+      working-directory: C:/ci.gradle
+      run: cp -r build/reports/tests/test D:/buildReports/${{runner.os}}/java${{matrix.java}}/${{matrix.RUNTIME}}-${{matrix.RUNTIME_VERSION}}/      
+    - uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: buildReportsArtifact
+        path: D:/buildReports
+        retention-days: 3
+  build-unix:
+    runs-on: ubuntu-18.04
+    name: ${{ matrix.RUNTIME }} ${{ matrix.RUNTIME_VERSION }}, Java ${{ matrix.java }}, Linux
+    needs: cache
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    strategy:
+      fail-fast: false
+      matrix:
+        # test against latest update of each major Java version, as well as specific updates of LTS versions:
+        RUNTIME: [ol, wlp]
+        RUNTIME_VERSION: [21.0.0.3, 20.0.0.12]
+        java: [11, 8]
+        exclude:
+        - java: 8
+          RUNTIME_VERSION: 20.0.0.12
     steps:
     - name: Setup Java ${{ matrix.java }}
       uses: joschi/setup-jdk@v2
@@ -47,22 +116,6 @@ jobs:
       with:
         repository: OpenLiberty/ci.ant
         path: ci.ant
-    - name: Cache maven packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
-    - name: Cache Gradle packages
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-
-          ${{ runner.os }}-
     - name: Install ci.ant and ci.common
       run: |
         cd ./ci.ant
@@ -74,15 +127,18 @@ jobs:
       run: |
         export GRADLE_OPTS="-Dorg.gradle.daemon=true -Dorg.gradle.jvmargs='-XX:MaxPermSize=1024m -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:+HeapDumpOnOutOfMemoryError -Xmx2048m'"
         ./gradlew clean install check -P"test.exclude"="**/*15*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --no-daemon
-      if: matrix.os=='ubuntu-18.04'
     - name: Run SpringBoot tests with Gradle 4.10 wrapper on Ubuntu
       run: |
         ./gradlew wrapper --gradle-version 4.10
         ./gradlew check -P"test.include"="**/*15*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --no-daemon
-      if: matrix.os=='ubuntu-18.04'
-    - name: Run tests with Gradle on Windows
-      timeout-minutes: 60
-      run: ./gradlew clean install check -P"test.exclude"="**/*15*,**/Polling*,**/TestLoose*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" ${GRADLE_OPTS} --stacktrace --info --no-daemon
+    - name: Copy build/report/tests/test for upload
+      if: ${{ always() }}
+      run: mkdir -p ${BUILD_REPORTS_PATH} && cp -r build/reports/tests/test ${BUILD_REPORTS_PATH}
       env:
-        GRADLE_OPTS: "-Dorg.gradle.jvmargs='-XX:MaxMetaspaceSize=512m'"
-      if: matrix.os=='windows-latest'
+        BUILD_REPORTS_PATH: ~/buildReports/${{runner.os}}/java${{matrix.java}}/${{matrix.RUNTIME}}-${{matrix.RUNTIME_VERSION}}/
+    - uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: buildReportsArtifact
+        path: ~/buildReports
+        retention-days: 3

--- a/src/main/groovy/io/openliberty/tools/gradle/Liberty.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/Liberty.groovy
@@ -188,7 +188,7 @@ class Liberty implements Plugin<Project> {
         if (installDir.toString().endsWith("wlp")) {
             return installDir
         } else { // not valid wlp dir
-            project.getLogger().warn(MessageFormat.format("The installDir {0} path does not reference a wlp folder. Using path {0}/wlp instead.", installDir))
+            project.getLogger().warn(MessageFormat.format("The installDir {0} path does not reference a wlp folder. Using path {0}{1}wlp instead.", installDir, File.separator))
             return new File(installDir, 'wlp')
         }
     }


### PR DESCRIPTION
Moved contents from D:/ drive to C:/ drive to avoid limited disk space issue while testing on Windows
Exclude LibertyTest from Windows testing due to noticed hanging issue during `run`. Test is run on Ubuntu
Corrected previous installDir property logging to now be consistent with OS

**Log Artifacts**:
Whenever a build fails GitHub actions will now upload a downloadable zip of the Gradle reports page, since reviewing the logs in the console isn't the most readable. 