### PR TITLE
Cache changes

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -10,24 +10,20 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
+# UNIX BUILDS
+  build-unix:
+    runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
       matrix:
         # test against latest update of each major Java version, as well as specific updates of LTS versions:
-        os: [ubuntu-18.04, windows-latest]
         RUNTIME: [ol, wlp]
         RUNTIME_VERSION: [21.0.0.3, 20.0.0.12]
         java: [11, 8]
         exclude:
         - java: 8
           RUNTIME_VERSION: 20.0.0.12
-        - java: 8
-          RUNTIME: wlp
-          os: windows-latest
-
-    name: ${{ matrix.RUNTIME }} ${{ matrix.RUNTIME_VERSION }}, Java ${{ matrix.java }}, ${{ matrix.os }}
+    name: ${{ matrix.RUNTIME }} ${{ matrix.RUNTIME_VERSION }}, Java ${{ matrix.java }}, Linux
     steps:
 # Checkout repos
     - name: Checkout ci.gradle
@@ -38,25 +34,16 @@ jobs:
         distribution: 'adopt'
         java-version: ${{ matrix.java }}
         cache: 'gradle'
-    - name: Checkout ci.common (Linux)
-      if: ${{ runner.os == 'Linux' }}
+    - name: Checkout ci.common
       uses: actions/checkout@v2
       with:
         repository: OpenLiberty/ci.common
         path: ci.common
-    - name: Checkout ci.ant (Linux)
-      if: ${{ runner.os == 'Linux' }}
+    - name: Checkout ci.ant
       uses: actions/checkout@v2
       with:
         repository: OpenLiberty/ci.ant
         path: ci.ant
-    # Moving and cloning to C: drive for Windows for more disk space
-    - name: Clone ci.ant, ci.common, ci.gradle repos to C drive (Windows)
-      if: ${{ runner.os == 'Windows' }}
-      run: |
-        cp -r D:/a/ci.gradle/ci.gradle C:/ci.gradle
-        git clone https://github.com/OpenLiberty/ci.common/ C:/ci.common
-        git clone https://github.com/OpenLiberty/ci.ant C:/ci.ant
 # Cache mvn/gradle packages
     - name: Cache Maven packages
       uses: actions/cache@v2
@@ -74,15 +61,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gradle-
 # Install dependencies
-    - name: Install ci.ant and ci.common (Windows)
-      if: ${{ runner.os == 'Windows' }}
-      run: |
-        cd C:/ci.ant
-        mvn clean install
-        cd C:/ci.common
-        mvn clean install
-    - name: Install ci.ant and ci.common (Linux)
-      if: ${{ runner.os == 'Linux' }}
+    - name: Install ci.ant and ci.common
       run: |
         cd ./ci.ant
         mvn clean install
@@ -91,15 +70,82 @@ jobs:
         cd ..
 # Run tests
     - name: Run tests with Gradle on Ubuntu
-      if: ${{ runner.os == 'Linux' }}
       run: |
         export GRADLE_OPTS="-Dorg.gradle.daemon=true -Dorg.gradle.jvmargs='-XX:MaxPermSize=1024m -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:+HeapDumpOnOutOfMemoryError -Xmx2048m'"
         ./gradlew clean install check -P"test.exclude"="**/*15*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --no-daemon
     - name: Run SpringBoot tests with Gradle 4.10 wrapper on Ubuntu
-      if: ${{ runner.os == 'Linux' }}
       run: |
         ./gradlew wrapper --gradle-version 4.10
         ./gradlew check -P"test.include"="**/*15*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --no-daemon
