### PR TITLE
Add support for Spring Boot Gradle plugin using plugins DSL

### DIFF
--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractLibertyTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractLibertyTask.groovy
@@ -80,7 +80,9 @@ abstract class AbstractLibertyTask extends DefaultTask {
         if (project.plugins.hasPlugin("org.springframework.boot")) {
             try {
                 for (Dependency dep : project.buildscript.configurations.classpath.getAllDependencies().toArray()) {
-                    if ("org.springframework.boot".equals(dep.getGroup()) && "spring-boot-gradle-plugin".equals(dep.getName())) {
+                    if ("org.springframework.boot".equals(dep.getGroup()) &&
+                            ("spring-boot-gradle-plugin".equals(dep.getName()) ||
+                                "org.springframework.boot.gradle.plugin".equals(dep.getName()))) {
                         version = dep.getVersion()
                         break
                     }

--- a/src/test/groovy/io/openliberty/tools/gradle/TestSpringBootApplication30.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/TestSpringBootApplication30.groovy
@@ -132,4 +132,20 @@ public class TestSpringBootApplication30 extends AbstractIntegrationTest{
             throw new AssertionError ("Fail on task deploy.", e)
         }
     }
+
+    @Test
+    public void test_spring_boot_plugins_dsl_apps_30() {
+        try {
+            runTasks(buildDir, 'deploy', 'libertyStart')
+
+            String webPage = new URL("http://localhost:9080").getText()
+            Assert.assertEquals("Did not get expected http response.","Hello!", webPage)
+            Assert.assertTrue('defaultServer/dropins has app deployed',
+                    new File(buildDir, 'build/wlp/usr/servers/defaultServer/dropins').list().size() == 0)
+            Assert.assertTrue('no app in apps folder',
+                    new File(buildDir, "build/wlp/usr/servers/defaultServer/apps/thin-${testName.getMethodName()}-1.0-SNAPSHOT.jar").exists() )
+        } catch (Exception e) {
+            throw new AssertionError ("Fail on task deploy.", e)
+        }
+    }
 }

--- a/src/test/resources/sample.springboot3/settings.gradle
+++ b/src/test/resources/sample.springboot3/settings.gradle
@@ -1,1 +1,9 @@
-//Empty
+pluginManagement {
+    repositories {
+        mavenCentral()
+        mavenLocal()
+        maven {
+            url = uri(file("$rootDir/../../plugin-test-repository/"))
+        }
+    }
+}

--- a/src/test/resources/sample.springboot3/test_spring_boot_plugins_dsl_apps_30.gradle
+++ b/src/test/resources/sample.springboot3/test_spring_boot_plugins_dsl_apps_30.gradle
@@ -1,0 +1,25 @@
+plugins {
+	id 'java'
+	id 'org.springframework.boot' version '3.1.3'
+	id 'io.spring.dependency-management' version '1.1.6'
+	id 'io.openliberty.tools.gradle.Liberty' version "$lgpVersion"
+}
+
+group = 'liberty.gradle'
+version = '1.0-SNAPSHOT'
+sourceCompatibility = 17
+
+repositories {
+	mavenCentral()
+}
+dependencies {
+	implementation("org.springframework.boot:spring-boot-starter-web")
+	testImplementation('org.springframework.boot:spring-boot-starter-test')
+	libertyRuntime group: 'io.openliberty', name: 'openliberty-runtime', version: '23.0.0.10'
+}
+
+liberty {
+	server {
+		serverXmlFile = file("src/main/liberty/config/server30.xml")
+	}
+}


### PR DESCRIPTION
This PR adds support for identifying the Spring Boot version from the Spring Boot Gradle plugin configured using the plugins DSL. Previously adding the Liberty Gradle plugin to such a Spring Boot project resulted in a NullPointerException as described in issue [#893](https://github.com/OpenLiberty/ci.gradle/issues/893).

I signed the individual CLA to provide this PR.