### PR TITLE
Gen feat build file fix

### DIFF
--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
@@ -566,20 +566,19 @@ class DevTask extends AbstractFeatureTask {
                 return true;
             } else if (installFeatures) {
                 if (generateFeatures) {
-                    // TODO confirm a call to generate features is required when a build file's compilation dependencies are modified
-                    // Increment generate features on build dependency change
+                    // TODO: if we generate features here we will also need to skip installing features on a failure
                     ProjectConnection gradleConnection = initGradleProjectConnection();
                     BuildLauncher gradleBuildLauncher = gradleConnection.newBuild();
                     runGradleTask(gradleBuildLauncher, 'compileJava', 'processResources'); // ensure class files exist
 
-                    // only call generateFeatures if classes
+                    // optimize generate features on build dependency change
                     Collection<String> javaSourceClassPaths = getJavaSourceClassPaths();
-                    if (!javaSourceClassPaths.isEmpty()) {
-                        if (libertyGenerateFeatures(javaSourceClassPaths, false)) {
-                            util.javaSourceClassPaths.clear();
-                        };
-                        libertyCreate(); // need to run create in order to copy generated config file to target
-                    }
+                    boolean generateFeaturesSuccess = libertyGenerateFeatures(javaSourceClassPaths, true);
+                    if (generateFeaturesSuccess) {
+                        util.javaSourceClassPaths.clear();
+                    };
+                    libertyCreate(); // need to run create in order to copy generated config file to target
+
                 }
                 libertyInstallFeature();
             }

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
@@ -566,13 +566,20 @@ class DevTask extends AbstractFeatureTask {
                 return true;
             } else if (installFeatures) {
                 if (generateFeatures) {
+                    // TODO confirm a call to generate features is required when a build file's compilation dependencies are modified
                     // Increment generate features on build dependency change
                     ProjectConnection gradleConnection = initGradleProjectConnection();
                     BuildLauncher gradleBuildLauncher = gradleConnection.newBuild();
                     runGradleTask(gradleBuildLauncher, 'compileJava', 'processResources'); // ensure class files exist
+
+                    // only call generateFeatures if classes
                     Collection<String> javaSourceClassPaths = getJavaSourceClassPaths();
-                    libertyGenerateFeatures(javaSourceClassPaths, false);
-                    libertyCreate(); // need to run create in order to copy generated config file to target
+                    if (!javaSourceClassPaths.isEmpty()) {
+                        if (libertyGenerateFeatures(javaSourceClassPaths, false)) {
+                            util.javaSourceClassPaths.clear();
+                        };
+                        libertyCreate(); // need to run create in order to copy generated config file to target
+                    }
                 }
                 libertyInstallFeature();
             }

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
@@ -580,13 +580,11 @@ class DevTask extends AbstractFeatureTask {
                 // - start server
                 util.restartServer();
                 return true;
-            } else if ((installFeatures || compileDependenciesChanged) && generateFeatures) { // generate features if compile dependencies have been modified
+            } else if (compileDependenciesChanged && generateFeatures) { // generate features if compile dependencies have been modified
                 // optimize generate features on build dependency change
                 boolean generateFeaturesSuccess = libertyGenerateFeatures(null, true);
                 if (generateFeaturesSuccess) {
                     util.javaSourceClassPaths.clear();
-                    libertyCreate(); // need to run create in order to copy generated config file to target
-                    libertyInstallFeature(); // install newly generated features
                 };
             } else if (installFeatures) {
                 libertyInstallFeature();

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
@@ -538,7 +538,7 @@ class DevTask extends AbstractFeatureTask {
                 List<String> newFeatureNames = newProject.liberty.server.features.name;
 
                 if (oldFeatureNames != newFeatureNames) {
-                    logger.warn('Server feature changed');
+                    logger.debug('Server feature changed');
                     installFeatures = true;
                     project.liberty.server.features.name = newFeatureNames;
                 }


### PR DESCRIPTION
When a build file dependency change is detected, add an additional check to only call generateFeatures if there are class files to generate for.

Also include a minor improvement to the clean up logic in the dev integration tests. 

See https://github.com/OpenLiberty/ci.maven/pull/1409