+# Copy build reports and upload artifact if build failed
+    - name: Copy build/report/tests/test for upload
+      if: ${{ failure() }}
+      run: mkdir -p ${BUILD_REPORTS_PATH} && cp -r build/reports/tests/test ${BUILD_REPORTS_PATH}
+      env:
+        BUILD_REPORTS_PATH: ~/buildReports/${{runner.os}}/java${{matrix.java}}/${{matrix.RUNTIME}}-${{matrix.RUNTIME_VERSION}}/
+    - uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: buildReportsArtifact
+        path: ~/buildReports
+        retention-days: 3
+
+# WINDOWS BUILDS
+  build-windows:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # test against latest update of each major Java version, as well as specific updates of LTS versions:
+        RUNTIME: [ol, wlp]
+        RUNTIME_VERSION: [21.0.0.3, 20.0.0.12]
+        java: [11, 8]
+        exclude:
+        - java: 8
+          RUNTIME_VERSION: 20.0.0.12
+        - java: 8
+          RUNTIME: wlp
+    name: ${{ matrix.RUNTIME }} ${{ matrix.RUNTIME_VERSION }}, Java ${{ matrix.java }}, Windows
+    steps:
+# Checkout repos
+    - name: Checkout ci.gradle
+      uses: actions/checkout@v2
+    - name: Setup Java ${{ matrix.java }}
+      uses: actions/setup-java@v2
+      with:
+        distribution: 'adopt'
+        java-version: ${{ matrix.java }}
+        cache: 'gradle'
+    # Moving and cloning to C: drive for Windows for more disk space
+    - name: Clone ci.ant, ci.common, ci.gradle repos to C drive
+      run: |
+        cp -r D:/a/ci.gradle/ci.gradle C:/ci.gradle
+        git clone https://github.com/OpenLiberty/ci.common.git C:/ci.common
+        git clone https://github.com/OpenLiberty/ci.ant.git C:/ci.ant
+# Cache mvn/gradle packages
+    - name: Cache Maven packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+    - name: Cache Gradle packages
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+# Install dependencies
+    - name: Install ci.ant and ci.common
+      run: |
+        cd C:/ci.ant
+        mvn clean install
+        cd C:/ci.common
+        mvn clean install
+# Run tests
     - name: Run tests with Gradle on Windows
       if: ${{ runner.os == 'Windows' }}
       working-directory: C:/ci.gradle
@@ -109,23 +155,12 @@ jobs:
       env:
         GRADLE_OPTS: "-Dorg.gradle.jvmargs='-XX:MaxMetaspaceSize=512m'"
 # Copy build reports and upload artifact if build failed
-    - name: Copy build/report/tests/test for upload (Linux)
-      if: ${{ runner.os == 'Linux' && failure() }}
-      run: mkdir -p ${BUILD_REPORTS_PATH} && cp -r build/reports/tests/test ${BUILD_REPORTS_PATH}
-      env:
-        BUILD_REPORTS_PATH: ~/buildReports/${{runner.os}}/java${{matrix.java}}/${{matrix.RUNTIME}}-${{matrix.RUNTIME_VERSION}}/
-    - uses: actions/upload-artifact@v2
-      if: ${{ runner.os == 'Linux' && failure() }}
-      with:
-        name: buildReportsArtifact
-        path: ~/buildReports
-        retention-days: 3
-    - name: Copy build/report/tests/test for upload (Windows)
-      if: ${{ runner.os == 'Windows' && failure() }}
+    - name: Copy build/report/tests/test for upload
+      if: ${{ failure() }}
       working-directory: C:/ci.gradle
       run: cp -r build/reports/tests/test D:/buildReports/${{runner.os}}/java${{matrix.java}}/${{matrix.RUNTIME}}-${{matrix.RUNTIME_VERSION}}/      
     - uses: actions/upload-artifact@v2
-      if: ${{ runner.os == 'Windows' && failure() }}
+      if: ${{ failure() }}
       with:
         name: buildReportsArtifact
         path: D:/buildReports

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -10,33 +10,9 @@ on:
     branches: [ main ]
 
 jobs:
