### PR TITLE
Specify version 24.0.0.2 for binary scanner

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ compileTestGroovy {
 }
 
 def libertyAntVersion = "1.9.16"
-def libertyCommonVersion = "1.8.37"
+def libertyCommonVersion = "1.8.38-SNAPSHOT"
 
 dependencies {
     implementation gradleApi()


### PR DESCRIPTION
This specifies the ci.common version which references the latest binary scanner on Maven Central.

Responding to https://github.com/OpenLiberty/ci.maven/issues/1874