### PR TITLE
Fix two generated features integration tests and instrument tests for easier debugging

### DIFF
--- a/src/test/groovy/io/openliberty/tools/gradle/BaseGenerateFeaturesTest.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/BaseGenerateFeaturesTest.groovy
@@ -134,11 +134,15 @@ class BaseGenerateFeaturesTest extends AbstractIntegrationTest {
         process.waitFor(20, TimeUnit.SECONDS);
         assertFalse(process.isAlive());
 
-        // save and print process output
+        System.out.println(formatOutput(getProcessOutput()));
+    }
+
+    protected static String getProcessOutput() {
+        // save and return process output
         Path path = logFile.toPath();
         Charset charset = StandardCharsets.UTF_8;
         processOutput = new String(Files.readAllBytes(path), charset);
-        System.out.println("Process output: " + processOutput);
+        return processOutput;
     }
 
     protected static boolean verifyLogMessageExists(String message, int timeout, File log)
@@ -210,5 +214,28 @@ class BaseGenerateFeaturesTest extends AbstractIntegrationTest {
 
     protected static void runGenerateFeatures() throws IOException, InterruptedException, FileNotFoundException {
         runProcess("generateFeatures");
+    }
+
+    // Format the output to help debug test failures.
+    // The problem is that the test case log looks just like the JUnit log of
+    // the calling process.
+    // For a short stream just print it. Add a start and end string to separate
+    // it from the rest of the log.
+    // For long output streams, add a header which indicates how many lines to skip
+    // if you want to read the end. Also add a trailer to similarly show how many
+    // lines to scroll up to find the beginning. Number each line to help parse
+    // the output.
+    protected static String formatOutput(String output) {
+        if (output == null || output.length() < 101) {
+            return "\n==Process Output==\n" + output + "\n==End==";
+        }
+        String[] lines = output.split("\r\n|\r|\n");
+        StringBuffer result = new StringBuffer(String.format("==Process Output %d lines==\n", lines.length));
+        int count = 1;
+        for (String line : lines) {
+            result.append(String.format("%5d>%s\n", count++, line));
+        }
+        result.append(String.format("==Process Output End %d lines==\n", lines.length));
+        return result.toString();
     }
 }

--- a/src/test/groovy/io/openliberty/tools/gradle/GenerateFeaturesTest.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/GenerateFeaturesTest.groovy
@@ -49,7 +49,7 @@ class GenerateFeaturesTest extends BaseGenerateFeaturesTest {
         assertTrue(targetDir.exists());
 
         // verify that the generated features file was created
-        assertTrue(newFeatureFile.exists());
+        assertTrue(formatOutput(getProcessOutput()), newFeatureFile.exists());
 
         // verify that the correct features are in the generated-features.xml
         Set<String> features = readFeatures(newFeatureFile);
@@ -168,7 +168,8 @@ class GenerateFeaturesTest extends BaseGenerateFeaturesTest {
         Set<String> recommendedFeatureSet = new HashSet<String>();
         recommendedFeatureSet.addAll("servlet-4.0");
         // search log file instead of process output because warning message in process output may be interrupted
-        verifyLogMessageExists(String.format(BINARY_SCANNER_CONFLICT_MESSAGE2, getCdi12ConflictingFeatures(), recommendedFeatureSet), 1000, logFile);
+        boolean b = verifyLogMessageExists(String.format(BINARY_SCANNER_CONFLICT_MESSAGE2, getCdi12ConflictingFeatures(), recommendedFeatureSet), 1000, logFile);
+        assertTrue(formatOutput(getProcessOutput()), b);
     }
 
     /**
@@ -192,7 +193,8 @@ class GenerateFeaturesTest extends BaseGenerateFeaturesTest {
         recommendedFeatureSet.addAll("cdi-2.0");
         recommendedFeatureSet.addAll("servlet-4.0");
         // search log file instead of process output because warning message in process output may be interrupted
-        verifyLogMessageExists(String.format(BINARY_SCANNER_CONFLICT_MESSAGE1, getCdi12ConflictingFeatures(), recommendedFeatureSet), 1000, logFile);
+        boolean b = verifyLogMessageExists(String.format(BINARY_SCANNER_CONFLICT_MESSAGE1, getCdi12ConflictingFeatures(), recommendedFeatureSet), 1000, logFile);
+        assertTrue(formatOutput(getProcessOutput()), b);
     }
 
     // TODO add an integration test for feature conflict for API usage (BINARY_SCANNER_CONFLICT_MESSAGE3), ie. MP4 and EE9


### PR DESCRIPTION
Instrument basicTest() in case it fails as we've seen in other cases. 

Repair tests userAndGeneratedConflictTest() and userConflictTest() which were not testing results properly.