### PR TITLE
Additional support for multi-module loose ear applications

### DIFF
--- a/src/main/groovy/io/openliberty/tools/gradle/utils/LooseEarApplication.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/utils/LooseEarApplication.groovy
@@ -64,7 +64,10 @@ public class LooseEarApplication extends LooseApplication {
                     config.addFile(moduleArchive, f, "/WEB-INF/lib/" + f.getName());
                     break
                 case "MF":
-                    addManifestFileWithParent(moduleArchive, f)
+                    //This checks the manifest file and resource directory of the project's jar source set.
+                    //The location of the resource directory should be the same as proj.getProjectDir()/build/resources.
+                    //If the manifest file exists, it is copied to proj.getProjectDir()/build/resources/tmp/META-INF. If it does not exist, one is created there.
+                    addManifestFileWithParent(moduleArchive, f, proj.sourceSets.main.getOutput().getResourcesDir().getParentFile().getCanonicalPath())
                     break
                 default:
                     break

--- a/src/test/groovy/io/openliberty/tools/gradle/TestLooseWarWithLooseJar.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/TestLooseWarWithLooseJar.groovy
@@ -18,6 +18,8 @@ import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 
+import io.openliberty.tools.common.plugins.util.OSUtil
+
 public class TestLooseWarWithLooseJar extends AbstractIntegrationTest{
     static File resourceDir = new File("build/resources/test/loose-war-with-loose-jar")
     static File buildDir = new File(integTestDir, "/loose-war-with-loose-jar")
@@ -93,8 +95,13 @@ public class TestLooseWarWithLooseJar extends AbstractIntegrationTest{
 
         //Check loose jar classes dir location
         String nodeValue = nodes.item(0).getAttributes().getNamedItem("sourceOnDisk").getNodeValue();
-        Assert.assertEquals("sibling archive targetInArchive attribute value", buildDir.getCanonicalPath() + "/ejb-ejb/build/classes/java/main",
-            nodes.item(0).getAttributes().getNamedItem("sourceOnDisk").getNodeValue()); 
+        if (OSUtil.isWindows()) {
+            Assert.assertEquals("sibling archive targetInArchive attribute value", buildDir.getCanonicalPath() + "\\ejb-ejb\\build\\classes\\java\\main",
+                nodes.item(0).getAttributes().getNamedItem("sourceOnDisk").getNodeValue()); 
+        } else {
+            Assert.assertEquals("sibling archive targetInArchive attribute value", buildDir.getCanonicalPath() + "/ejb-ejb/build/classes/java/main",
+                nodes.item(0).getAttributes().getNamedItem("sourceOnDisk").getNodeValue()); 
+        }
         
          //Check loose jar contains correct amount of file elements
         expression = "/archive/archive/file";
@@ -103,8 +110,14 @@ public class TestLooseWarWithLooseJar extends AbstractIntegrationTest{
 
         //Check loose jar manifest file location
         nodeValue = nodes.item(0).getAttributes().getNamedItem("sourceOnDisk").getNodeValue();
-        Assert.assertEquals("sibling archive targetInArchive attribute value", buildDir.getCanonicalPath() + "/ejb-ejb/build/resources/tmp/META-INF/MANIFEST.MF",
-            nodes.item(0).getAttributes().getNamedItem("sourceOnDisk").getNodeValue()); 
+        if (OSUtil.isWindows()) {
+            Assert.assertEquals("sibling archive targetInArchive attribute value", buildDir.getCanonicalPath() + "\\ejb-ejb\\build\\resources\\tmp\\META-INF\\MANIFEST.MF",
+                nodes.item(0).getAttributes().getNamedItem("sourceOnDisk").getNodeValue());
+        } else {
+            Assert.assertEquals("sibling archive targetInArchive attribute value", buildDir.getCanonicalPath() + "/ejb-ejb/build/resources/tmp/META-INF/MANIFEST.MF",
+                nodes.item(0).getAttributes().getNamedItem("sourceOnDisk").getNodeValue());
+        }
+ 
 
         //Check correct number of additional file elements are present
         expression = "/archive/file";
@@ -112,24 +125,36 @@ public class TestLooseWarWithLooseJar extends AbstractIntegrationTest{
         Assert.assertEquals("Number of <file/> element ==>", 4, nodes.getLength());
 
         Assert.assertEquals("archive targetInArchive attribute value", "/WEB-INF/lib/javaee-api-7.0.jar",
-            nodes.item(0).getAttributes().getNamedItem("targetInArchive").getNodeValue());
+            nodes.item(0).getAttributes().getNamedItem("targetInArchive").getNodeValue()); 
 
         // Check that dependencies are not located in the test build dir since copyLibsDirectory not set. They will be located in the gradle cache somewhere.
         nodeValue = nodes.item(0).getAttributes().getNamedItem("sourceOnDisk").getNodeValue();
-        assert nodeValue.endsWith("/javaee-api-7.0.jar") && !nodeValue.contains("/loose-war-with-loose-jar/") : 'archive sourceOnDisk attribute value not correct'
+        if (OSUtil.isWindows()) {
+            assert nodeValue.endsWith("\\javaee-api-7.0.jar") && !nodeValue.contains("\\loose-war-with-loose-jar\\") : 'archive sourceOnDisk attribute value not correct'
+        } else {
+            assert nodeValue.endsWith("/javaee-api-7.0.jar") && !nodeValue.contains("/loose-war-with-loose-jar/") : 'archive sourceOnDisk attribute value not correct'
+        }
 
         Assert.assertEquals("archive targetInArchive attribute value", "/WEB-INF/lib/javax.mail-1.5.0.jar",
             nodes.item(1).getAttributes().getNamedItem("targetInArchive").getNodeValue());
 
         // Check that dependencies are not located in the test build dir since copyLibsDirectory not set. They will be located in the gradle cache somewhere.
         nodeValue = nodes.item(1).getAttributes().getNamedItem("sourceOnDisk").getNodeValue();
-        assert nodeValue.endsWith("/javax.mail-1.5.0.jar") && !nodeValue.contains("/loose-war-with-loose-jar/") : 'archive sourceOnDisk attribute value not correct'
+        if (OSUtil.isWindows()) {
+            assert nodeValue.endsWith("\\javax.mail-1.5.0.jar") && !nodeValue.contains("\\loose-war-with-loose-jar/") : 'archive sourceOnDisk attribute value not correct'
+        } else {
+            assert nodeValue.endsWith("/javax.mail-1.5.0.jar") && !nodeValue.contains("/loose-war-with-loose-jar/") : 'archive sourceOnDisk attribute value not correct'
+        }
 
         Assert.assertEquals("archive targetInArchive attribute value", "/WEB-INF/lib/activation-1.1.jar",
             nodes.item(2).getAttributes().getNamedItem("targetInArchive").getNodeValue());
 
         // Check that dependencies are not located in the test build dir since copyLibsDirectory not set. They will be located in the gradle cache somewhere.
         nodeValue = nodes.item(2).getAttributes().getNamedItem("sourceOnDisk").getNodeValue();
-        assert nodeValue.endsWith("/activation-1.1.jar") && !nodeValue.contains("/loose-war-with-loose-jar/") : 'archive sourceOnDisk attribute value not correct'
+        if (OSUtil.isWindows()) {
+            assert nodeValue.endsWith("\\activation-1.1.jar") && !nodeValue.contains("\\loose-war-with-loose-jar\\") : 'archive sourceOnDisk attribute value not correct'
+        } else {
+            assert nodeValue.endsWith("/activation-1.1.jar") && !nodeValue.contains("/loose-war-with-loose-jar/") : 'archive sourceOnDisk attribute value not correct'
+        }
     }
 }

--- a/src/test/groovy/io/openliberty/tools/gradle/TestMultiModuleLooseEar.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/TestMultiModuleLooseEar.groovy
@@ -1,0 +1,123 @@
+package io.openliberty.tools.gradle;
+
+import org.junit.AfterClass
+import org.junit.BeforeClass
+import org.junit.Test
+
+import java.io.File;
+import java.io.FileInputStream;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+import org.w3c.dom.Node;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import io.openliberty.tools.common.plugins.util.OSUtil
+
+public class TestMultiModuleLooseEar extends AbstractIntegrationTest{
+    static File resourceDir = new File("build/resources/test/multi-module-loose-ear-test")
+    static File buildDir = new File(integTestDir, "/multi-module-loose-ear-test")
+    static String buildFilename = "build.gradle"
+
+    @BeforeClass
+    public static void setup() {
+        createDir(buildDir)
+        createTestProject(buildDir, resourceDir, buildFilename)
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        runTasks(buildDir, 'libertyStop')
+    }
+
+    @Test
+    public void test_loose_config_file_exists() {
+        try {
+            runTasks(buildDir, 'deploy')
+        } catch (Exception e) {
+            throw new AssertionError ("Fail on task deploy. " + e)
+        }
+        assert new File('build/testBuilds/multi-module-loose-ear-test/ejb-ear/build/wlp/usr/servers/ejbServer/apps/ejb-ear.ear.xml').exists() : 'looseApplication config file was not copied over to the liberty runtime'
+    }
+    /*
+        Expected output to the XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <archive>
+            <file sourceOnDisk="/Users/../../ci.gradle/build/testBuilds/multi-module-loose-ear-test/ejb-ear/build/tmp/ear/application.xml" targetInArchive="/META-INF/application.xml"/>
+            <file sourceOnDisk="/Users/../../ci.gradle/build/testBuilds/multi-module-loose-ear-test/ejb-ear/build/libs/1557427330063525/commons-text-1.1.jar" targetInArchive="/WEB-INF/lib/commons-text-1.1.jar"/>
+            <archive targetInArchive="/ejb-war.war">
+                <dir sourceOnDisk="/Users/../../ci.gradle/build/testBuilds/multi-module-loose-ear-test/ejb-war/build/classes/java/main" targetInArchive="/WEB-INF/classes"/>
+                <file sourceOnDisk="/Users/../../ci.gradle/build/testBuilds/multi-module-loose-ear-test/ejb-war/build/resources/tmp/META-INF/MANIFEST.MF" targetInArchive="/META-INF/MANIFEST.MF"/>
+                <archive targetInArchive="/WEB-INF/lib/ejb-ejb.jar">
+                    <dir sourceOnDisk="/Users/../../ci.gradle/build/testBuilds/multi-module-loose-ear-test/ejb-ejb/build/classes/java/main" targetInArchive="/"/>
+                    <file sourceOnDisk="/Users/../../ci.gradle/build/testBuilds/multi-module-loose-ear-test/ejb-ejb/build/resources/tmp/META-INF/MANIFEST.MF" targetInArchive="/META-INF/MANIFEST.MF"/>
+                </archive>
+            </archive>
+            <file sourceOnDisk="/Users/../../ci.gradle/build/testBuilds/multi-module-loose-ear-test/loose-ear-test/ejb-ear/build/tmp/META-INF/MANIFEST.MF" targetInArchive="/META-INF/MANIFEST.MF"/>
+        </archive>
+    */
+    @Test
+    public void test_loose_config_file_contents_are_correct(){
+        File on = new File("build/testBuilds/multi-module-loose-ear-test/ejb-ear/build/wlp/usr/servers/ejbServer/apps/ejb-ear.ear.xml");
+        FileInputStream input = new FileInputStream(on);
+
+        // get input XML Document
+        DocumentBuilderFactory inputBuilderFactory = DocumentBuilderFactory.newInstance();
+        inputBuilderFactory.setIgnoringComments(true);
+        inputBuilderFactory.setCoalescing(true);
+        inputBuilderFactory.setIgnoringElementContentWhitespace(true);
+        inputBuilderFactory.setValidating(false);
+        DocumentBuilder inputBuilder = inputBuilderFactory.newDocumentBuilder();
+        Document inputDoc=inputBuilder.parse(input);
+
+        // parse input XML Document
+        XPath xPath = XPathFactory.newInstance().newXPath();
+        String expression = "/archive/dir";
+        NodeList nodes = (NodeList) xPath.compile(expression).evaluate(inputDoc, XPathConstants.NODESET);
+        Assert.assertEquals("Number of <dir/> element ==>", 0, nodes.getLength());
+
+        expression = "/archive/archive";
+        nodes = (NodeList) xPath.compile(expression).evaluate(inputDoc, XPathConstants.NODESET);
+        Assert.assertEquals("Number of <archive/> element ==>", 1, nodes.getLength());
+
+        String ejbWar = "/ejb-war.war"
+
+        Assert.assertTrue(ejbWar.equals(nodes.item(0).getAttributes().getNamedItem("targetInArchive").getNodeValue()))
+
+        expression = "/archive/archive/archive";
+        nodes = (NodeList) xPath.compile(expression).evaluate(inputDoc, XPathConstants.NODESET);
+        Assert.assertEquals("Number of <archive/> element ==>", 1, nodes.getLength());
+
+        String ejbJar = "/WEB-INF/lib/ejb-ejb.jar"
+
+        Assert.assertTrue(ejbJar.equals(nodes.item(0).getAttributes().getNamedItem("targetInArchive").getNodeValue()))
+
+        expression = "/archive/file";
+        nodes = (NodeList) xPath.compile(expression).evaluate(inputDoc, XPathConstants.NODESET);
+        Assert.assertEquals("Number of <file/> element ==>", 3, nodes.getLength());
+
+        // check that lib dependency is referenced in copyLibsDirectory location
+        for (Node node : nodes) {
+            if (node.getAttributes().getNamedItem("targetInArchive").getNodeValue().equals("/WEB-INF/lib/commons-text-1.1.jar")) {
+                // Check that dependencies are located in the test build dir specified by copyLibsDirectory. Otherwise they would be located in the gradle cache somewhere.
+                String nodeValue = node.getAttributes().getNamedItem("sourceOnDisk").getNodeValue();
+
+                if (OSUtil.isWindows()) {
+                    Assert.assertTrue(nodeValue.endsWith("\\commons-text-1.1.jar") && nodeValue.contains("\\multi-module-loose-ear-test\\ejb-ear\\build\\libs\\"))
+                } else {
+                    Assert.assertTrue(nodeValue.endsWith("/commons-text-1.1.jar") && nodeValue.contains("/multi-module-loose-ear-test/ejb-ear/build/libs/"))
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/multi-module-loose-ear-test/build.gradle
+++ b/src/test/resources/multi-module-loose-ear-test/build.gradle
@@ -1,0 +1,19 @@
+allprojects  {
+    group = 'sample'
+    version = '1.0'
+}
+
+subprojects {
+    apply plugin: 'java'
+    
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
+    tasks.withType(JavaCompile) {
+        options.encoding = 'UTF-8'
+    }
+    
+    repositories {
+        mavenLocal()
+        mavenCentral()
+    }
+}

--- a/src/test/resources/multi-module-loose-ear-test/ejb-ear/build.gradle
+++ b/src/test/resources/multi-module-loose-ear-test/ejb-ear/build.gradle
@@ -1,0 +1,55 @@
+apply plugin: 'ear'
+apply plugin: 'liberty'
+
+description = 'EAR Module'
+
+buildscript {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        maven {
+            name = 'Sonatype Nexus Snapshots'
+            url = 'https://oss.sonatype.org/content/repositories/snapshots/'
+        }
+    }
+    dependencies {
+        classpath "io.openliberty.tools:liberty-gradle-plugin:$lgpVersion"
+    }
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    deploy project(path:':ejb-war', configuration:'archives')
+    deploy 'org.apache.commons:commons-text:1.1'
+    testImplementation group: 'commons-httpclient', name: 'commons-httpclient', version:'3.1'
+    testImplementation group: 'junit', name: 'junit', version:'4.13.1'
+    libertyRuntime group: runtimeGroup, name: kernelArtifactId, version: runtimeVersion
+}
+
+ear {
+    archiveName = baseName + '.' + extension
+    deploymentDescriptor {
+        module ('ejb-ejb.jar', 'ejb')
+        webModule ('ejb-war.war', '/ejb-war')
+    }
+}
+
+liberty {
+    server {
+        name = "ejbServer"
+        deploy {
+            apps = [ear]
+            copyLibsDirectory = file("${project.buildDir}/libs")
+        }
+        verifyAppStartTimeout = 30
+        looseApplication = true
+    }
+}
+
+clean.dependsOn 'libertyStop'
+deploy.dependsOn 'ear'
+ear.dependsOn ':ejb-war:jar', ':ejb-war:war'

--- a/src/test/resources/multi-module-loose-ear-test/ejb-ear/src/main/liberty/config/server.xml
+++ b/src/test/resources/multi-module-loose-ear-test/ejb-ear/src/main/liberty/config/server.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="ejb server">
+
+    <!-- Enable features -->
+    <featureManager>
+        <feature>javaee-7.0</feature>
+    </featureManager>
+
+    <!-- Encoded password can be generated using bin/securityUtility -->
+    <keyStore password="change1me"/>
+
+    <basicRegistry id="basic" realm="BasicRealm">
+        <user name="user1" password="change1me"/>
+    </basicRegistry>
+
+    <!-- To access this server from a remote client add a host attribute to the following element, e.g. host="*" -->
+    <httpEndpoint id="defaultHttpEndpoint"
+                  httpPort="9080"
+                  httpsPort="9443" />
+    
+    <enterpriseApplication id="ejb-ear" location="ejb-ear.ear" name="ejb-ear"/>
+</server>

--- a/src/test/resources/multi-module-loose-ear-test/ejb-ejb/build.gradle
+++ b/src/test/resources/multi-module-loose-ear-test/ejb-ejb/build.gradle
@@ -1,0 +1,11 @@
+
+description = 'EJB Module'
+
+dependencies {
+    testImplementation group: 'junit', name: 'junit', version:'4.13.1'
+    compileOnly group: 'javax', name: 'javaee-api', version:'7.0'
+}
+
+jar {
+    archiveName = baseName + '.' + extension
+}

--- a/src/test/resources/multi-module-loose-ear-test/ejb-ejb/src/main/java/wasdev/ejb/ejb/SampleStatelessBean.java
+++ b/src/test/resources/multi-module-loose-ear-test/ejb-ejb/src/main/java/wasdev/ejb/ejb/SampleStatelessBean.java
@@ -1,0 +1,11 @@
+package wasdev.ejb.ejb;
+
+import javax.ejb.Stateless;
+
+@Stateless
+public class SampleStatelessBean {
+
+    public String hello() {
+        return "Hello EJB World.";
+    }
+}

--- a/src/test/resources/multi-module-loose-ear-test/ejb-war/build.gradle
+++ b/src/test/resources/multi-module-loose-ear-test/ejb-war/build.gradle
@@ -1,0 +1,15 @@
+
+apply plugin: 'war'
+
+jar.enabled = false
+description = 'WAR Module'
+dependencies {
+    testImplementation group: 'junit', name: 'junit', version:'4.13.1'
+    providedCompile group: 'javax', name: 'javaee-api', version:'7.0'
+    implementation project(':ejb-ejb')
+}
+
+war {
+    archiveName = baseName + '.' + extension
+}
+

--- a/src/test/resources/multi-module-loose-ear-test/ejb-war/src/main/java/wasdev/ejb/ejb/web/EJBServlet.java
+++ b/src/test/resources/multi-module-loose-ear-test/ejb-war/src/main/java/wasdev/ejb/ejb/web/EJBServlet.java
@@ -1,0 +1,34 @@
+package wasdev.ejb.ejb.web;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.ejb.EJB;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import wasdev.ejb.ejb.SampleStatelessBean;
+
+/**
+ * A servlet which injects a stateless EJB
+ */
+@WebServlet({"/", "/ejbServlet"})
+public class EJBServlet extends HttpServlet {
+    private static final long serialVersionUID = 1L;
+
+    @EJB
+    SampleStatelessBean statelessBean;
+
+    @Override
+    protected void doGet(HttpServletRequest request,
+                         HttpServletResponse response) throws IOException {
+        PrintWriter writer = response.getWriter();
+
+        // Call hello method on a stateless session bean
+        String message = statelessBean.hello();
+
+        writer.println(message);
+    }
+}

--- a/src/test/resources/multi-module-loose-ear-test/settings.gradle
+++ b/src/test/resources/multi-module-loose-ear-test/settings.gradle
@@ -1,0 +1,8 @@
+rootProject.name = 'ejb'
+include ':ejb-ejb'
+include ':ejb-war'
+include ':ejb-ear'
+
+project(':ejb-ejb').projectDir = "$rootDir/ejb-ejb" as File
+project(':ejb-war').projectDir = "$rootDir/ejb-war" as File
+project(':ejb-ear').projectDir = "$rootDir/ejb-ear" as File


### PR DESCRIPTION
The loose ear logic will now check for additional project dependencies inside of war project dependencies and handle them accordingly.