### PR TITLE
Fix configDirectory up to date check

### DIFF
--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/CreateTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/CreateTask.groovy
@@ -39,10 +39,11 @@ class CreateTask extends AbstractServerTask {
 
     @InputDirectory @Optional
     File getConfigDir() {
+        File defaultConfigDir = new File(DEFAULT_PATH)
         if(server.configDirectory != null && server.configDirectory.exists()) {
             return server.configDirectory
-        } else {
-            return new File(project.projectDir, "src/main/liberty/config")
+        } else if (defaultConfigDir.exists()) {
+            return defaultConfigDir
         }
     }
 

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/CreateTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/CreateTask.groovy
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2014, 2020.
+ * (C) Copyright IBM Corporation 2014, 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,8 @@ class CreateTask extends AbstractServerTask {
     File getConfigDir() {
         if(server.configDirectory != null && server.configDirectory.exists()) {
             return server.configDirectory
+        } else {
+            return new File(project.projectDir, "src/main/liberty/config")
         }
     }
 

--- a/src/test/groovy/io/openliberty/tools/gradle/AbstractIntegrationTest.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/AbstractIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corporation 2015, 2018.
+ * (C) Copyright IBM Corporation 2015, 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -119,6 +119,23 @@ abstract class AbstractIntegrationTest {
                 assert SUCCESS == result.task(":$it").getOutcome()
             }
         }
+    }
+
+    protected static BuildResult runTasksResult(File projectDir, String... tasks) {
+        List<String> args = new ArrayList<String>()
+        tasks.each {
+            args.add(it)
+        }
+        args.add("-i")
+        args.add("-s")
+
+        BuildResult result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .forwardOutput()
+            .withArguments(args)
+            .build()
+
+        return result
     }
 
     protected static boolean runTaskCheckForUpToDate(File projectDir, String task, String argument) {

--- a/src/test/groovy/io/openliberty/tools/gradle/TestCreateConfigDirUpToDate.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/TestCreateConfigDirUpToDate.groovy
@@ -10,6 +10,8 @@ import org.gradle.testkit.runner.BuildResult
 import org.junit.BeforeClass
 import org.junit.Test
 
+import io.openliberty.tools.common.plugins.util.OSUtil
+
 public class TestCreateConfigDirUpToDate extends AbstractIntegrationTest {
     static File sourceDir = new File("build/resources/test/server-config")
     static File testBuildDir = new File(integTestDir, "/test-create-config-dir-up-to-date")
@@ -48,7 +50,13 @@ public class TestCreateConfigDirUpToDate extends AbstractIntegrationTest {
         String configDirMessageString = "Input property 'configDir' file"
         String testFileMessageString = "/build/testBuilds/test-create-config-dir-up-to-date/src/main/liberty/config/test.txt has changed."
 
-        assert result.getOutput().contains(configDirMessageString) && result.getOutput().contains(testFileMessageString)
+        if (OSUtil.isWindows()) {
+            configDirMessageString = "Input property \'configDir\' file"
+            testFileMessageString = "\\build\\testBuilds\\test-create-config-dir-up-to-date\\src\\main\\liberty\\config\\test.txt has changed."
+        } 
+
+        assert result.getOutput().contains(configDirMessageString)
+        assert result.getOutput().contains(testFileMessageString)
 
         //Check updated file was copied to server directory
         assert serverTestTextFile.text.contains('Test Comment 2')

--- a/src/test/groovy/io/openliberty/tools/gradle/TestCreateConfigDirUpToDate.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/TestCreateConfigDirUpToDate.groovy
@@ -1,0 +1,56 @@
+package io.openliberty.tools.gradle
+
+import static org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE
+import static org.junit.Assert.assertFalse
+
+import java.io.File
+
+import org.gradle.testkit.runner.BuildResult
+
+import org.junit.BeforeClass
+import org.junit.Test
+
+public class TestCreateConfigDirUpToDate extends AbstractIntegrationTest {
+    static File sourceDir = new File("build/resources/test/server-config")
+    static File testBuildDir = new File(integTestDir, "/test-create-config-dir-up-to-date")
+    static String buildFilename = "testCreateUpToDate.gradle"
+
+    @BeforeClass
+    public static void setup() {
+        createDir(testBuildDir)
+        createTestProject(testBuildDir, sourceDir, buildFilename, true)
+    }
+
+    @Test
+    public void test_create_with_default_configDir() {
+        //Update contents of file in config directory to test up to date check of libertyCreate
+        //Using additional file since Liberty config files are task inputs
+        def testTextFile = new File("build/testBuilds/test-create-config-dir-up-to-date/src/main/liberty/config/test.txt")
+        testTextFile.createNewFile()
+        testTextFile.append('Test Comment')
+
+        runTasks(testBuildDir, 'libertyCreate')
+
+        //Check config directory test file was copied to server directory
+        def serverTestTextFile = new File("build/testBuilds/test-create-config-dir-up-to-date/build/wlp/usr/servers/defaultServer/test.txt")
+
+        assert serverTestTextFile.exists() : "file not found"
+
+        //Update config directory test file content
+        testTextFile.append('/nTest Comment 2')
+
+        //Rebuild and check libertyCreate is not up to date
+        BuildResult result = runTasksResult(testBuildDir, 'libertyCreate')
+
+        assertFalse UP_TO_DATE == result.task(":libertyCreate").getOutcome()
+
+        //Log should show: Input property 'configDir' file <some path>/build/testBuilds/test-create-config-dir-up-to-date/src/main/liberty/config/test.txt has changed.
+        String configDirMessageString = "Input property 'configDir' file"
+        String testFileMessageString = "/build/testBuilds/test-create-config-dir-up-to-date/src/main/liberty/config/test.txt has changed."
+
+        assert result.getOutput().contains(configDirMessageString) && result.getOutput().contains(testFileMessageString)
+
+        //Check updated file was copied to server directory
+        assert serverTestTextFile.text.contains('Test Comment 2')
+    }
+}

--- a/src/test/resources/server-config/testCreateUpToDate.gradle
+++ b/src/test/resources/server-config/testCreateUpToDate.gradle
@@ -1,0 +1,32 @@
+group = 'liberty.gradle'
+version = '1'
+
+buildscript {
+    repositories {
+        mavenCentral()
+		mavenLocal()
+        maven {
+            name = 'Sonatype Nexus Snapshots'
+            url = 'https://oss.sonatype.org/content/repositories/snapshots/'
+        }
+    }
+    dependencies {
+        classpath "io.openliberty.tools:liberty-gradle-plugin:$lgpVersion"
+    }
+}
+
+apply plugin: 'liberty'
+
+repositories {
+    mavenCentral()
+    maven {
+        name 'liberty-starter-maven-repo'
+        url 'https://liberty-starter.wasdev.developer.ibm.com/start/api/v1/repo'
+    }
+}
+
+dependencies {
+    libertyRuntime group: runtimeGroup, name: kernelArtifactId, version: runtimeVersion
+}
+
+installFeature.enabled = false //No need to run during config file tests


### PR DESCRIPTION
Will use default `configDirectory` value if `null` during `libertyCreate` up to date check.

Fixes #686 