### PR TITLE
Groovy File deprecation fix part 1

### DIFF
--- a/src/main/groovy/io/openliberty/tools/gradle/Liberty.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/Liberty.groovy
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2014, 2021.
+ * (C) Copyright IBM Corporation 2014, 2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -175,7 +175,7 @@ class Liberty implements Plugin<Project> {
             return installDir
         } else if (project.liberty.installDir == null) {
             if (project.liberty.baseDir == null) {
-                return new File(project.buildDir, 'wlp')
+                return new File(project.layout.buildDirectory.asFile.get(), 'wlp')
             } else {
                 return new File(project.liberty.baseDir, 'wlp')
             }

--- a/src/main/groovy/io/openliberty/tools/gradle/Liberty.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/Liberty.groovy
@@ -175,7 +175,7 @@ class Liberty implements Plugin<Project> {
             return installDir
         } else if (project.liberty.installDir == null) {
             if (project.liberty.baseDir == null) {
-                return new File(project.layout.buildDirectory.asFile.get(), 'wlp')
+                return new File(project.getLayout().getBuildDirectory().getAsFile().get(), 'wlp')
             } else {
                 return new File(project.liberty.baseDir, 'wlp')
             }

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractFeatureTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractFeatureTask.groovy
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2021, 2023.
+ * (C) Copyright IBM Corporation 2021, 2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,13 +23,12 @@ import io.openliberty.tools.common.plugins.util.PluginExecutionException
 import io.openliberty.tools.common.plugins.util.PluginScenarioException
 import io.openliberty.tools.common.plugins.util.ServerFeatureUtil
 import io.openliberty.tools.gradle.utils.ArtifactDownloadUtil
-import java.util.Map.Entry
-import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.options.Option
-import org.gradle.testfixtures.ProjectBuilder
-import org.gradle.api.artifacts.Configuration
+
+import java.util.Map.Entry
 
 public class AbstractFeatureTask extends AbstractServerTask {
 
@@ -297,7 +296,7 @@ public class AbstractFeatureTask extends AbstractServerTask {
     private void createNewInstallFeatureUtil(Set<String> pluginListedEsas, List<ProductProperties> propertiesList, String openLibertyVerion, String containerName, List<String> additionalJsons, Collection<Map<String,String>> keyMap) throws PluginExecutionException {
         try {
 			logger.info("Feature signature verify option: " + server.features.verify)
-            util = new InstallFeatureTaskUtil(getInstallDir(project), project.getBuildDir(), server.features.from, server.features.to, pluginListedEsas, propertiesList, openLibertyVerion, containerName, additionalJsons, server.features.verify, keyMap)
+            util = new InstallFeatureTaskUtil(getInstallDir(project), project.getLayout().getBuildDirectory().getAsFile().get(), server.features.from, server.features.to, pluginListedEsas, propertiesList, openLibertyVerion, containerName, additionalJsons, server.features.verify, keyMap)
         } catch (PluginScenarioException e) {
             logger.debug("Exception received: " + e.getMessage(), (Throwable) e)
             logger.debug("Installing features from installUtility.")

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractLibertyTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractLibertyTask.groovy
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2017, 2023.
+ * (C) Copyright IBM Corporation 2017, 2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,13 @@
 package io.openliberty.tools.gradle.tasks
 
 import io.openliberty.tools.gradle.Liberty
-
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.Project
-import org.gradle.api.artifacts.Dependency
 import org.gradle.api.Task
+import org.gradle.api.artifacts.Dependency
 import org.gradle.api.tasks.Internal
+import groovy.xml.XmlParser
 
 abstract class AbstractLibertyTask extends DefaultTask {
 
@@ -35,7 +35,7 @@ abstract class AbstractLibertyTask extends DefaultTask {
     protected boolean isInstallDirChanged(Project project) {
 
         XmlParser pluginXmlParser = new XmlParser()
-        Node libertyPluginConfig = pluginXmlParser.parse(new File(project.buildDir, 'liberty-plugin-config.xml'))
+        Node libertyPluginConfig = pluginXmlParser.parse(new File(project.layout.buildDirectory.asFile.get(), 'liberty-plugin-config.xml'))
         if (!libertyPluginConfig.getAt('installDirectory').isEmpty()) {
             Node installDirNode = libertyPluginConfig.getAt('installDirectory').get(0)
             File previousInstallDir = new File(installDirNode.text())

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractLibertyTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractLibertyTask.groovy
@@ -35,7 +35,7 @@ abstract class AbstractLibertyTask extends DefaultTask {
     protected boolean isInstallDirChanged(Project project) {
 
         XmlParser pluginXmlParser = new XmlParser()
-        Node libertyPluginConfig = pluginXmlParser.parse(new File(project.layout.buildDirectory.asFile.get(), 'liberty-plugin-config.xml'))
+        Node libertyPluginConfig = pluginXmlParser.parse(new File(project.getLayout().getBuildDirectory().getAsFile().get(), 'liberty-plugin-config.xml'))
         if (!libertyPluginConfig.getAt('installDirectory').isEmpty()) {
             Node installDirNode = libertyPluginConfig.getAt('installDirectory').get(0)
             File previousInstallDir = new File(installDirNode.text())

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractServerTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractServerTask.groovy
@@ -16,45 +16,34 @@
 package io.openliberty.tools.gradle.tasks
 
 import groovy.xml.StreamingMarkupBuilder
+import groovy.xml.XmlParser
+import groovy.xml.XmlNodePrinter
+import io.openliberty.tools.ant.ServerTask
 import io.openliberty.tools.common.plugins.config.ApplicationXmlDocument
 import io.openliberty.tools.common.plugins.config.ServerConfigDocument
+import io.openliberty.tools.common.plugins.config.ServerConfigXmlDocument
+import io.openliberty.tools.common.plugins.util.DevUtil
 import io.openliberty.tools.common.plugins.util.ServerFeatureUtil
 import io.openliberty.tools.gradle.utils.CommonLogger
-
 import org.apache.commons.io.FileUtils
+import org.apache.commons.io.FilenameUtils
+import org.apache.commons.io.filefilter.FileFilterUtils
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ModuleDependency
-import org.gradle.api.tasks.bundling.War
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.bundling.War
 import org.gradle.plugins.ear.Ear
 
+import javax.xml.parsers.ParserConfigurationException
+import javax.xml.transform.TransformerException
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
-
-import org.apache.commons.io.FilenameUtils
-import org.apache.commons.io.filefilter.FileFilterUtils
-
-import io.openliberty.tools.ant.ServerTask
-import io.openliberty.tools.common.plugins.config.ServerConfigXmlDocument;
-
-import java.util.ArrayList
-import java.util.List
-import java.util.HashMap
-import java.util.Map
 import java.util.Map.Entry
-import java.util.Properties
-import java.util.HashSet
-import java.util.Set
-import java.util.EnumSet
-import java.util.regex.Pattern
 import java.util.regex.Matcher
-
-import javax.xml.transform.TransformerException
-import javax.xml.parsers.ParserConfigurationException
-import io.openliberty.tools.common.plugins.util.DevUtil;
+import java.util.regex.Pattern
 
 abstract class AbstractServerTask extends AbstractLibertyTask {
 
@@ -742,7 +731,7 @@ abstract class AbstractServerTask extends AbstractLibertyTask {
 
     protected void writeServerPropertiesToXml(Project project) {
         XmlParser pluginXmlParser = new XmlParser()
-        Node libertyPluginConfig = pluginXmlParser.parse(new File(project.buildDir, 'liberty-plugin-config.xml'))
+        Node libertyPluginConfig = pluginXmlParser.parse(new File(project.layout.buildDirectory.asFile.get(), 'liberty-plugin-config.xml'))
         if (libertyPluginConfig.getAt('servers').isEmpty()) {
             libertyPluginConfig.appendNode('servers')
         } else {
@@ -758,14 +747,14 @@ abstract class AbstractServerTask extends AbstractLibertyTask {
 
         libertyPluginConfig.getAt('servers')[0].append(serverNode)
 
-        new File( project.buildDir, 'liberty-plugin-config.xml' ).withWriter('UTF-8') { output ->
+        new File( project.layout.buildDirectory.asFile.get(), 'liberty-plugin-config.xml' ).withWriter('UTF-8') { output ->
             output << new StreamingMarkupBuilder().bind { mkp.xmlDeclaration(encoding: 'UTF-8', version: '1.0' ) }
             XmlNodePrinter printer = new XmlNodePrinter( new PrintWriter(output) )
             printer.preserveWhitespace = true
             printer.print( libertyPluginConfig )
         }
 
-        logger.info ("Adding Liberty plugin config info to ${project.buildDir}/liberty-plugin-config.xml.")
+        logger.info ("Adding Liberty plugin config info to ${project.layout.buildDirectory.asFile.get()}/liberty-plugin-config.xml.")
     }
 
     private void writeBootstrapProperties(File file, Properties properties, Map<String, String> projectProperties) throws IOException {
@@ -1109,7 +1098,7 @@ abstract class AbstractServerTask extends AbstractLibertyTask {
                 File appFile = depArtifact
                 if (dep instanceof ModuleDependency && server.stripVersion && depArtifact.getName().contains(dep.getVersion())) {
                     String noVersionName = depArtifact.getName().minus("-" + dep.getVersion()) //Assuming default Gradle naming scheme
-                    File noVersionDependencyFile = new File(project.getBuildDir(), 'libs/' + noVersionName) //Copying the file to build/libs with no version
+                    File noVersionDependencyFile = new File(project.getLayout().getBuildDirectory().asFile.get(), 'libs/' + noVersionName) //Copying the file to build/libs with no version
                     FileUtils.copyFile(depArtifact, noVersionDependencyFile)
                     appFile = noVersionDependencyFile
                 }
@@ -1220,7 +1209,7 @@ abstract class AbstractServerTask extends AbstractLibertyTask {
         }
 
         if (container) {
-            File devcDestDir = new File(new File(project.buildDir, DevUtil.DEVC_HIDDEN_FOLDER), appsDir)
+            File devcDestDir = new File(new File(project.layout.buildDirectory.asFile.get(), DevUtil.DEVC_HIDDEN_FOLDER), appsDir)
             return (new File(devcDestDir, looseConfigFileName));
         } else {
             File destDir = new File(getServerDir(project), appsDir)

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractServerTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractServerTask.groovy
@@ -731,7 +731,7 @@ abstract class AbstractServerTask extends AbstractLibertyTask {
 
     protected void writeServerPropertiesToXml(Project project) {
         XmlParser pluginXmlParser = new XmlParser()
-        Node libertyPluginConfig = pluginXmlParser.parse(new File(project.layout.buildDirectory.asFile.get(), 'liberty-plugin-config.xml'))
+        Node libertyPluginConfig = pluginXmlParser.parse(new File(project.getLayout().getBuildDirectory().getAsFile().get(), 'liberty-plugin-config.xml'))
         if (libertyPluginConfig.getAt('servers').isEmpty()) {
             libertyPluginConfig.appendNode('servers')
         } else {
@@ -747,14 +747,14 @@ abstract class AbstractServerTask extends AbstractLibertyTask {
 
         libertyPluginConfig.getAt('servers')[0].append(serverNode)
 
-        new File( project.layout.buildDirectory.asFile.get(), 'liberty-plugin-config.xml' ).withWriter('UTF-8') { output ->
+        new File( project.getLayout().getBuildDirectory().getAsFile().get(), 'liberty-plugin-config.xml' ).withWriter('UTF-8') { output ->
             output << new StreamingMarkupBuilder().bind { mkp.xmlDeclaration(encoding: 'UTF-8', version: '1.0' ) }
             XmlNodePrinter printer = new XmlNodePrinter( new PrintWriter(output) )
             printer.preserveWhitespace = true
             printer.print( libertyPluginConfig )
         }
 
-        logger.info ("Adding Liberty plugin config info to ${project.layout.buildDirectory.asFile.get()}/liberty-plugin-config.xml.")
+        logger.info ("Adding Liberty plugin config info to ${project.getLayout().getBuildDirectory().getAsFile().get()}/liberty-plugin-config.xml.")
     }
 
     private void writeBootstrapProperties(File file, Properties properties, Map<String, String> projectProperties) throws IOException {
@@ -1209,7 +1209,7 @@ abstract class AbstractServerTask extends AbstractLibertyTask {
         }
 
         if (container) {
-            File devcDestDir = new File(new File(project.layout.buildDirectory.asFile.get(), DevUtil.DEVC_HIDDEN_FOLDER), appsDir)
+            File devcDestDir = new File(new File(project.getLayout().getBuildDirectory().getAsFile().get(), DevUtil.DEVC_HIDDEN_FOLDER), appsDir)
             return (new File(devcDestDir, looseConfigFileName));
         } else {
             File destDir = new File(getServerDir(project), appsDir)

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/CreateTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/CreateTask.groovy
@@ -69,7 +69,7 @@ class CreateTask extends AbstractServerTask {
 
     @InputFile
     File getPluginConfigXml() {
-        return new File(project.layout.buildDirectory.asFile.get(), 'liberty-plugin-config.xml')
+        return new File(project.getLayout().getBuildDirectory().getAsFile().get(), 'liberty-plugin-config.xml')
     }
 
     @TaskAction
@@ -96,12 +96,12 @@ class CreateTask extends AbstractServerTask {
     }
 
     protected boolean isServerDirChanged(Project project) {
-        if (!project.layout.buildDirectory.asFile.get().exists() || !(new File(project.layout.buildDirectory.asFile.get(), 'liberty-plugin-config.xml')).exists()) {
+        if (!project.getLayout().getBuildDirectory().getAsFile().get().exists() || !(new File(project.getLayout().getBuildDirectory().getAsFile().get(), 'liberty-plugin-config.xml')).exists()) {
             return false
         }
 
         XmlParser pluginXmlParser = new XmlParser()
-        Node libertyPluginConfig = pluginXmlParser.parse(new File(project.layout.buildDirectory.asFile.get(), 'liberty-plugin-config.xml'))
+        Node libertyPluginConfig = pluginXmlParser.parse(new File(project.getLayout().getBuildDirectory().getAsFile().get(), 'liberty-plugin-config.xml'))
         if (!libertyPluginConfig.getAt('serverDirectory').isEmpty()) {
             File currentDir = getServerDir(project)
             File previousDir = new File(libertyPluginConfig.getAt('serverDirectory')[0].value)

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/CreateTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/CreateTask.groovy
@@ -16,13 +16,12 @@
 package io.openliberty.tools.gradle.tasks
 
 import io.openliberty.tools.gradle.Liberty
-
+import org.gradle.api.Project
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
-import org.gradle.api.logging.LogLevel
-import org.gradle.api.Project
+import groovy.xml.XmlParser
 
 class CreateTask extends AbstractServerTask {
 
@@ -70,7 +69,7 @@ class CreateTask extends AbstractServerTask {
 
     @InputFile
     File getPluginConfigXml() {
-        return new File(project.buildDir, 'liberty-plugin-config.xml')
+        return new File(project.layout.buildDirectory.asFile.get(), 'liberty-plugin-config.xml')
     }
 
     @TaskAction
@@ -97,12 +96,12 @@ class CreateTask extends AbstractServerTask {
     }
 
     protected boolean isServerDirChanged(Project project) {
-        if (!project.buildDir.exists() || !(new File(project.buildDir, 'liberty-plugin-config.xml')).exists()) {
+        if (!project.layout.buildDirectory.asFile.get().exists() || !(new File(project.layout.buildDirectory.asFile.get(), 'liberty-plugin-config.xml')).exists()) {
             return false
         }
 
         XmlParser pluginXmlParser = new XmlParser()
-        Node libertyPluginConfig = pluginXmlParser.parse(new File(project.buildDir, 'liberty-plugin-config.xml'))
+        Node libertyPluginConfig = pluginXmlParser.parse(new File(project.layout.buildDirectory.asFile.get(), 'liberty-plugin-config.xml'))
         if (!libertyPluginConfig.getAt('serverDirectory').isEmpty()) {
             File currentDir = getServerDir(project)
             File previousDir = new File(libertyPluginConfig.getAt('serverDirectory')[0].value)

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DeployTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DeployTask.groovy
@@ -250,7 +250,7 @@ class DeployTask extends AbstractServerTask {
         File destDir = new File(getServerDir(project), appsDir)
         File looseConfigFile = new File(destDir, looseConfigFileName)
         
-        File devcDestDir = new File(new File(project.buildDir, DevUtil.DEVC_HIDDEN_FOLDER), appsDir)
+        File devcDestDir = new File(new File(project.getLayout().getBuildDirectory().getAsFile().get(), DevUtil.DEVC_HIDDEN_FOLDER), appsDir)
         File devcLooseConfigFile = new File(devcDestDir, looseConfigFileName)
 
         LooseConfigData config = new LooseConfigData()
@@ -312,8 +312,8 @@ class DeployTask extends AbstractServerTask {
 
                 if (server.deploy.copyLibsDirectory == null) { // in container mode, copy dependencies from .m2 dir to the build dir to mount in container
                     // if buildDir is subdirectory of projectDir, use buildDir/libs.  Otherwise use projectDir/build/libs since it must be under the project root in order to make use of DEVMODE_PROJECT_ROOT
-                    if (project.getBuildDir().getCanonicalFile().toPath().startsWith(project.getProjectDir().getCanonicalFile().toPath())) {
-                        server.deploy.copyLibsDirectory = new File(project.getBuildDir(), LIBS);
+                    if (project.getLayout().getBuildDirectory().getAsFile().get().getCanonicalFile().toPath().startsWith(project.getProjectDir().getCanonicalFile().toPath())) {
+                        server.deploy.copyLibsDirectory = new File(project.getLayout().getBuildDirectory().getAsFile().get(), LIBS);
                         logger.debug("Setting copyLibsDirectory to " + server.deploy.copyLibsDirectory);
                     } else {
                         server.deploy.copyLibsDirectory = new File(project.getProjectDir(), BUILD_LIBS);
@@ -343,7 +343,7 @@ class DeployTask extends AbstractServerTask {
         addWarEmbeddedLib(looseWar.getDocumentRoot(), looseWar, task);
 
         //add Manifest file
-        File manifestFile = new File(project.buildDir.getAbsolutePath() + "/tmp/war/MANIFEST.MF")
+        File manifestFile = new File(project.getLayout().getBuildDirectory().getAsFile().get().getAbsolutePath() + "/tmp/war/MANIFEST.MF")
         looseWar.addManifestFile(manifestFile)
     }
 
@@ -406,12 +406,12 @@ class DeployTask extends AbstractServerTask {
         LooseEarApplication looseEar = new LooseEarApplication(task, config);
         looseEar.addSourceDir();
         looseEar.addApplicationXmlFile();
-        
+
         //Checking ear plugin dependency configurations to determine loose-ear content
         processDeployDependencies(looseEar, task)
         processEarlibDependencies(looseEar, task)
 
-        File manifestFile = new File(project.buildDir.getAbsolutePath() + "/tmp/ear/MANIFEST.MF")
+        File manifestFile = new File(project.getLayout().getBuildDirectory().getAsFile().get().getAbsolutePath() + "/tmp/ear/MANIFEST.MF")
         looseEar.addManifestFile(manifestFile)
     }
 

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
@@ -1254,7 +1254,7 @@ class DevTask extends AbstractFeatureTask {
 
         // Instantiate util before any child gradle tasks launched so it can help find available port if needed
         try {
-            this.util = new DevTaskUtil(project.layout.buildDirectory.asFile.get(), serverInstallDir, getUserDir(project, serverInstallDir),
+            this.util = new DevTaskUtil(project.getLayout().getBuildDirectory().getAsFile().get(), serverInstallDir, getUserDir(project, serverInstallDir),
                 serverDirectory, sourceDirectory, testSourceDirectory, configDirectory, project.getRootDir(),
                 resourceDirs, changeOnDemandTestsAction.booleanValue(), hotTests.booleanValue(), skipTests.booleanValue(), skipInstallFeature.booleanValue(), artifactId, serverStartTimeout.intValue(),
                 verifyAppStartTimeout.intValue(), verifyAppStartTimeout.intValue(), compileWait.doubleValue(),
@@ -1401,9 +1401,9 @@ class DevTask extends AbstractFeatureTask {
     }
 
     private boolean isInstallDirChanged(Project project, File currentInstallDir) {
-        if (project.layout.buildDirectory.asFile.get().exists() && new File(project.layout.buildDirectory.asFile.get(), 'liberty-plugin-config.xml').exists()) {
+        if (project.getLayout().getBuildDirectory().getAsFile().get().exists() && new File(project.getLayout().getBuildDirectory().getAsFile().get(), 'liberty-plugin-config.xml').exists()) {
             XmlParser pluginXmlParser = new XmlParser()
-            Node libertyPluginConfig = pluginXmlParser.parse(new File(project.layout.buildDirectory.asFile.get(), 'liberty-plugin-config.xml'))
+            Node libertyPluginConfig = pluginXmlParser.parse(new File(project.getLayout().getBuildDirectory().getAsFile().get(), 'liberty-plugin-config.xml'))
             if (!libertyPluginConfig.getAt('installDirectory').isEmpty()) {
                 Node installDirNode = libertyPluginConfig.getAt('installDirectory').get(0)
                 String installDirValue = installDirNode.text()

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2019, 2023.
+ * (C) Copyright IBM Corporation 2019, 2023, 2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,6 +49,7 @@ import io.openliberty.tools.common.plugins.util.BinaryScannerUtil
 import java.util.concurrent.TimeUnit
 import java.util.Map.Entry
 import java.nio.file.Path;
+import groovy.xml.XmlParser
 
 class DevTask extends AbstractFeatureTask {
 
@@ -1253,7 +1254,7 @@ class DevTask extends AbstractFeatureTask {
 
         // Instantiate util before any child gradle tasks launched so it can help find available port if needed
         try {
-            this.util = new DevTaskUtil(project.buildDir, serverInstallDir, getUserDir(project, serverInstallDir),
+            this.util = new DevTaskUtil(project.layout.buildDirectory.asFile.get(), serverInstallDir, getUserDir(project, serverInstallDir),
                 serverDirectory, sourceDirectory, testSourceDirectory, configDirectory, project.getRootDir(),
                 resourceDirs, changeOnDemandTestsAction.booleanValue(), hotTests.booleanValue(), skipTests.booleanValue(), skipInstallFeature.booleanValue(), artifactId, serverStartTimeout.intValue(),
                 verifyAppStartTimeout.intValue(), verifyAppStartTimeout.intValue(), compileWait.doubleValue(),
@@ -1400,9 +1401,9 @@ class DevTask extends AbstractFeatureTask {
     }
 
     private boolean isInstallDirChanged(Project project, File currentInstallDir) {
-        if (project.buildDir.exists() && new File(project.buildDir, 'liberty-plugin-config.xml').exists()) {
+        if (project.layout.buildDirectory.asFile.get().exists() && new File(project.layout.buildDirectory.asFile.get(), 'liberty-plugin-config.xml').exists()) {
             XmlParser pluginXmlParser = new XmlParser()
-            Node libertyPluginConfig = pluginXmlParser.parse(new File(project.buildDir, 'liberty-plugin-config.xml'))
+            Node libertyPluginConfig = pluginXmlParser.parse(new File(project.layout.buildDirectory.asFile.get(), 'liberty-plugin-config.xml'))
             if (!libertyPluginConfig.getAt('installDirectory').isEmpty()) {
                 Node installDirNode = libertyPluginConfig.getAt('installDirectory').get(0)
                 String installDirValue = installDirNode.text()

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/InstallFeatureTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/InstallFeatureTask.groovy
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2014, 2023.
+ * (C) Copyright IBM Corporation 2014, 2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -102,7 +102,7 @@ class InstallFeatureTask extends AbstractFeatureTask {
     void installFeatureFromAnt() {
         // Set default server.outputDir to liberty-alt-output-dir for installFeature task.
         if (getOutputDir(project).equals(getUserDir(project).toString() + "/servers")) {
-            server.outputDir = new File(project.getBuildDir(), "liberty-alt-output-dir");
+            server.outputDir = new File(project.getLayout().getBuildDirectory().getAsFile().get(), "liberty-alt-output-dir");
         }
 
         def params = buildAntParams()

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/InstallLibertyTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/InstallLibertyTask.groovy
@@ -48,7 +48,7 @@ class InstallLibertyTask extends AbstractLibertyTask {
         outputs.upToDateWhen {
             // ensure a Liberty installation exists at the install directory
             getInstallDir(project).exists() && new File(getInstallDir(project), 'lib/ws-launch.jar').exists() && 
-            project.layout.buildDirectory.asFile.get().exists() && new File(project.layout.buildDirectory.asFile.get(), 'liberty-plugin-config.xml').exists() &&
+            project.getLayout().getBuildDirectory().getAsFile().get().exists() && new File(project.getLayout().getBuildDirectory().getAsFile().get(), 'liberty-plugin-config.xml').exists() &&
             !isInstallDirChanged(project)
         }
     }
@@ -119,7 +119,7 @@ class InstallLibertyTask extends AbstractLibertyTask {
 
             String licenseFilePath = project.configurations.getByName('libertyLicense').getAsPath()
             if (licenseFilePath) {
-                def command = "java -jar " + licenseFilePath + " --acceptLicense " + project.layout.buildDirectory.asFile.get()
+                def command = "java -jar " + licenseFilePath + " --acceptLicense " + project.getLayout().getBuildDirectory().getAsFile().get()
                 def process = command.execute()
                 process.waitFor()
             }
@@ -129,7 +129,7 @@ class InstallLibertyTask extends AbstractLibertyTask {
 
     protected void updatePluginXmlFile() {
         XmlParser pluginXmlParser = new XmlParser()
-        Node libertyPluginConfig = pluginXmlParser.parse(new File(project.layout.buildDirectory.asFile.get(), 'liberty-plugin-config.xml'))
+        Node libertyPluginConfig = pluginXmlParser.parse(new File(project.getLayout().getBuildDirectory().getAsFile().get(), 'liberty-plugin-config.xml'))
 
         Node installDirNode = libertyPluginConfig.getAt('installDirectory').isEmpty() ? libertyPluginConfig.appendNode('installDirectory') : libertyPluginConfig.getAt('installDirectory').get(0)
         installDirNode.setValue(getInstallDir(project).toString())
@@ -181,36 +181,36 @@ class InstallLibertyTask extends AbstractLibertyTask {
             }
         }
 
-        new File( project.layout.buildDirectory.asFile.get(), 'liberty-plugin-config.xml' ).withWriter('UTF-8') { output ->
+        new File( project.getLayout().getBuildDirectory().getAsFile().get(), 'liberty-plugin-config.xml' ).withWriter('UTF-8') { output ->
             output << new StreamingMarkupBuilder().bind { mkp.xmlDeclaration(encoding: 'UTF-8', version: '1.0' ) }
             XmlNodePrinter printer = new XmlNodePrinter( new PrintWriter(output) )
             printer.preserveWhitespace = true
             printer.print( libertyPluginConfig )
         }
 
-        logger.info ("Updating Liberty plugin config info at ${project.layout.buildDirectory.asFile.get()}/liberty-plugin-config.xml.")
+        logger.info ("Updating Liberty plugin config info at ${project.getLayout().getBuildDirectory().getAsFile().get()}/liberty-plugin-config.xml.")
 
     }
 
     protected void createPluginXmlFile(boolean isExisting) {
         if(!this.state.upToDate) {
-            if (!project.layout.buildDirectory.asFile.get().exists()) {
-                logger.info ("Creating missing project buildDir at ${project.layout.buildDirectory.asFile.get()}.")
-                project.layout.buildDirectory.asFile.get().mkdirs()
+            if (!project.getLayout().getBuildDirectory().getAsFile().get().exists()) {
+                logger.info ("Creating missing project buildDir at ${project.getLayout().getBuildDirectory().getAsFile().get()}.")
+                project.getLayout().getBuildDirectory().getAsFile().get().mkdirs()
             }
 
             // if the file already exists, update it instead of replacing it
-            if (new File(project.layout.buildDirectory.asFile.get(), 'liberty-plugin-config.xml').exists()) {
+            if (new File(project.getLayout().getBuildDirectory().getAsFile().get(), 'liberty-plugin-config.xml').exists()) {
                 updatePluginXmlFile()
             } else {
-                new File(project.layout.buildDirectory.asFile.get(), 'liberty-plugin-config.xml').withWriter { writer ->
+                new File(project.getLayout().getBuildDirectory().getAsFile().get(), 'liberty-plugin-config.xml').withWriter { writer ->
                     def xmlDoc = new MarkupBuilder(writer)
                     xmlDoc.mkp.xmlDeclaration(version: "1.0", encoding: "UTF-8")
                     xmlDoc.'liberty-plugin-config'('version':'2.0') {
                         outputLibertyPropertiesToXml(xmlDoc, isExisting)
                     }
                 }
-                logger.info ("Creating Liberty plugin config info to ${project.layout.buildDirectory.asFile.get()}/liberty-plugin-config.xml.")
+                logger.info ("Creating Liberty plugin config info to ${project.getLayout().getBuildDirectory().getAsFile().get()}/liberty-plugin-config.xml.")
             }
         }
     }
@@ -322,7 +322,7 @@ class InstallLibertyTask extends AbstractLibertyTask {
         }
 
         if (project.liberty.baseDir == null) {
-           result.put('baseDir', project.layout.buildDirectory.asFile.get())
+           result.put('baseDir', project.getLayout().getBuildDirectory().getAsFile().get())
         } else {
            result.put('baseDir', project.liberty.baseDir)
         }

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/InstallLibertyTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/InstallLibertyTask.groovy
@@ -15,28 +15,23 @@
  */
 package io.openliberty.tools.gradle.tasks
 
-import javax.xml.parsers.*
+import groovy.xml.MarkupBuilder
 import groovy.xml.StreamingMarkupBuilder
-
+import org.gradle.api.GradleException
 import org.gradle.api.Project
-import org.gradle.api.tasks.TaskAction
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.ResolveException
+import org.gradle.api.artifacts.ResolvedConfiguration
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
-import org.gradle.api.logging.LogLevel
-import org.gradle.api.artifacts.Configuration
-import org.gradle.api.artifacts.ResolvedConfiguration
-import org.gradle.api.artifacts.ResolvedArtifact
-import org.gradle.api.artifacts.ResolveException
-import org.gradle.api.artifacts.Dependency
-import org.gradle.api.artifacts.repositories.MavenArtifactRepository
-import groovy.xml.MarkupBuilder
+import org.gradle.api.tasks.TaskAction
+import groovy.xml.XmlParser
+import groovy.xml.XmlNodePrinter
 
 import java.util.Map.Entry
-import java.util.Set
-
-import org.gradle.api.GradleException
 
 class InstallLibertyTask extends AbstractLibertyTask {
     protected Properties libertyRuntimeProjectProps = new Properties()
@@ -53,7 +48,7 @@ class InstallLibertyTask extends AbstractLibertyTask {
         outputs.upToDateWhen {
             // ensure a Liberty installation exists at the install directory
             getInstallDir(project).exists() && new File(getInstallDir(project), 'lib/ws-launch.jar').exists() && 
-            project.buildDir.exists() && new File(project.buildDir, 'liberty-plugin-config.xml').exists() &&
+            project.layout.buildDirectory.asFile.get().exists() && new File(project.layout.buildDirectory.asFile.get(), 'liberty-plugin-config.xml').exists() &&
             !isInstallDirChanged(project)
         }
     }
@@ -124,7 +119,7 @@ class InstallLibertyTask extends AbstractLibertyTask {
 
             String licenseFilePath = project.configurations.getByName('libertyLicense').getAsPath()
             if (licenseFilePath) {
-                def command = "java -jar " + licenseFilePath + " --acceptLicense " + project.buildDir
+                def command = "java -jar " + licenseFilePath + " --acceptLicense " + project.layout.buildDirectory.asFile.get()
                 def process = command.execute()
                 process.waitFor()
             }
@@ -134,7 +129,7 @@ class InstallLibertyTask extends AbstractLibertyTask {
 
     protected void updatePluginXmlFile() {
         XmlParser pluginXmlParser = new XmlParser()
-        Node libertyPluginConfig = pluginXmlParser.parse(new File(project.buildDir, 'liberty-plugin-config.xml'))
+        Node libertyPluginConfig = pluginXmlParser.parse(new File(project.layout.buildDirectory.asFile.get(), 'liberty-plugin-config.xml'))
 
         Node installDirNode = libertyPluginConfig.getAt('installDirectory').isEmpty() ? libertyPluginConfig.appendNode('installDirectory') : libertyPluginConfig.getAt('installDirectory').get(0)
         installDirNode.setValue(getInstallDir(project).toString())
@@ -186,36 +181,36 @@ class InstallLibertyTask extends AbstractLibertyTask {
             }
         }
 
-        new File( project.buildDir, 'liberty-plugin-config.xml' ).withWriter('UTF-8') { output ->
+        new File( project.layout.buildDirectory.asFile.get(), 'liberty-plugin-config.xml' ).withWriter('UTF-8') { output ->
             output << new StreamingMarkupBuilder().bind { mkp.xmlDeclaration(encoding: 'UTF-8', version: '1.0' ) }
             XmlNodePrinter printer = new XmlNodePrinter( new PrintWriter(output) )
             printer.preserveWhitespace = true
             printer.print( libertyPluginConfig )
         }
 
-        logger.info ("Updating Liberty plugin config info at ${project.buildDir}/liberty-plugin-config.xml.")
+        logger.info ("Updating Liberty plugin config info at ${project.layout.buildDirectory.asFile.get()}/liberty-plugin-config.xml.")
 
     }
 
     protected void createPluginXmlFile(boolean isExisting) {
         if(!this.state.upToDate) {
-            if (!project.buildDir.exists()) {
-                logger.info ("Creating missing project buildDir at ${project.buildDir}.")
-                project.buildDir.mkdirs()
+            if (!project.layout.buildDirectory.asFile.get().exists()) {
+                logger.info ("Creating missing project buildDir at ${project.layout.buildDirectory.asFile.get()}.")
+                project.layout.buildDirectory.asFile.get().mkdirs()
             }
 
             // if the file already exists, update it instead of replacing it
-            if (new File(project.buildDir, 'liberty-plugin-config.xml').exists()) {
+            if (new File(project.layout.buildDirectory.asFile.get(), 'liberty-plugin-config.xml').exists()) {
                 updatePluginXmlFile()
             } else {
-                new File(project.buildDir, 'liberty-plugin-config.xml').withWriter { writer ->
+                new File(project.layout.buildDirectory.asFile.get(), 'liberty-plugin-config.xml').withWriter { writer ->
                     def xmlDoc = new MarkupBuilder(writer)
                     xmlDoc.mkp.xmlDeclaration(version: "1.0", encoding: "UTF-8")
                     xmlDoc.'liberty-plugin-config'('version':'2.0') {
                         outputLibertyPropertiesToXml(xmlDoc, isExisting)
                     }
                 }
-                logger.info ("Creating Liberty plugin config info to ${project.buildDir}/liberty-plugin-config.xml.")
+                logger.info ("Creating Liberty plugin config info to ${project.layout.buildDirectory.asFile.get()}/liberty-plugin-config.xml.")
             }
         }
     }
@@ -327,7 +322,7 @@ class InstallLibertyTask extends AbstractLibertyTask {
         }
 
         if (project.liberty.baseDir == null) {
-           result.put('baseDir', project.buildDir)
+           result.put('baseDir', project.layout.buildDirectory.asFile.get())
         } else {
            result.put('baseDir', project.liberty.baseDir)
         }

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/PackageTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/PackageTask.groovy
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2014, 2023.
+ * (C) Copyright IBM Corporation 2014, 2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ class PackageTask extends AbstractServerTask {
     void packageServer() {
         // Set default server.outputDir to liberty-alt-output-dir for libertyPackage task.
         if (getOutputDir(project).equals(getUserDir(project).toString() + "/servers")) {
-            server.outputDir = new File(project.getBuildDir(), "liberty-alt-output-dir");
+            server.outputDir = new File(project.layout.buildDirectory.asFile.get(), "liberty-alt-output-dir");
         }
 
         def params = buildLibertyMap(project)
@@ -125,7 +125,7 @@ class PackageTask extends AbstractServerTask {
      * @throws IOException
      */
     private String getPackageDirectory() throws IOException {
-        def buildDirLibFolder = new File(project.getBuildDir(),'libs')
+        def buildDirLibFolder = new File(project.layout.buildDirectory.asFile.get(),'libs')
         if (server.packageLiberty.packageDirectory != null && !server.packageLiberty.packageDirectory.isEmpty()) {
             // check if path is relative or absolute, convert to canonical
             def dir = new File(server.packageLiberty.packageDirectory)

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/PackageTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/PackageTask.groovy
@@ -71,7 +71,7 @@ class PackageTask extends AbstractServerTask {
     void packageServer() {
         // Set default server.outputDir to liberty-alt-output-dir for libertyPackage task.
         if (getOutputDir(project).equals(getUserDir(project).toString() + "/servers")) {
-            server.outputDir = new File(project.layout.buildDirectory.asFile.get(), "liberty-alt-output-dir");
+            server.outputDir = new File(project.getLayout().getBuildDirectory().getAsFile().get(), "liberty-alt-output-dir");
         }
 
         def params = buildLibertyMap(project)
@@ -125,7 +125,7 @@ class PackageTask extends AbstractServerTask {
      * @throws IOException
      */
     private String getPackageDirectory() throws IOException {
-        def buildDirLibFolder = new File(project.layout.buildDirectory.asFile.get(),'libs')
+        def buildDirLibFolder = new File(project.getLayout().getBuildDirectory().getAsFile().get(),'libs')
         if (server.packageLiberty.packageDirectory != null && !server.packageLiberty.packageDirectory.isEmpty()) {
             // check if path is relative or absolute, convert to canonical
             def dir = new File(server.packageLiberty.packageDirectory)

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/arquillian/ConfigureArquillianTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/arquillian/ConfigureArquillianTask.groovy
@@ -16,26 +16,23 @@
 
 package io.openliberty.tools.gradle.tasks.arquillian;
 
-import java.io.File
-import java.io.FileNotFoundException
-import java.io.IOException
-import javax.xml.parsers.ParserConfigurationException
-import javax.xml.xpath.XPathExpressionException
-import org.gradle.api.artifacts.UnknownConfigurationException
-import org.gradle.api.GradleException
-import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.TaskAction
-import org.gradle.api.logging.LogLevel
-import org.xml.sax.SAXException
-import io.openliberty.tools.common.arquillian.objects.LibertyProperty;
-import io.openliberty.tools.common.arquillian.objects.LibertyRemoteObject
 import io.openliberty.tools.common.arquillian.objects.LibertyManagedObject
+import io.openliberty.tools.common.arquillian.objects.LibertyProperty
+import io.openliberty.tools.common.arquillian.objects.LibertyRemoteObject
 import io.openliberty.tools.common.arquillian.util.ArquillianConfigurationException
 import io.openliberty.tools.common.arquillian.util.ArtifactCoordinates;
 import io.openliberty.tools.common.arquillian.util.Constants
 import io.openliberty.tools.common.arquillian.util.HttpPortUtil
 import io.openliberty.tools.gradle.tasks.AbstractServerTask
+import org.gradle.api.GradleException
+import org.gradle.api.artifacts.UnknownConfigurationException
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.TaskAction
+import org.xml.sax.SAXException
+
+import javax.xml.parsers.ParserConfigurationException
+import javax.xml.xpath.XPathExpressionException
 
 class ConfigureArquillianTask extends AbstractServerTask {
 
@@ -68,7 +65,7 @@ class ConfigureArquillianTask extends AbstractServerTask {
 
     @TaskAction
     void doExecute() throws GradleException {
-        File arquillianXml = new File(project.getBuildDir(), "resources/test/arquillian.xml");
+        File arquillianXml = new File(project.getLayout().getBuildDirectory().getAsFile().get(), "resources/test/arquillian.xml");
         try {
             if (project.configurations.getByName('testCompile') != null) {
                 project.configurations.testCompile.find {

--- a/src/test/groovy/io/openliberty/tools/gradle/TestEclipseFacetsEar.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/TestEclipseFacetsEar.groovy
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corporation 2018.
+ * (C) Copyright IBM Corporation 2018, 2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,9 @@
  */
 package io.openliberty.tools.gradle;
 
-import org.junit.AfterClass
 import org.junit.BeforeClass
 import org.junit.Test
-import groovy.util.XmlParser
-import java.util.HashMap
+import groovy.xml.XmlParser
 
 public class TestEclipseFacetsEar extends AbstractIntegrationTest{
     static File resourceDir = new File("build/resources/test/loose-ear-test")

--- a/src/test/groovy/io/openliberty/tools/gradle/TestEclipseFacetsWar.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/TestEclipseFacetsWar.groovy
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corporation 2018.
+ * (C) Copyright IBM Corporation 2018, 2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,9 @@
  */
 package io.openliberty.tools.gradle;
 
-import org.junit.AfterClass
 import org.junit.BeforeClass
 import org.junit.Test
-import groovy.util.XmlParser
-import java.util.HashMap
+import groovy.xml.XmlParser
 
 public class TestEclipseFacetsWar extends AbstractIntegrationTest{
     static File resourceDir = new File("build/resources/test/sample.servlet")

--- a/src/test/groovy/io/openliberty/tools/gradle/TestSpringBootApplication20.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/TestSpringBootApplication20.groovy
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corporation 2018.
+ * (C) Copyright IBM Corporation 2018, 2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  */
 package io.openliberty.tools.gradle
 
-import groovy.xml.QName
 import org.junit.*
 import org.junit.rules.TestName
 

--- a/src/test/groovy/io/openliberty/tools/gradle/TestSpringBootApplication30.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/TestSpringBootApplication30.groovy
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corporation 2023.
+ * (C) Copyright IBM Corporation 2023, 2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  */
 package io.openliberty.tools.gradle
 
-import groovy.xml.QName
 import org.junit.*
 import org.junit.rules.TestName
 


### PR DESCRIPTION
1. Project.buildDir is deprecated, to be replaced by

Refer:- https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.api/-project/get-build-dir.html
Per doumumentation we should use Use getLayout().getBuildDirectory() instead

we need to use project.layout.buildDirectory.asFile.get() to get in File format

Refer:-https://github.com/gradle/gradle/issues/20210


2. xmlParser
﻿groovy.util.XmlParser is deprecated
﻿Ref:- https://docs.groovy-lang.org/3.0.1/html/api/groovy/util/XmlParser.html
﻿
﻿use  groovy.xml.xmlParser
﻿
﻿3. groovy.util.xmlNodePrinter is deprecated. use groovy.xml.XmlNodePrinter instead
﻿
﻿Refer:- https://docs.groovy-lang.org/docs/groovy-3.0.10/html/api/groovy/util/XmlNodePrinter.html