### PR TITLE
Enhance error handling for tasks

### DIFF
--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractServerTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractServerTask.groovy
@@ -208,6 +208,20 @@ abstract class AbstractServerTask extends AbstractLibertyTask {
         }
     }
 
+    // Use this method to copy over the server.xml file from the defaultServer template.
+    // Returns true if the server.xml file does not exist and the defaultServer template server.xml file is copied over, false otherwise.
+    protected boolean copyDefaultServerTemplate(File installDir, File serverDir) {
+        File serverXmlFile = new File(serverDir, "server.xml")
+        if (!serverXmlFile.exists()) {
+            File defaultServerTemplate = new File(installDir, "templates/servers/defaultServer/server.xml")
+            if (defaultServerTemplate.exists()) {
+                Files.copy(defaultServerTemplate.toPath(), serverXmlFile.toPath(), StandardCopyOption.REPLACE_EXISTING)
+                return true;
+            }
+        }
+        return false;
+    }
+    
     protected void copyConfigDirectory() {
         //merge default server.env with one in config directory
         File configDirServerEnv = new File(server.configDirectory, "server.env")

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/StatusTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/StatusTask.groovy
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2014, 2019.
+ * (C) Copyright IBM Corporation 2014, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,9 +29,23 @@ class StatusTask extends AbstractServerTask {
 
     @TaskAction
     void status() {
-        def status_process = new ProcessBuilder(buildCommand("status")).redirectErrorStream(true).start()
-        status_process.inputStream.eachLine {
-            println it
+        if (isLibertyInstalledAndValid(project)) {
+            File serverDir = getServerDir(project)
+            if (serverDir.exists()) {
+                File serverXmlFile = new File(serverDir,"server.xml")
+                if (serverXmlFile.exists()) {
+                    def status_process = new ProcessBuilder(buildCommand("status")).redirectErrorStream(true).start()
+                    status_process.inputStream.eachLine {
+                        println it
+                    }
+                } else {
+        	        logger.error ('The server status cannot be checked. There is no server.xml file in the server.')
+                }
+            } else {
+        	    logger.error ('The server status cannot be checked. The server has not been created.')
+            }
+        } else {
+            logger.error ('The server status cannot be checked. The runtime has not been installed.')
         }
     }
 

--- a/src/test/groovy/io/openliberty/tools/gradle/LibertyTest.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/LibertyTest.groovy
@@ -28,6 +28,7 @@ class LibertyTest extends AbstractIntegrationTest{
     static File resourceDir = new File("build/resources/test/liberty-test")
     static File buildDir = new File(integTestDir, "/liberty-test")
     static String buildFilename = "build.gradle"
+    static File serverXmlFile = new File(buildDir, "/build/wlp/usr/servers/LibertyProjectServer/server.xml")
 
     @BeforeClass
     public static void setup() {
@@ -180,10 +181,30 @@ class LibertyTest extends AbstractIntegrationTest{
            throw new AssertionError ("Fail on task libertyStart after second clean.", e)
         }
 
+        // try deleting the server.xml and see if we can recover
+        assert serverXmlFile.exists() : 'server.xml file does not exist in LibertyProjectServer'
+        assert serverXmlFile.delete() : 'server.xml could not be deleted in LibertyProjectServer'
+
         try{
            runTasks(buildDir, 'libertyStop')
         } catch (Exception e) {
-           throw new AssertionError ("Fail on task libertyStop after libertyStart.", e)
+           throw new AssertionError ("Fail on task libertyStop after deleting server.xml.", e)
+        }
+
+        assert !serverXmlFile.exists() : 'server.xml file unexpectedly exists in LibertyProjectServer after libertyStop'
+
+        try{
+            runTasks(buildDir, 'libertyStatus')
+        } catch (Exception e) {
+            throw new AssertionError ("Fail on task libertyStatus after deleting server.xml.", e)
+        }
+
+        assert serverXmlFile.exists() : 'server.xml file does not exist in LibertyProjectServer after libertyStatus'
+
+        try{
+            runTasks(buildDir, 'clean')
+        } catch (Exception e) {
+            throw new AssertionError ("Fail on task clean after deleting server.xml.", e)
         }
     }
 


### PR DESCRIPTION
Fixes #850 

The following logic has been added to help deal with a missing `server.xml` file in a running Liberty server.

CreateTask
- change the `upToDateWhen` check to include the existence of the `server.xml` file
- change the create logic to handle the server directory existing but the `server.xml` file not existing by copying over the `defaultServer` template server.xml file (this file will get overwritten by the project provided `server.xml` file if one exists)

RunTask
- change the shutdown hook logic to handle the server directory existing but the `server.xml` file not existing by copying over the `defaultServer` template server.xml file (this file will get overwritten by the project provided `server.xml` file if one exists)

StatusTask
- check for existence of `server.xml` before issuing the `server status` command

StopTask
- change the stop logic to handle the server directory existing but the `server.xml` file not existing by copying over the `defaultServer` template server.xml file 
- after the server stops, delete the `server.xml` file that was copied over (this will allow the CreateTask to detect that it is not upToDate and replace with the appropriate server.xml file on a subsequent task)