-  cache:
-    name: Cache Maven and Gradle packages
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-18.04, windows-latest]
-    steps:
-    - name: Cache Maven packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
-    - name: Cache Gradle packages
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-
-          ${{ runner.os }}-
   build-windows:
     runs-on: windows-latest
     name: ${{ matrix.RUNTIME }} ${{ matrix.RUNTIME_VERSION }}, Java ${{ matrix.java }}, Windows
-    needs: cache
     strategy:
       fail-fast: false
       matrix:
@@ -50,17 +26,34 @@ jobs:
         - java: 8
           RUNTIME: wlp
     steps:
-    - name: Setup Java ${{ matrix.java }}
-      uses: joschi/setup-jdk@v2
-      with:
-        java-version: ${{ matrix.java }}
     - name: Checkout ci.gradle
       uses: actions/checkout@v2
+    - name: Setup Java ${{ matrix.java }}
+      uses: actions/setup-java@v2
+      with:
+        distribution: 'adopt'
+        java-version: ${{ matrix.java }}
+        cache: 'gradle'
     - name: Clone ci.ant, ci.common, ci.gradle repos to C drive
       run: |
         cp -r D:/a/ci.gradle/ci.gradle C:/ci.gradle
         git clone https://github.com/OpenLiberty/ci.common/ C:/ci.common
         git clone https://github.com/OpenLiberty/ci.ant C:/ci.ant
+    - name: Cache Maven packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+    - name: Cache Gradle packages
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
     - name: Install ci.ant and ci.common
       run: |
         cd C:/ci.ant
@@ -87,7 +80,6 @@ jobs:
   build-unix:
     runs-on: ubuntu-18.04
     name: ${{ matrix.RUNTIME }} ${{ matrix.RUNTIME_VERSION }}, Java ${{ matrix.java }}, Linux
-    needs: cache
     # Steps represent a sequence of tasks that will be executed as part of the job
     strategy:
       fail-fast: false
@@ -118,6 +110,21 @@ jobs:
       with:
         repository: OpenLiberty/ci.ant
         path: ci.ant
+    - name: Cache Maven packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+    - name: Cache Gradle packages
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
     - name: Install ci.ant and ci.common
       run: |
         cd ./ci.ant

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -10,13 +10,13 @@ on:
     branches: [ main ]
 
 jobs:
-  build-windows:
-    runs-on: windows-latest
-    name: ${{ matrix.RUNTIME }} ${{ matrix.RUNTIME_VERSION }}, Java ${{ matrix.java }}, Windows
+  build:
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         # test against latest update of each major Java version, as well as specific updates of LTS versions:
+        os: [ubuntu-18.04, windows-latest]
         RUNTIME: [ol, wlp]
         RUNTIME_VERSION: [21.0.0.3, 20.0.0.12]
         java: [11, 8]
@@ -25,6 +25,9 @@ jobs:
           RUNTIME_VERSION: 20.0.0.12
         - java: 8
           RUNTIME: wlp
+          os: windows-latest
+
+    name: ${{ matrix.RUNTIME }} ${{ matrix.RUNTIME_VERSION }}, Java ${{ matrix.java }}, ${{ matrix.os }}
     steps:
     - name: Checkout ci.gradle
       uses: actions/checkout@v2
@@ -34,7 +37,20 @@ jobs:
         distribution: 'adopt'
         java-version: ${{ matrix.java }}
         cache: 'gradle'
-    - name: Clone ci.ant, ci.common, ci.gradle repos to C drive
+    - name: Checkout ci.common (Linux)
+      if: ${{ runner.os == 'Linux' }}
+      uses: actions/checkout@v2
+      with:
+        repository: OpenLiberty/ci.common
+        path: ci.common
+    - name: Checkout ci.ant (Linux)
+      if: ${{ runner.os == 'Linux' }}
+      uses: actions/checkout@v2
+      with:
+        repository: OpenLiberty/ci.ant
+        path: ci.ant
+    - name: Clone ci.ant, ci.common, ci.gradle repos to C drive (Windows)
+      if: ${{ runner.os == 'Windows' }}
       run: |
         cp -r D:/a/ci.gradle/ci.gradle C:/ci.gradle
         git clone https://github.com/OpenLiberty/ci.common/ C:/ci.common
