### PR TITLE
removing use of deprecated plugin conventions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -178,7 +178,7 @@ pluginBundle {
 publishing {
     publications {
         libertyGradle (MavenPublication) {
-            artifactId = base.archivesName
+            artifactId = 'liberty-maven-plugin'
 
             from components.java
             artifact groovydocJar

--- a/build.gradle
+++ b/build.gradle
@@ -178,7 +178,7 @@ pluginBundle {
 publishing {
     publications {
         libertyGradle (MavenPublication) {
-            artifactId = 'liberty-maven-plugin'
+            artifactId = 'liberty-gradle-plugin'
 
             from components.java
             artifact groovydocJar

--- a/build.gradle
+++ b/build.gradle
@@ -1,17 +1,14 @@
-import java.io.FileOutputStream
-import java.io.IOException
-import java.io.OutputStream
-import java.util.Properties
 
 apply plugin: 'groovy'
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 apply plugin: "com.gradle.plugin-publish"
 
-archivesBaseName = 'liberty-gradle-plugin'
 group = 'io.openliberty.tools'
 version = '3.8.4-SNAPSHOT'
-
+base {
+    archivesName='liberty-gradle-plugin'
+}
 repositories {
     mavenLocal()
     mavenCentral()
@@ -116,29 +113,29 @@ test {
 
         try {
 
-        output = new FileOutputStream("${buildDir}/gradle.properties");
+            output = new FileOutputStream("${buildDir}/gradle.properties");
 
-        if (libertyRuntime == "ol") {
-            runtimeGroup = "io.openliberty"
-            runtimeArtifactId = "openliberty-runtime"
-            kernelArtifactId = "openliberty-kernel"
-        } else {
-            runtimeGroup = "com.ibm.websphere.appserver.runtime"
-            runtimeArtifactId = "wlp-javaee7"
-            kernelArtifactId = "wlp-kernel"
-        }
+            if (libertyRuntime == "ol") {
+                runtimeGroup = "io.openliberty"
+                runtimeArtifactId = "openliberty-runtime"
+                kernelArtifactId = "openliberty-kernel"
+            } else {
+                runtimeGroup = "com.ibm.websphere.appserver.runtime"
+                runtimeArtifactId = "wlp-javaee7"
+                kernelArtifactId = "wlp-kernel"
+            }
 
-        // set the properties value
-        prop.setProperty("lgpVersion", version)
-        prop.setProperty("runtimeGroup", runtimeGroup)
-        prop.setProperty("runtimeArtifactId", runtimeArtifactId)
-        prop.setProperty("kernelArtifactId", kernelArtifactId)
-        prop.setProperty("runtimeVersion", runtimeVersion)
-        prop.setProperty("antVersion", libertyAntVersion)
-        prop.setProperty("commonVersion", libertyCommonVersion)
+            // set the properties value
+            prop.setProperty("lgpVersion", version)
+            prop.setProperty("runtimeGroup", runtimeGroup)
+            prop.setProperty("runtimeArtifactId", runtimeArtifactId)
+            prop.setProperty("kernelArtifactId", kernelArtifactId)
+            prop.setProperty("runtimeVersion", runtimeVersion)
+            prop.setProperty("antVersion", libertyAntVersion)
+            prop.setProperty("commonVersion", libertyCommonVersion)
 
-        // save properties to project root folder
-        prop.store(output, null)
+            // save properties to project root folder
+            prop.store(output, null)
 
         } catch (IOException io) {
             io.printStackTrace()
@@ -181,11 +178,11 @@ pluginBundle {
 publishing {
     publications {
         libertyGradle (MavenPublication) {
-            artifactId = archivesBaseName
+            artifactId = base.archivesName
 
             from components.java
             artifact groovydocJar
-            artifact sourcesJar 
+            artifact sourcesJar
 
             pom {
                 name = 'liberty-gradle-plugin'
@@ -218,7 +215,7 @@ publishing {
 }
 
 if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')) {
-    
+
     if (!version.endsWith("SNAPSHOT")) {
         signing {
             sign publishing.publications.libertyGradle

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
-
 apply plugin: 'groovy'
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 apply plugin: "com.gradle.plugin-publish"
+apply plugin: 'base'
 
 group = 'io.openliberty.tools'
 version = '3.8.4-SNAPSHOT'
@@ -113,7 +113,7 @@ test {
 
         try {
 
-            output = new FileOutputStream("${buildDir}/gradle.properties");
+            output = new FileOutputStream("${project.getLayout().getBuildDirectory().getAsFile().get()}/gradle.properties");
 
             if (libertyRuntime == "ol") {
                 runtimeGroup = "io.openliberty"
@@ -178,7 +178,7 @@ pluginBundle {
 publishing {
     publications {
         libertyGradle (MavenPublication) {
-            artifactId = 'liberty-gradle-plugin'
+            artifactId = base.archivesName.get()
 
             from components.java
             artifact groovydocJar

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/CompileJSPTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/CompileJSPTask.groovy
@@ -15,21 +15,11 @@
  */
 package io.openliberty.tools.gradle.tasks
 
-import java.io.File;
-import java.text.MessageFormat;
-import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.HashSet;
-
-import org.gradle.api.tasks.TaskAction
+import io.openliberty.tools.ant.jsp.CompileJSPs
+import org.apache.tools.ant.Project
 import org.gradle.api.Task
-import org.gradle.api.GradleException
+import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.bundling.War
-import org.gradle.api.logging.LogLevel
-
-import org.apache.tools.ant.Project;
-import io.openliberty.tools.ant.jsp.CompileJSPs;
 
 class CompileJSPTask extends AbstractFeatureTask {
     protected Project ant = new Project();
@@ -69,8 +59,8 @@ class CompileJSPTask extends AbstractFeatureTask {
         War war;
         if(project.plugins.hasPlugin("war")){
             war = (War)project.war
-            if ( war.webAppDirectory.asFile.get() != null) {
-                compileJsp.setSrcdir( war.webAppDirectory.asFile.get())
+            if ( war.getWebAppDirectory().getAsFile().get() != null) {
+                compileJsp.setSrcdir( war.getWebAppDirectory().getAsFile().get())
             }
         }else {
             compileJsp.setSrcdir(new File("src/main/webapp"))

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/CompileJSPTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/CompileJSPTask.groovy
@@ -59,17 +59,20 @@ class CompileJSPTask extends AbstractFeatureTask {
     protected void perTaskCompileJSP(Task task) throws Exception {
         CompileJSPs compileJsp = new CompileJSPs()
         compileJsp.setInstallDir(getInstallDir(project))
-        compileJsp.setTempdir(project.buildDir)
-        compileJsp.setDestdir(new File(project.buildDir.getAbsolutePath()+"/classes/java"))
+        compileJsp.setTempdir(project.getLayout().getBuildDirectory().getAsFile().get())
+        compileJsp.setDestdir(new File(project.getLayout().getBuildDirectory().getAsFile().get().getAbsolutePath()+"/classes/java"))
         compileJsp.setTimeout(project.liberty.jsp.jspCompileTimeout)
         // don't delete temporary server dir
         compileJsp.setCleanup(false)
         compileJsp.setProject(ant)
         compileJsp.setTaskName('antlib:net/wasdev/wlp/ant:compileJSPs')
-
-        if (project.convention.plugins.war.webAppDirName != null) {
-            compileJsp.setSrcdir(project.convention.plugins.war.webAppDir)
-        } else {
+        War war;
+        if(project.plugins.hasPlugin("war")){
+            war = (War)project.war
+            if ( war.webAppDirectory.asFile.get() != null) {
+                compileJsp.setSrcdir( war.webAppDirectory.asFile.get())
+            }
+        }else {
             compileJsp.setSrcdir(new File("src/main/webapp"))
         }
         Set<String> classpath = new HashSet<String>();

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DeployTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DeployTask.groovy
@@ -335,7 +335,7 @@ class DeployTask extends AbstractServerTask {
             }
         }
 
-        LooseWarApplication looseWar = new LooseWarApplication(task, config)
+        LooseWarApplication looseWar = new LooseWarApplication(task, config,logger)
         looseWar.addSourceDir()
         looseWar.addOutputDir(looseWar.getDocumentRoot() , task.classpath.getFiles().toArray()[0], "/WEB-INF/classes/");
 
@@ -403,7 +403,7 @@ class DeployTask extends AbstractServerTask {
     }
 
     protected void installLooseConfigEar(LooseConfigData config, Task task) throws Exception{
-        LooseEarApplication looseEar = new LooseEarApplication(task, config);
+        LooseEarApplication looseEar = new LooseEarApplication(task, config, logger);
         looseEar.addSourceDir();
         looseEar.addApplicationXmlFile();
 

--- a/src/main/groovy/io/openliberty/tools/gradle/utils/LooseEarApplication.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/utils/LooseEarApplication.groovy
@@ -5,16 +5,19 @@ import io.openliberty.tools.common.plugins.config.LooseConfigData
 import org.apache.commons.io.FilenameUtils
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.logging.Logger
 import org.gradle.plugins.ear.Ear
 import org.w3c.dom.Element
 
 public class LooseEarApplication extends LooseApplication {
     
     protected Task task;
+    protected Logger logger;
 
-    public LooseEarApplication(Task task, LooseConfigData config) {
+    public LooseEarApplication(Task task, LooseConfigData config, Logger logger) {
         super(task.getProject().getLayout().getBuildDirectory().getAsFile().get().getAbsolutePath(), config)
         this.task = task
+        this.logger = logger
     }
 
     public void addSourceDir() throws Exception {
@@ -39,6 +42,9 @@ public class LooseEarApplication extends LooseApplication {
                 applicationXmlFile = new File(task.getDestinationDirectory().get().getAsFile().getParentFile().getAbsolutePath() + "/tmp/ear" + applicationName);
                 config.addFile(applicationXmlFile, "/META-INF/application.xml");
             }
+        }
+        else {
+            logger.warn("Project is expected to have EAR plugin. Application xml file may not be added correctly")
         }
     }
     

--- a/src/main/groovy/io/openliberty/tools/gradle/utils/LooseEarApplication.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/utils/LooseEarApplication.groovy
@@ -23,28 +23,28 @@ public class LooseEarApplication extends LooseApplication {
     public void addSourceDir() throws Exception {
         if (task.getProject().getPlugins().hasPlugin("ear")) {
             Ear ear = (Ear) task.getProject().ear
-            File sourceDir = new File(task.getProject().path.replace(":","") + "/" + ear.getAppDirectory().getAsFile().get().getAbsolutePath())
+            File sourceDir = new File(task.getProject().path.replace(":","") + "/" + ear.getAppDirectory().getAsFile().get().getPath())
             config.addDir(sourceDir, "/")
         }
     }
 
     public void addApplicationXmlFile() throws Exception {
+        String applicationName = "/application.xml"
+        File applicationXmlFile;
         if (task.getProject().getPlugins().hasPlugin("ear")) {
             Ear ear = (Ear) task.getProject().ear
-            String applicationName = "/application.xml"
-            if (ear.getDeploymentDescriptor() != null){
+            if (ear.getDeploymentDescriptor() != null) {
                 applicationName = "/" + ear.getDeploymentDescriptor().getFileName()
             }
-            File applicationXmlFile = new File(task.getProject().path.replace(":", "") + "/" + ear.getAppDirectory().getAsFile().get().getAbsolutePath() + "/META-INF/" + applicationName)
+            applicationXmlFile = new File(task.getProject().path.replace(":", "") + "/" + ear.getAppDirectory().getAsFile().get().getAbsolutePath() + "/META-INF/" + applicationName)
             if (applicationXmlFile.exists()) {
-                config.addFile(applicationXmlFile, "/META-INF/application.xml");
-            } else {
-                applicationXmlFile = new File(task.getDestinationDirectory().get().getAsFile().getParentFile().getAbsolutePath() + "/tmp/ear" + applicationName);
                 config.addFile(applicationXmlFile, "/META-INF/application.xml");
             }
         }
-        else {
-            logger.warn("Project is expected to have EAR plugin. Application xml file may not be added correctly")
+        if (applicationXmlFile == null || !applicationXmlFile.exists()) {
+            applicationXmlFile = new File(task.getDestinationDirectory().get().getAsFile().getParentFile().getAbsolutePath() + "/tmp/ear" + applicationName);
+            config.addFile(applicationXmlFile, "/META-INF/application.xml");
+            logger.warn("Could not get the application.xml file location from the EAR plugin because it is not configured. The file may not be added correctly to the application archive.")
         }
     }
     

--- a/src/main/groovy/io/openliberty/tools/gradle/utils/LooseEarApplication.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/utils/LooseEarApplication.groovy
@@ -38,13 +38,12 @@ public class LooseEarApplication extends LooseApplication {
             }
             applicationXmlFile = new File(task.getProject().path.replace(":", "") + "/" + ear.getAppDirectory().getAsFile().get().getAbsolutePath() + "/META-INF/" + applicationName)
             if (applicationXmlFile.exists()) {
-                config.addFile(applicationXmlFile, "/META-INF/application.xml");
+                config.addFile(applicationXmlFile, "/META-INF/application.xml")
             }
         }
         if (applicationXmlFile == null || !applicationXmlFile.exists()) {
             applicationXmlFile = new File(task.getDestinationDirectory().get().getAsFile().getParentFile().getAbsolutePath() + "/tmp/ear" + applicationName);
-            config.addFile(applicationXmlFile, "/META-INF/application.xml");
-            logger.warn("Could not get the application.xml file location from the EAR plugin because it is not configured. The file may not be added correctly to the application archive.")
+            config.addFile(applicationXmlFile, "/META-INF/application.xml")
         }
     }
     

--- a/src/main/groovy/io/openliberty/tools/gradle/utils/LooseWarApplication.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/utils/LooseWarApplication.groovy
@@ -27,7 +27,7 @@ public class LooseWarApplication extends LooseApplication {
                 sourceDir = new File(war.getWebAppDirectory().getAsFile().get().getAbsolutePath())
             }
         }else {
-            logger.warn("Default sourcedir path to src/main/webapp as WAR plugin does not exist. Application may not work expectedly")
+            logger.warn("Could not get the webAppDirectory location from the WAR plugin because it is not configured. Using the default location src/main/webapp instead. Application may not work as expected.")
         }
         config.addDir(sourceDir, "/")
     }

--- a/src/main/groovy/io/openliberty/tools/gradle/utils/LooseWarApplication.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/utils/LooseWarApplication.groovy
@@ -1,27 +1,29 @@
 package io.openliberty.tools.gradle.utils;
 
-import java.io.File;
-import org.gradle.api.Project;
-import org.gradle.api.plugins.WarPluginConvention
+import io.openliberty.tools.common.plugins.config.LooseApplication
+import io.openliberty.tools.common.plugins.config.LooseConfigData
 import org.gradle.api.Task
 import org.gradle.api.tasks.bundling.War
-
-import io.openliberty.tools.common.plugins.config.LooseConfigData
-import io.openliberty.tools.common.plugins.util.PluginExecutionException
-import io.openliberty.tools.common.plugins.config.LooseApplication
 
 public class LooseWarApplication extends LooseApplication {
     
     protected Task task;
 
     public LooseWarApplication(Task task, LooseConfigData config) {
-        super(task.getProject().getBuildDir().getAbsolutePath(), config)
+        super(task.getProject().getLayout().getBuildDirectory().getAsFile().get().getAbsolutePath(), config)
         this.task = task
     }
 
     public void addSourceDir() throws Exception {
-        WarPluginConvention wpc = task.getProject().getConvention().findPlugin(WarPluginConvention)
-        File sourceDir = new File(wpc.getWebAppDir().getAbsolutePath())
+
+        War war;
+        File sourceDir = new File("src/main/webapp")
+        if (task.getProject().getPlugins().hasPlugin("war")) {
+            war = (War) task.getProject().war
+            if (war.webAppDirectory.asFile.get() != null) {
+                sourceDir = new File(war.webAppDirectory.asFile.get().getAbsolutePath())
+            }
+        }
         config.addDir(sourceDir, "/")
     }
 

--- a/src/main/groovy/io/openliberty/tools/gradle/utils/LooseWarApplication.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/utils/LooseWarApplication.groovy
@@ -3,15 +3,18 @@ package io.openliberty.tools.gradle.utils;
 import io.openliberty.tools.common.plugins.config.LooseApplication
 import io.openliberty.tools.common.plugins.config.LooseConfigData
 import org.gradle.api.Task
+import org.gradle.api.logging.Logger
 import org.gradle.api.tasks.bundling.War
 
 public class LooseWarApplication extends LooseApplication {
     
     protected Task task;
+    protected Logger logger;
 
-    public LooseWarApplication(Task task, LooseConfigData config) {
+    public LooseWarApplication(Task task, LooseConfigData config, Logger logger) {
         super(task.getProject().getLayout().getBuildDirectory().getAsFile().get().getAbsolutePath(), config)
         this.task = task
+        this.logger = logger
     }
 
     public void addSourceDir() throws Exception {
@@ -23,6 +26,8 @@ public class LooseWarApplication extends LooseApplication {
             if (war.getWebAppDirectory().getAsFile().get() != null) {
                 sourceDir = new File(war.getWebAppDirectory().getAsFile().get().getAbsolutePath())
             }
+        }else {
+            logger.warn("Default sourcedir path to src/main/webapp as WAR plugin does not exist. Application may not work expectedly")
         }
         config.addDir(sourceDir, "/")
     }

--- a/src/main/groovy/io/openliberty/tools/gradle/utils/LooseWarApplication.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/utils/LooseWarApplication.groovy
@@ -20,8 +20,8 @@ public class LooseWarApplication extends LooseApplication {
         File sourceDir = new File("src/main/webapp")
         if (task.getProject().getPlugins().hasPlugin("war")) {
             war = (War) task.getProject().war
-            if (war.webAppDirectory.asFile.get() != null) {
-                sourceDir = new File(war.webAppDirectory.asFile.get().getAbsolutePath())
+            if (war.getWebAppDirectory().getAsFile().get() != null) {
+                sourceDir = new File(war.getWebAppDirectory().getAsFile().get().getAbsolutePath())
             }
         }
         config.addDir(sourceDir, "/")

--- a/src/test/groovy/io/openliberty/tools/gradle/KernelInstallFeatureTest.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/KernelInstallFeatureTest.groovy
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corporation 2018.
+ * (C) Copyright IBM Corporation 2018, 2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,7 @@
  */
 package io.openliberty.tools.gradle
 
-import static junit.framework.Assert.assertEquals
-import static org.junit.Assert.*
+import static org.junit.Assert.assertEquals
 
 import org.junit.Before
 import org.junit.BeforeClass


### PR DESCRIPTION
1. archivesBaseName in basepluginconvention is deprecated :- replace with baseextension base.archivesName
Refer:- https://discuss.gradle.org/t/android-defaultconfig-archivesbasename-deprecated/46384