### PR TITLE
Suppress logs from ServerFeatureUtil so that dev console is not flooded

### DIFF
--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractFeatureTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractFeatureTask.groovy
@@ -75,6 +75,8 @@ public class AbstractFeatureTask extends AbstractServerTask {
         void warn(String msg) {
             if (!suppressLogs) {
                 logger.warn(msg);
+            } else {
+                logger.debug(msg);
             }
         }
 
@@ -82,6 +84,8 @@ public class AbstractFeatureTask extends AbstractServerTask {
         void info(String msg) {
             if (!suppressLogs) {
                 logger.lifecycle(msg);
+            } else {
+                logger.debug(msg);
             }
         }
     }
@@ -211,10 +215,21 @@ public class AbstractFeatureTask extends AbstractServerTask {
         return featuresToInstall
     }
 
+    /**
+     * Get a new instance of ServerFeatureUtil
+     *
+     * @param suppressLogs if true info and warning will be logged as debug
+     * @return instance of ServerFeatureUtil
+     */
     @Internal
-    protected ServerFeatureUtil getServerFeatureUtil() {
+    protected ServerFeatureUtil getServerFeatureUtil(boolean suppressLogs) {
         if (servUtil == null) {
             servUtil = new ServerFeatureTaskUtil();
+        }
+        if (suppressLogs) {
+            servUtil.setSuppressLogs(true);
+        } else {
+            servUtil.setSuppressLogs(false);
         }
         return servUtil;
     }

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
@@ -305,7 +305,7 @@ class DevTask extends AbstractFeatureTask {
                     false /* recompileDependencies only supported in ci.maven */, packagingType, buildFile, null /* parent build files */, generateFeatures, null /* compileArtifactPaths */, null /* testArtifactPaths */, new ArrayList<Path>() /* webResources */
                 );
 
-            ServerFeatureUtil servUtil = getServerFeatureUtil();
+            ServerFeatureUtil servUtil = getServerFeatureUtil(true);
             this.libertyDirPropertyFiles = AbstractServerTask.getLibertyDirectoryPropertyFiles(installDirectory, userDirectory, serverDirectory);
             this.existingFeatures = servUtil.getServerFeatures(serverDirectory, libertyDirPropertyFiles);
 
@@ -657,7 +657,7 @@ class DevTask extends AbstractFeatureTask {
 
         @Override
         public void installFeatures(File configFile, File serverDir) {
-            ServerFeatureUtil servUtil = getServerFeatureUtil();
+            ServerFeatureUtil servUtil = getServerFeatureUtil(true);
             Set<String> features = servUtil.getServerFeatures(serverDir, libertyDirPropertyFiles);
 
             if (features == null) {
@@ -707,7 +707,8 @@ class DevTask extends AbstractFeatureTask {
 
         @Override
         public ServerFeatureUtil getServerFeatureUtilObj() {
-            return getServerFeatureUtil();
+            // suppress logs from ServerFeatureUtil so that dev console is not flooded
+            return getServerFeatureUtil(true);
         }
 
         @Override

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
@@ -98,8 +98,7 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
         } */
 
         // get existing server features from source directory
-        ServerFeatureUtil servUtil = getServerFeatureUtil();
-
+        ServerFeatureUtil servUtil = getServerFeatureUtil(true);
         Set<String> generatedFiles = new HashSet<String>();
         generatedFiles.add(GENERATED_FEATURES_FILE_NAME);
 


### PR DESCRIPTION
Partial fix for https://github.com/OpenLiberty/ci.maven/issues/1369

Output when running `generateFeatures` task standalone:
```
kathrynkodama@MacBook-Pro demo-devmode % gradle generateFeatures

> Task :generateFeatures
Generated the following features: [cdi-2.0, jaxrs-2.1]

BUILD SUCCESSFUL in 1s
1 actionable task: 1 executed
```

Ouptut when triggering generateFeatures in dev mode on source file change (but no new API usage):
```
> Task :compileJava UP-TO-DATE
> Task :processResources NO-SOURCE

BUILD SUCCESSFUL in 95ms
1 actionable task: 1 up-to-date

> Task :libertyDev
Source compilation was successful.
<-------------> 0% EXECUTING [53s]
> :libertyDev
```

Output when triggering generateFeatures in dev mode with new API usage:
```
> Task :libertyDev
Source compilation was successful.

[AUDIT   ] CWWKT0017I: Web application removed (default_host): http://192.168.0.33:9080/
[AUDIT   ] CWWKZ0009I: The application demo-devmode-gradle has stopped successfully.
[AUDIT   ] CWWKT0016I: Web application available (default_host): http://192.168.0.33:9080/
[AUDIT   ] CWWKZ0003I: The application demo-devmode-gradle updated in 0.066 seconds.

> Task :generateFeatures
Generated the following features: [cdi-2.0, mpHealth-2.2, jaxrs-2.1, mpConfig-1.4]

BUILD SUCCESSFUL in 832ms
1 actionable task: 1 executed

> Task :libertyDev
Generating feature list from incremental changes...
Copied file: /Users/kathrynkodama/devex/featureGeneration/snapshot-testing/demo-devmode/src/main/liberty/config/configDropins/overrides/generated-features.xml to: /private/var/folders/gr/3p093xzj0f9fj9psx80z_zw00000gn/T/tempConfig15533137059770627857/configDropins/overrides/generated-features.xml


> Task :installFeature


BUILD SUCCESSFUL in 8s
1 actionable task: 1 executed

> Task :libertyDev
Copied file: /Users/kathrynkodama/devex/featureGeneration/snapshot-testing/demo-devmode/src/main/liberty/config/configDropins/overrides/generated-features.xml to: /Users/kathrynkodama/devex/featureGeneration/snapshot-testing/demo-devmode/build/wlp/usr/servers/defaultServer/configDropins/overrides/generated-features.xml

[AUDIT   ] CWWKG0016I: Starting server configuration update.
[AUDIT   ] CWWKG0028A: Processing included configuration resource: /Users/kathrynkodama/devex/featureGeneration/snapshot-testing/demo-devmode/build/wlp/usr/servers/defaultServer/extraFeatures1.xml
[AUDIT   ] CWWKG0028A: Processing included configuration resource: /Users/kathrynkodama/devex/featureGeneration/snapshot-testing/demo-devmode/build/wlp/usr/servers/defaultServer/extraServerConfig1.xml
[AUDIT   ] CWWKG0093A: Processing configuration drop-ins resource: /Users/kathrynkodama/devex/featureGeneration/snapshot-testing/demo-devmode/build/wlp/usr/servers/defaultServer/configDropins/overrides/generated-features.xml
[AUDIT   ] CWWKG0093A: Processing configuration drop-ins resource: /Users/kathrynkodama/devex/featureGeneration/snapshot-testing/demo-devmode/build/wlp/usr/servers/defaultServer/configDropins/overrides/liberty-plugin-variable-config.xml
[AUDIT   ] CWWKT0017I: Web application removed (default_host): http://192.168.0.33:9080/
[AUDIT   ] CWWKZ0009I: The application demo-devmode-gradle has stopped successfully.
[AUDIT   ] CWWKG0017I: The server configuration was successfully updated in 0.285 seconds.
[AUDIT   ] CWWKF0012I: The server installed the following features: [json-1.0, mpConfig-1.4, mpHealth-2.2].
[AUDIT   ] CWWKF0008I: Feature update completed in 0.282 seconds.
[AUDIT   ] CWWKT0016I: Web application available (default_host): http://192.168.0.33:9080/health/
[AUDIT   ] CWWKT0016I: Web application available (default_host): http://192.168.0.33:9080/
[AUDIT   ] CWWKZ0003I: The application demo-devmode-gradle updated in 0.147 seconds.
```

If users want to see which config file(s) generate-features gathers existing features from they can use the `--debug` debug flag. 



Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>