### PR TITLE
Change visibility for  MP and EE version methods to protected

### DIFF
--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
@@ -337,18 +337,19 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
     protected getMPVersion(Object project) {
         String mpVersion = null
         project.configurations.compileClasspath.allDependencies.each {
-            if (it.group.equals("org.eclipse.microprofile") &&
-                    it.name.equals("microprofile")) {
-                if (it.version.startsWith("1") && (isLatestVersion(mpVersion, BINARY_SCANNER_MPV1, "mp"))) {
-                    mpVersion = BINARY_SCANNER_MPV1
-                } else if (it.version.startsWith("2") && (isLatestVersion(mpVersion, BINARY_SCANNER_MPV2, "mp"))) {
-                    mpVersion = BINARY_SCANNER_MPV2
-                } else if (it.version.startsWith("3") && (isLatestVersion(mpVersion, BINARY_SCANNER_MPV3, "mp"))) {
-                    mpVersion = BINARY_SCANNER_MPV3
-                } else if (it.version.startsWith("4") && (isLatestVersion(mpVersion, BINARY_SCANNER_MPV4, "mp"))) {
-                    mpVersion = BINARY_SCANNER_MPV4
+            dependency ->
+                if (dependency.group.equals("org.eclipse.microprofile") &&
+                        dependency.name.equals("microprofile")) {
+                    if (dependency.version.startsWith("1") && (isLatestVersion(mpVersion, BINARY_SCANNER_MPV1, "mp"))) {
+                        mpVersion = BINARY_SCANNER_MPV1
+                    } else if (dependency.version.startsWith("2") && (isLatestVersion(mpVersion, BINARY_SCANNER_MPV2, "mp"))) {
+                        mpVersion = BINARY_SCANNER_MPV2
+                    } else if (dependency.version.startsWith("3") && (isLatestVersion(mpVersion, BINARY_SCANNER_MPV3, "mp"))) {
+                        mpVersion = BINARY_SCANNER_MPV3
+                    } else if (dependency.version.startsWith("4") && (isLatestVersion(mpVersion, BINARY_SCANNER_MPV4, "mp"))) {
+                        mpVersion = BINARY_SCANNER_MPV4
+                    }
                 }
-            }
         }
         return mpVersion;
     }

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
@@ -312,7 +312,7 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
         project.configurations.compileClasspath.allDependencies.each {
             dependency ->
                 if (dependency.group.equals("javax") && dependency.name.equals("javaee-api")) {
-                    if (dependency.version.startsWith("8.") && (isLatestVersion(eeVersion, BINARY_SCANNER_EEV8, "ee"))) {
+                    if (dependency.version.startsWith("8.")) {
                         eeVersion = BINARY_SCANNER_EEV8
                     } else if (dependency.version.startsWith("7.") && (isLatestVersion(eeVersion, BINARY_SCANNER_EEV7, "ee"))) {
                         eeVersion = BINARY_SCANNER_EEV7
@@ -321,7 +321,7 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
                     }
                 } else if (dependency.group.equals("jakarta.platform") &&
                         dependency.name.equals("jakarta.jakartaee-api") &&
-                        dependency.version.startsWith("8.") && (isLatestVersion(eeVersion, BINARY_SCANNER_EEV8, "ee"))) {
+                        dependency.version.startsWith("8.")) {
                     eeVersion = BINARY_SCANNER_EEV8
                 }
         }
@@ -346,7 +346,7 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
                         mpVersion = BINARY_SCANNER_MPV2
                     } else if (dependency.version.startsWith("3") && (isLatestVersion(mpVersion, BINARY_SCANNER_MPV3, "mp"))) {
                         mpVersion = BINARY_SCANNER_MPV3
-                    } else if (dependency.version.startsWith("4") && (isLatestVersion(mpVersion, BINARY_SCANNER_MPV4, "mp"))) {
+                    } else if (dependency.version.startsWith("4")) {
                         mpVersion = BINARY_SCANNER_MPV4
                     }
                 }
@@ -354,13 +354,13 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
         return mpVersion;
     }
 
-    // Return true if the newVer > latestVer, programming model is "ee" or "mp"
-    protected static boolean isLatestVersion(String latestVer, String newVer, String programmingModel) {
-        if (latestVer == null || latestVer.isEmpty())  {
+    // Return true if the newVer > currentVer, programming model is "ee" or "mp"
+    protected static boolean isLatestVersion(String currentVer, String newVer, String programmingModel) {
+        if (currentVer == null || currentVer.isEmpty())  {
             return true;
         }
         return (Integer.parseInt(newVer.substring(newVer.lastIndexOf(programmingModel) + 2)) > Integer
-                .parseInt(latestVer.substring(latestVer.lastIndexOf(programmingModel) + 2)));
+                .parseInt(currentVer.substring(currentVer.lastIndexOf(programmingModel) + 2)));
     }
 
     // Define the logging functions of the binary scanner handler and make it available in this plugin

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
@@ -307,7 +307,7 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
      * @param project
      * @return latest EE major version corresponding to the EE umbrella dependency, null if an EE umbrella dependency is not found
      */
-    private getEEVersion(Object project) {
+    protected getEEVersion(Object project) {
         String eeVersion = null
         project.configurations.compileClasspath.allDependencies.each {
             dependency ->
@@ -321,9 +321,9 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
                     }
                 } else if (dependency.group.equals("jakarta.platform") &&
                         dependency.name.equals("jakarta.jakartaee-api") &&
-                        dependency.version.startsWith("8.") && (isLatestVersion(eeVersion, BINARY_SCANNER_EEV8, "ee")) ) {
-                eeVersion = BINARY_SCANNER_EEV8
-            }
+                        dependency.version.startsWith("8.") && (isLatestVersion(eeVersion, BINARY_SCANNER_EEV8, "ee"))) {
+                    eeVersion = BINARY_SCANNER_EEV8
+                }
         }
         return eeVersion;
     }
@@ -334,7 +334,7 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
      * @param project
      * @return latest MP major version corresponding to the MP umbrella dependency, null if an MP umbrella dependency is not found
      */
-    private getMPVersion(Object project) {
+    protected getMPVersion(Object project) {
         String mpVersion = null
         project.configurations.compileClasspath.allDependencies.each {
             if (it.group.equals("org.eclipse.microprofile") &&
@@ -354,8 +354,8 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
     }
 
     // Return true if the newVer > latestVer, programming model is "ee" or "mp"
-    private static boolean isLatestVersion(String latestVer, String newVer, String programmingModel) {
-        if (latestVer == null)  {
+    protected static boolean isLatestVersion(String latestVer, String newVer, String programmingModel) {
+        if (latestVer == null || latestVer.isEmpty())  {
             return true;
         }
         return (Integer.parseInt(newVer.substring(newVer.lastIndexOf(programmingModel) + 2)) > Integer


### PR DESCRIPTION
Addresses the following error:

```
Caused by: org.gradle.internal.metaobject.AbstractDynamicObject$CustomMessageMissingMethodException: Could not find method isLatestVersion() for arguments [null, ee8, ee] on task ':generateFeatures' of type io.openliberty.tools.gradle.tasks.GenerateFeaturesTask
```

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>