### PR TITLE
Call generate features on compile dependency changes in dev mode flow

### DIFF
--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
@@ -442,7 +442,7 @@ class DevTask extends AbstractFeatureTask {
         }
 
         @Override
-        public boolean recompileBuildFile(File buildFile, Set<String> compileArtifactPaths, Set<String> testArtifactPaths, ThreadPoolExecutor executor) {
+        public boolean recompileBuildFile(File buildFile, Set<String> compileArtifactPaths, Set<String> testArtifactPaths, boolean generateFeatures, ThreadPoolExecutor executor) {
             boolean restartServer = false;
             boolean installFeatures = false;
             boolean compileDependenciesChanged = false;
@@ -573,8 +573,8 @@ class DevTask extends AbstractFeatureTask {
 
             }
             if (restartServer) {
+                // TODO check if features are generated here
                 // - stop Server
-                // - generate features (if generateFeatures=true)
                 // - create server or runBoostMojo
                 // - install feature
                 // - deploy app
@@ -586,7 +586,9 @@ class DevTask extends AbstractFeatureTask {
                 boolean generateFeaturesSuccess = libertyGenerateFeatures(null, true);
                 if (generateFeaturesSuccess) {
                     util.javaSourceClassPaths.clear();
-                };
+                } else {
+                    installFeatures = false;
+                }
             } else if (installFeatures) {
                 libertyInstallFeature();
             }


### PR DESCRIPTION
Part of https://github.com/OpenLiberty/ci.maven/issues/1441

Call `generateFeatures` task when compile dependencies have changed in a build file.

Blocked from adding integration tests for this logic, see https://github.com/OpenLiberty/ci.gradle/issues/708

See https://github.com/OpenLiberty/ci.common/pull/349