@@ -54,78 +70,15 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
         restore-keys: |
           ${{ runner.os }}-gradle-
-    - name: Install ci.ant and ci.common
+    - name: Install ci.ant and ci.common (Windows)
+      if: ${{ runner.os == 'Windows' }}
       run: |
         cd C:/ci.ant
         mvn clean install
         cd C:/ci.common
         mvn clean install
-    - name: Run tests with Gradle on Windows
-      working-directory: C:/ci.gradle
-      # LibertyTest is excluded because test0_run hangs
-      run: ./gradlew clean install check -P"test.exclude"="**/*15*,**/Polling*,**/TestLoose*,**/LibertyTest*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" ${GRADLE_OPTS} --stacktrace --info --no-daemon
-      timeout-minutes: 60
-      env:
-        GRADLE_OPTS: "-Dorg.gradle.jvmargs='-XX:MaxMetaspaceSize=512m'"
-    - name: Copy build/report/tests/test for upload
-      if: ${{ always() }}
-      working-directory: C:/ci.gradle
-      run: cp -r build/reports/tests/test D:/buildReports/${{runner.os}}/java${{matrix.java}}/${{matrix.RUNTIME}}-${{matrix.RUNTIME_VERSION}}/      
-    - uses: actions/upload-artifact@v2
-      if: ${{ failure() }}
-      with:
-        name: buildReportsArtifact
-        path: D:/buildReports
-        retention-days: 3
-  build-unix:
-    runs-on: ubuntu-18.04
-    name: ${{ matrix.RUNTIME }} ${{ matrix.RUNTIME_VERSION }}, Java ${{ matrix.java }}, Linux
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    strategy:
-      fail-fast: false
-      matrix:
-        # test against latest update of each major Java version, as well as specific updates of LTS versions:
-        RUNTIME: [ol, wlp]
-        RUNTIME_VERSION: [21.0.0.3, 20.0.0.12]
-        java: [11, 8]
-        exclude:
-        - java: 8
-          RUNTIME_VERSION: 20.0.0.12
-    steps:
-    - name: Checkout ci.gradle
-      uses: actions/checkout@v2
-    - name: Setup Java ${{ matrix.java }}
-      uses: actions/setup-java@v2
-      with:
-        distribution: 'adopt'
-        java-version: ${{ matrix.java }}
-        cache: 'gradle'
-    - name: Checkout ci.common
-      uses: actions/checkout@v2
-      with:
-        repository: OpenLiberty/ci.common
-        path: ci.common
-    - name: Checkout ci.ant
-      uses: actions/checkout@v2
-      with:
-        repository: OpenLiberty/ci.ant
-        path: ci.ant
-    - name: Cache Maven packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
-    - name: Cache Gradle packages
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-
-    - name: Install ci.ant and ci.common
+    - name: Install ci.ant and ci.common (Linux)
+      if: ${{ runner.os == 'Linux' }}
       run: |
         cd ./ci.ant
         mvn clean install
@@ -133,21 +86,41 @@ jobs:
         mvn clean install
         cd ..
     - name: Run tests with Gradle on Ubuntu
+      if: ${{ runner.os == 'Linux' }}
       run: |
         export GRADLE_OPTS="-Dorg.gradle.daemon=true -Dorg.gradle.jvmargs='-XX:MaxPermSize=1024m -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:+HeapDumpOnOutOfMemoryError -Xmx2048m'"
         ./gradlew clean install check -P"test.exclude"="**/*15*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --no-daemon
     - name: Run SpringBoot tests with Gradle 4.10 wrapper on Ubuntu
