### PR TITLE
Compose parameters for binary scanner from umbrella version numbers in build file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ compileTestGroovy {
 }
 
 def libertyAntVersion = "1.9.10"
-def libertyCommonVersion = "1.8.21"
+def libertyCommonVersion = "1.8.22-SNAPSHOT"
 
 dependencies {
     implementation gradleApi()

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
@@ -335,22 +335,20 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
         project.configurations.compileClasspath.allDependencies.each {
             dependency ->
                 if (dependency.group.equals("javax") && dependency.name.equals("javaee-api")) {
-                    if (dependency.version.startsWith("8.")) {
-                        eeVersion = BINARY_SCANNER_EEV8
-                    } else if (dependency.version.startsWith("7.") && (isLatestVersion(eeVersion, BINARY_SCANNER_EEV7))) {
-                        eeVersion = BINARY_SCANNER_EEV7
-                    } else if (dependency.version.startsWith("6.") && (isLatestVersion(eeVersion, BINARY_SCANNER_EEV6))) {
-                        eeVersion = BINARY_SCANNER_EEV6
+                    String newVersion = composeEEVersion(dependency.version)
+                    if (newVersion != null && isLatestVersion(eeVersion, newVersion)) {
+                        eeVersion = newVersion
                     }
                 } else if (dependency.group.equals("jakarta.platform") &&
-                        dependency.name.equals("jakarta.jakartaee-api") &&
-                        dependency.version.startsWith("8.")) {
-                    eeVersion = BINARY_SCANNER_EEV8
+                        dependency.name.equals("jakarta.jakartaee-api")) {
+                    String newVersion = composeEEVersion(dependency.version)
+                    if (newVersion != null && isLatestVersion(eeVersion, newVersion)) {
+                        eeVersion = newVersion
+                    }
                 }
         }
         return eeVersion;
     }
-
     /**
      * Returns the latest MicroProfile major version detected in the project dependencies
      *
@@ -363,20 +361,9 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
             dependency ->
                 if (dependency.group.equals("org.eclipse.microprofile") &&
                         dependency.name.equals("microprofile")) {
-                    String version = null;
-                    if (dependency.version.length() == 3) { // version is 'm.n'
-                        version = BINARY_SCANNER_MP.get(dependency.version);
-                    }
-                    if ((version != null) && (isLatestVersion(mpVersion, version))) {
-                        mpVersion = version;
-                    } else if (dependency.version.startsWith("1") && (isLatestVersion(mpVersion, BINARY_SCANNER_MPV1))) {
-                        mpVersion = BINARY_SCANNER_MPV1
-                    } else if (dependency.version.startsWith("2") && (isLatestVersion(mpVersion, BINARY_SCANNER_MPV2))) {
-                        mpVersion = BINARY_SCANNER_MPV2
-                    } else if (dependency.version.startsWith("3") && (isLatestVersion(mpVersion, BINARY_SCANNER_MPV3))) {
-                        mpVersion = BINARY_SCANNER_MPV3
-                    } else if (dependency.version.startsWith("4")) {
-                        mpVersion = BINARY_SCANNER_MPV4
+                    String newVersion = composeMPVersion(dependency.version)
+                    if (newVersion != null && isLatestVersion(mpVersion, newVersion)) {
+                        mpVersion = newVersion;
                     }
                 }
         }

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
@@ -334,13 +334,9 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
         String eeVersion = null
         project.configurations.compileClasspath.allDependencies.each {
             dependency ->
-                if (dependency.group.equals("javax") && dependency.name.equals("javaee-api")) {
-                    String newVersion = composeEEVersion(dependency.version)
-                    if (newVersion != null && isLatestVersion(eeVersion, newVersion)) {
-                        eeVersion = newVersion
-                    }
-                } else if (dependency.group.equals("jakarta.platform") &&
-                        dependency.name.equals("jakarta.jakartaee-api")) {
+                if ((dependency.group.equals("javax") && dependency.name.equals("javaee-api")) ||
+                    (dependency.group.equals("jakarta.platform") &&
+                        dependency.name.equals("jakarta.jakartaee-api"))) {
                     String newVersion = composeEEVersion(dependency.version)
                     if (newVersion != null && isLatestVersion(eeVersion, newVersion)) {
                         eeVersion = newVersion


### PR DESCRIPTION
Use the facility added in BinaryScannerUtil to create a version number parameter from the value in the build.gradle build file. 

No tests are added due to issues changing the build file in dev mode in JUnit. Similar code in ci.maven tests the message generated by BinaryScannerUtil. Related to https://github.com/OpenLiberty/ci.gradle/issues/708