### PR TITLE
Suggest first command of assemble rather than build

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The Liberty Gradle plugin supports install and operational control of Liberty ru
 Clone this repository and then, with a JRE on the path, execute the following command in the root directory.
 
 ```bash
-$ ./gradlew build
+$ ./gradlew assemble
 ```
 
 This will download Gradle, build the plugin, and install it in to the `build\libs` directory. It is also possible to install the plugin in to your local Maven repository using `./gradlew install`.


### PR DESCRIPTION
The first, suggested command of `./gradlew build` doesn't work without the runtime, runtimeVersion props, so the doc should either mention this or use a command that doesn't need the props.

Seems the doc works if we switch to 'assemble'.