+      if: ${{ runner.os == 'Linux' }}
       run: |
         ./gradlew wrapper --gradle-version 4.10
         ./gradlew check -P"test.include"="**/*15*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --no-daemon
-    - name: Copy build/report/tests/test for upload
-      if: ${{ always() }}
+    - name: Run tests with Gradle on Windows
+      if: ${{ runner.os == 'Windows' }}
+      working-directory: C:/ci.gradle
+      # LibertyTest is excluded because test0_run hangs
+      run: ./gradlew clean install check -P"test.exclude"="**/*15*,**/Polling*,**/TestLoose*,**/LibertyTest*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" ${GRADLE_OPTS} --stacktrace --info --no-daemon
+      timeout-minutes: 60
+      env:
+        GRADLE_OPTS: "-Dorg.gradle.jvmargs='-XX:MaxMetaspaceSize=512m'"
+    - name: Copy build/report/tests/test for upload (Linux)
+      if: ${{ runner.os == 'Linux' && always() }}
       run: mkdir -p ${BUILD_REPORTS_PATH} && cp -r build/reports/tests/test ${BUILD_REPORTS_PATH}
       env:
         BUILD_REPORTS_PATH: ~/buildReports/${{runner.os}}/java${{matrix.java}}/${{matrix.RUNTIME}}-${{matrix.RUNTIME_VERSION}}/
     - uses: actions/upload-artifact@v2
-      if: ${{ failure() }}
+      if: ${{ runner.os == 'Linux' && failure() }}
       with:
         name: buildReportsArtifact
         path: ~/buildReports
+        retention-days: 3
+    - name: Copy build/report/tests/test for upload (Windows)
+      if: ${{ runner.os == 'Windows' && always() }}
+      working-directory: C:/ci.gradle
+      run: cp -r build/reports/tests/test D:/buildReports/${{runner.os}}/java${{matrix.java}}/${{matrix.RUNTIME}}-${{matrix.RUNTIME_VERSION}}/      
+    - uses: actions/upload-artifact@v2
+      if: ${{ runner.os == 'Windows' && failure() }}
+      with:
+        name: buildReportsArtifact
+        path: D:/buildReports
         retention-days: 3

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -147,7 +147,6 @@ jobs:
         mvn clean install
 # Run tests
     - name: Run tests with Gradle on Windows
-      if: ${{ runner.os == 'Windows' }}
       working-directory: C:/ci.gradle
       # LibertyTest is excluded because test0_run hangs
       run: ./gradlew clean install check -P"test.exclude"="**/*15*,**/Polling*,**/TestLoose*,**/LibertyTest*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" ${GRADLE_OPTS} --stacktrace --info --no-daemon

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -100,12 +100,14 @@ jobs:
         - java: 8
           RUNTIME_VERSION: 20.0.0.12
     steps:
-    - name: Setup Java ${{ matrix.java }}
-      uses: joschi/setup-jdk@v2
-      with:
-        java-version: ${{ matrix.java }}
     - name: Checkout ci.gradle
       uses: actions/checkout@v2
+    - name: Setup Java ${{ matrix.java }}
+      uses: actions/setup-java@v2
+      with:
+        distribution: 'adopt'
+        java-version: ${{ matrix.java }}
+        cache: 'gradle'
     - name: Checkout ci.common
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -29,6 +29,7 @@ jobs:
 
     name: ${{ matrix.RUNTIME }} ${{ matrix.RUNTIME_VERSION }}, Java ${{ matrix.java }}, ${{ matrix.os }}
     steps:
+# Checkout repos
     - name: Checkout ci.gradle
       uses: actions/checkout@v2
     - name: Setup Java ${{ matrix.java }}
@@ -49,12 +50,14 @@ jobs:
       with:
         repository: OpenLiberty/ci.ant
         path: ci.ant
