### PR TITLE
update readme for min gradle version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To build the plugin and run the integration tests execute the following commands
 
 ### Gradle Support
 
-The Liberty Gradle Plugin supports running with Gradle 7.3+ and Gradle 8.x as of release 3.6. The 7.3 version of Gradle is when full support for Java 17 was introduced. When using a Gradle wrapper, ensure the wrapper version matches the version of Gradle being used.
+The Liberty Gradle Plugin supports running with Gradle 7.6+ and Gradle 8.x as of release 3.7. When using a Gradle wrapper, ensure the wrapper version matches the version of Gradle being used.
 
 ### Java Support
 


### PR DESCRIPTION
Fixes #857 

It has been reported that running our plugin version `3.7` with versions of Gradle < `7.6` runs into the exception described in the referenced issue. This is a known problem in Gradle related to the ASM version being used. I am updating the README to indicate a minimum version of `7.6` is required, and will update the release notes also.

Running a project locally with `7.5`, I saw the following stack trace:

```
Caused by: java.io.IOException: Failed to process the entry 'META-INF/versions/19/com/fasterxml/jackson/core/io/doubleparser/FastDoubleSwar.class' from '/Users/cherylking/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.15.2/jackson-core-2.15.2.jar'
        at org.gradle.internal.classpath.InstrumentingClasspathFileTransformer.lambda$visitEntries$1(InstrumentingClasspathFileTransformer.java:161)
        at org.gradle.internal.classpath.ClasspathWalker.visitJarContents(ClasspathWalker.java:91)
        at org.gradle.internal.classpath.ClasspathWalker.visit(ClasspathWalker.java:55)
        at org.gradle.internal.classpath.InstrumentingClasspathFileTransformer.visitEntries(InstrumentingClasspathFileTransformer.java:148)
        at org.gradle.internal.classpath.InstrumentingClasspathFileTransformer.lambda$instrument$0(InstrumentingClasspathFileTransformer.java:139)
        at org.gradle.internal.classpath.ClasspathBuilder.buildJar(ClasspathBuilder.java:66)
        at org.gradle.internal.classpath.ClasspathBuilder.jar(ClasspathBuilder.java:53)
        ... 9 more
Caused by: java.lang.IllegalArgumentException: Unsupported class file major version 63
        at org.objectweb.asm.ClassReader.<init>(ClassReader.java:199)
        at org.objectweb.asm.ClassReader.<init>(ClassReader.java:180)
        at org.objectweb.asm.ClassReader.<init>(ClassReader.java:166)
        at org.gradle.internal.classpath.InstrumentingClasspathFileTransformer.lambda$visitEntries$1(InstrumentingClasspathFileTransformer.java:151)
        ... 15 more
```