### PR TITLE
Add build dir to install feature method

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -39,8 +39,7 @@ jobs:
     - name: Checkout ci.common
       uses: actions/checkout@v2
       with:
-        repository: cherylking/ci.common
-        ref: addBuildDirInstallFeature
+        repository: OpenLiberty/ci.common
         path: ci.common
     - name: Checkout ci.ant
       uses: actions/checkout@v2
@@ -123,7 +122,7 @@ jobs:
     - name: Clone ci.ant, ci.common, ci.gradle repos to C drive
       run: |
         cp -r D:/a/ci.gradle/ci.gradle C:/ci.gradle
-        git clone https://github.com/cherylking/ci.common.git C:/ci.common
+        git clone https://github.com/OpenLiberty/ci.common.git C:/ci.common
         git clone https://github.com/OpenLiberty/ci.ant.git C:/ci.ant
     # Cache mvn/gradle packages
     - name: Cache Maven packages
@@ -147,7 +146,6 @@ jobs:
         cd C:/ci.ant
         mvn clean install
         cd C:/ci.common
-        git checkout addBuildDirInstallFeature
         mvn clean install
     # Run tests
     - name: Run tests with Gradle on Windows

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -39,7 +39,8 @@ jobs:
     - name: Checkout ci.common
       uses: actions/checkout@v2
       with:
-        repository: OpenLiberty/ci.common
+        repository: cherylking/ci.common
+        ref: addBuildDirInstallFeature
         path: ci.common
     - name: Checkout ci.ant
       uses: actions/checkout@v2
@@ -122,7 +123,7 @@ jobs:
     - name: Clone ci.ant, ci.common, ci.gradle repos to C drive
       run: |
         cp -r D:/a/ci.gradle/ci.gradle C:/ci.gradle
-        git clone https://github.com/OpenLiberty/ci.common.git C:/ci.common
+        git clone https://github.com/cherylking/ci.common.git C:/ci.common
         git clone https://github.com/OpenLiberty/ci.ant.git C:/ci.ant
     # Cache mvn/gradle packages
     - name: Cache Maven packages
@@ -146,6 +147,7 @@ jobs:
         cd C:/ci.ant
         mvn clean install
         cd C:/ci.common
+        git checkout addBuildDirInstallFeature
         mvn clean install
     # Run tests
     - name: Run tests with Gradle on Windows

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ compileTestGroovy {
 }
 
 def libertyAntVersion = "1.9.10"
-def libertyCommonVersion = "1.8.22"
+def libertyCommonVersion = "1.8.23-SNAPSHOT"
 
 dependencies {
     implementation gradleApi()

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractFeatureTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractFeatureTask.groovy
@@ -91,8 +91,8 @@ public class AbstractFeatureTask extends AbstractServerTask {
     }
 
     private class InstallFeatureTaskUtil extends InstallFeatureUtil {
-        public InstallFeatureTaskUtil(File installDir, String from, String to, Set<String> pluginListedEsas, List<ProductProperties> propertiesList, String openLibertyVerion, String containerName, List<String> additionalJsons)  throws PluginScenarioException, PluginExecutionException {
-            super(installDir, from, to, pluginListedEsas, propertiesList, openLibertyVerion, containerName, additionalJsons)
+        public InstallFeatureTaskUtil(File installDir, File buildDir, String from, String to, Set<String> pluginListedEsas, List<ProductProperties> propertiesList, String openLibertyVerion, String containerName, List<String> additionalJsons)  throws PluginScenarioException, PluginExecutionException {
+            super(installDir, buildDir, from, to, pluginListedEsas, propertiesList, openLibertyVerion, containerName, additionalJsons)
         }
 
         @Override
@@ -237,7 +237,7 @@ public class AbstractFeatureTask extends AbstractServerTask {
 
     private void createNewInstallFeatureUtil(Set<String> pluginListedEsas, List<ProductProperties> propertiesList, String openLibertyVerion, String containerName, List<String> additionalJsons) throws PluginExecutionException {
         try {
-            util = new InstallFeatureTaskUtil(getInstallDir(project), server.features.from, server.features.to, pluginListedEsas, propertiesList, openLibertyVerion, containerName, additionalJsons)
+            util = new InstallFeatureTaskUtil(getInstallDir(project), project.getBuildDir(), server.features.from, server.features.to, pluginListedEsas, propertiesList, openLibertyVerion, containerName, additionalJsons)
         } catch (PluginScenarioException e) {
             logger.debug("Exception received: " + e.getMessage(), (Throwable) e)
             logger.debug("Installing features from installUtility.")


### PR DESCRIPTION
Related to https://github.com/OpenLiberty/ci.common/pull/387

Need to pass the build directory to install feature method so that the `.libertyls` directory can be deleted when features are installed.