+    # Moving and cloning to C: drive for Windows for more disk space
     - name: Clone ci.ant, ci.common, ci.gradle repos to C drive (Windows)
       if: ${{ runner.os == 'Windows' }}
       run: |
         cp -r D:/a/ci.gradle/ci.gradle C:/ci.gradle
         git clone https://github.com/OpenLiberty/ci.common/ C:/ci.common
         git clone https://github.com/OpenLiberty/ci.ant C:/ci.ant
+# Cache mvn/gradle packages
     - name: Cache Maven packages
       uses: actions/cache@v2
       with:
@@ -70,6 +73,7 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
         restore-keys: |
           ${{ runner.os }}-gradle-
+# Install dependencies
     - name: Install ci.ant and ci.common (Windows)
       if: ${{ runner.os == 'Windows' }}
       run: |
@@ -85,6 +89,7 @@ jobs:
         cd ../ci.common
         mvn clean install
         cd ..
+# Run tests
     - name: Run tests with Gradle on Ubuntu
       if: ${{ runner.os == 'Linux' }}
       run: |
@@ -103,6 +108,7 @@ jobs:
       timeout-minutes: 60
       env:
         GRADLE_OPTS: "-Dorg.gradle.jvmargs='-XX:MaxMetaspaceSize=512m'"
+# Copy build reports and upload artifact if build failed
     - name: Copy build/report/tests/test for upload (Linux)
       if: ${{ runner.os == 'Linux' && always() }}
       run: mkdir -p ${BUILD_REPORTS_PATH} && cp -r build/reports/tests/test ${BUILD_REPORTS_PATH}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -110,7 +110,7 @@ jobs:
         GRADLE_OPTS: "-Dorg.gradle.jvmargs='-XX:MaxMetaspaceSize=512m'"
 # Copy build reports and upload artifact if build failed
     - name: Copy build/report/tests/test for upload (Linux)
-      if: ${{ runner.os == 'Linux' && always() }}
+      if: ${{ runner.os == 'Linux' && failure() }}
       run: mkdir -p ${BUILD_REPORTS_PATH} && cp -r build/reports/tests/test ${BUILD_REPORTS_PATH}
       env:
         BUILD_REPORTS_PATH: ~/buildReports/${{runner.os}}/java${{matrix.java}}/${{matrix.RUNTIME}}-${{matrix.RUNTIME_VERSION}}/
@@ -121,7 +121,7 @@ jobs:
         path: ~/buildReports
         retention-days: 3
     - name: Copy build/report/tests/test for upload (Windows)
-      if: ${{ runner.os == 'Windows' && always() }}
+      if: ${{ runner.os == 'Windows' && failure() }}
       working-directory: C:/ci.gradle
       run: cp -r build/reports/tests/test D:/buildReports/${{runner.os}}/java${{matrix.java}}/${{matrix.RUNTIME}}-${{matrix.RUNTIME_VERSION}}/      
     - uses: actions/upload-artifact@v2


### PR DESCRIPTION
- Move caching steps back into the builds
- Switch back to official actions/setup-java now that it has the jdk we use
- Change the copy build reports step to only run if build failed (have not been able to test with a build failure yet)

To make the yaml file slightly easier to maintain, I consolidated the Windows/Unix builds back into one, with OS qualifiers on the OS-specific steps. This way, each step of the build, regardless of OS, is grouped together.

However, it's not as nicely separated on the Actions UI now.

With the recent change to separate Unix/Windows builds: 
![image](https://user-images.githubusercontent.com/689163/151391424-d2e02cc5-3c51-43ea-8d19-21241dd7971b.png)

Back to single consolidated build (which we've used all this time before):
![image](https://user-images.githubusercontent.com/689163/151391519-8667b1c0-e676-440c-b3a2-da3da9ce2736.png)

With the consolidation, the steps during the build looks messier, as it shows the skipped steps that are meant for the other OS:
![image](https://user-images.githubusercontent.com/689163/151392835-60a7746c-f563-4331-8a2c-bf5d03a061be.png)

Any opinions on the consolidated vs separate OS builds?