### PR TITLE
Do not pass custom features to binary scanner

### DIFF
--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
@@ -104,6 +104,11 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
 
         Set<String> existingFeatures = getServerFeatures(servUtil, generatedFiles, optimize);
         logger.debug("Existing features:" + existingFeatures);
+        Set<String> nonCustomFeatures = new HashSet<String>(); // binary scanner only handles actual Liberty features
+        for (String feature : existingFeatures) { // custom features are "usr:feature-1.0" or "myExt:feature-2.0"
+            if (!feature.contains(":")) nonCustomFeatures.add(feature);
+        }
+        logger.debug("Non-custom features:" + nonCustomFeatures);
 
         Set<String> scannedFeatureList;
         try {
@@ -114,7 +119,7 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
             }
             String eeVersion = getEEVersion(project);
             String mpVersion = getMPVersion(project);
-            scannedFeatureList = binaryScannerHandler.runBinaryScanner(existingFeatures, classFiles, directories, eeVersion, mpVersion, optimize);
+            scannedFeatureList = binaryScannerHandler.runBinaryScanner(nonCustomFeatures, classFiles, directories, eeVersion, mpVersion, optimize);
         } catch (BinaryScannerUtil.NoRecommendationException noRecommendation) {
             throw new GradleException(String.format(BinaryScannerUtil.BINARY_SCANNER_CONFLICT_MESSAGE3, noRecommendation.getConflicts()));
         } catch (BinaryScannerUtil.FeatureModifiedException featuresModified) {

--- a/src/test/resources/generate-features-test/basic-dev-project/src/main/liberty/config/server.xml
+++ b/src/test/resources/generate-features-test/basic-dev-project/src/main/liberty/config/server.xml
@@ -1,4 +1,5 @@
 <server description="Sample Liberty server">
+  <!--replaceable-->
   <httpEndpoint host="*" httpPort="${default.http.port}"
     httpsPort="${default.https.port}" id="defaultHttpEndpoint"/>
 </server>


### PR DESCRIPTION
Other code in LGP uses ":" to detect custom features: https://github.com/OpenLiberty/ci.common/blob/70db23360b84405b0ad48cab752d495d9cd3a99b/src/main/java/io/openliberty/tools/common/plugins/util/ServerFeatureUtil.java#L345-L372