### PR TITLE
Increase wait for generateFeatures in DevTests

### DIFF
--- a/src/test/groovy/io/openliberty/tools/gradle/DevTest.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/DevTest.groovy
@@ -80,7 +80,7 @@ class DevTest extends BaseDevTest {
         replaceString("<!-- replace -->", "<feature>servlet-4.0</feature>", srcServerXMLIncludes);
 
         // check that features have been generated (no additional features generated)
-        assertTrue(verifyLogMessage(10000, RUNNING_GENERATE_FEATURES, ++generateFeaturesCount)); // task ran
+        assertTrue("Could not verify that features had been generated: " + getContents(logFile, "Dev mode std output"), verifyLogMessage(18000, RUNNING_GENERATE_FEATURES, ++generateFeaturesCount)); // task ran
 
         // check for server configuration update
         File messagesLogFile = new File(targetDir, "wlp/usr/servers/defaultServer/logs/messages.log");


### PR DESCRIPTION
`configIncludesChangeTest()` intermittently fails through GitHub Actions because `generateFeatures` is not given enough time to run. Fix increases the time waiting to see generate features message in dev mode output.
Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>