### PR TITLE
Gradle version migration - Development Mode Tests

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: '**'
   pull_request:
-    branches: [ main, feature/gradle9 ]
+    branches: [ feature/gradle9 ]
 
 jobs:
   # UNIX BUILDS
@@ -30,7 +30,7 @@ jobs:
       # Checkout repos
       - name: Checkout ci.gradle
         uses: actions/checkout@v3
-      # Set up Java 17
+      # Set up Java
       - name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v3
         with:
@@ -113,12 +113,12 @@ jobs:
     #            RUNTIME: wlp
     name: ${{ matrix.RUNTIME }} ${{ matrix.RUNTIME_VERSION }}, Java ${{ matrix.java }}, Windows
     env:
-      TEST_EXCLUDE: '**/Polling*,**/LibertyTest*,**/GenerateFeaturesTest*,**/TestSpringBootApplication30*,**/TestCompileJSPSource17*,**/DevContainerTest*'
+#      TEST_EXCLUDE: ${{ ((matrix.java == '8') && '**/TestCreateWithConfigDir*,**/Polling*,**/LibertyTest*,**/GenerateFeaturesTest*,**/TestSpringBootApplication30*,**/TestCompileJSPSource17*,**/DevContainerTest*') || '**/Polling*,**/LibertyTest*,**/GenerateFeaturesTest*,**/TestSpringBootApplication30*,**/TestCompileJSPSource17*,**/DevContainerTest*' }}
     steps:
       # Checkout repos
       - name: Checkout ci.gradle
         uses: actions/checkout@v3
-        # Set up Java 17
+        # Set up Java
       - name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -78,6 +78,7 @@ jobs:
         ./gradlew clean install check -P"test.include"="**/AbstractIntegrationTest*,**/LibertyTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/PollingDevTest*" \
         -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" \
         -Dfile.encoding=UTF-8 -Dorg.gradle.jvmargs="-Dfile.encoding=UTF-8" \
+        -Dorg.gradle.java.home="${{ env.JAVA_HOME }}" \
         --stacktrace --info --warning-mode=all
     # Copy build reports and upload artifact if build failed
     - name: Copy build/report/tests/test for upload
@@ -165,10 +166,11 @@ jobs:
       # LibertyTest is excluded because test0_run hangs
       # For Java 8, TestCreateWithConfigDir is excluded because test_micro_clean_liberty_plugin_variable_config runs out of memory
       run: |
-        ./gradlew clean install check -P"test.include"="**/AbstractIntegrationTest*,**/LibertyTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/PollingDevTest*" \
-        -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" \
-        -Dfile.encoding=UTF-8 -Dorg.gradle.jvmargs="-Dfile.encoding=UTF-8" \
-        --stacktrace --info --warning-mode=all
+        ./gradlew "clean" "install" "check" "-P'test.include'='**/AbstractIntegrationTest*,**/LibertyTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/PollingDevTest*'" `
+        "-Druntime=${{ matrix.RUNTIME }}" "-DruntimeVersion=${{ matrix.RUNTIME_VERSION }}" `
+        "-Dfile.encoding=UTF-8" "-Dorg.gradle.jvmargs=-Dfile.encoding=UTF-8" `
+        "-Dorg.gradle.java.home=${{ env.JAVA_HOME }}" `
+        "--stacktrace" "--info" "--warning-mode=all"
       timeout-minutes: 75
     # Copy build reports and upload artifact if build failed
     - name: Copy build/report/tests/test for upload

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -198,7 +198,7 @@ jobs:
       # LibertyTest is excluded because test0_run hangs
       # For Java 8, TestCreateWithConfigDir is excluded because test_micro_clean_liberty_plugin_variable_config runs out of memory
       run: |
-        ./gradlew "clean" "install" "check" "-P'test.include'='**/AbstractIntegrationTest*,**/LibertyTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/PollingDevTest*'" `
+        ./gradlew "clean" "install" "check" "-Ptest.include=**/AbstractIntegrationTest*,**/LibertyTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/PollingDevTest*" `
         "-Druntime=${{ matrix.RUNTIME }}" "-DruntimeVersion=${{ matrix.RUNTIME_VERSION }}" `
         "-Dfile.encoding=UTF-8" "-Dorg.gradle.jvmargs=-Dfile.encoding=UTF-8" `
         "-Dorg.gradle.java.home=${{ env.GRADLE_JAVA_HOME }}" `

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -36,9 +36,9 @@ jobs:
         java-version: '17'
         cache: 'gradle'
         java-package: jdk
-    # Store Java 17 home for Gradle
+    # Store Java 17 home for Gradle (Unix format)
     - name: Set Gradle Java Home
-      id: gradle-java-home
+      id: gradle-java-home-unix
       run: echo "GRADLE_JAVA_HOME=$JAVA_HOME" >> $GITHUB_ENV
     # Set up matrix Java version for testing
     - name: Setup Java ${{ matrix.java }}
@@ -136,9 +136,17 @@ jobs:
         java-version: '17'
         cache: 'gradle'
         java-package: jdk
-    # Store Java 17 home for Gradle
+    # Store Java 17 home for Gradle (Windows format)
     - name: Set Gradle Java Home
       id: gradle-java-home
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        echo "GRADLE_JAVA_HOME=$env:JAVA_HOME" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+    # Store Java 17 home for Gradle (Unix format)
+    - name: Set Gradle Java Home
+      id: gradle-java-home-unix
+      if: runner.os != 'Windows'
       run: echo "GRADLE_JAVA_HOME=$JAVA_HOME" >> $GITHUB_ENV
     # Set up matrix Java version for testing
     - name: Setup Java ${{ matrix.java }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -112,7 +112,7 @@ jobs:
     #          - java: 11
     #            RUNTIME: wlp
     name: ${{ matrix.RUNTIME }} ${{ matrix.RUNTIME_VERSION }}, Java ${{ matrix.java }}, Windows
-    env:
+#    env:
 #      TEST_EXCLUDE: ${{ ((matrix.java == '8') && '**/TestCreateWithConfigDir*,**/Polling*,**/LibertyTest*,**/GenerateFeaturesTest*,**/TestSpringBootApplication30*,**/TestCompileJSPSource17*,**/DevContainerTest*') || '**/Polling*,**/LibertyTest*,**/GenerateFeaturesTest*,**/TestSpringBootApplication30*,**/TestCompileJSPSource17*,**/DevContainerTest*' }}
     steps:
       # Checkout repos

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -104,7 +104,7 @@ jobs:
       matrix:
         # test against latest update of each major Java version, as well as specific updates of LTS versions:
         RUNTIME: [ol, wlp]
-        RUNTIME_VERSION: [25.0.0.5]
+        RUNTIME_VERSION: [25.0.0.6]
         java: [21, 17]
     #        exclude:
     #          - java: 8

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -36,10 +36,6 @@ jobs:
         java-version: '17'
         cache: 'gradle'
         java-package: jdk
-    # Store Java 17 home for Gradle (Unix format)
-    - name: Set Gradle Java Home
-      id: gradle-java-home-unix
-      run: echo "GRADLE_JAVA_HOME=$JAVA_HOME" >> $GITHUB_ENV
     # Set up matrix Java version for testing
     - name: Setup Java ${{ matrix.java }}
       uses: actions/setup-java@v3
@@ -90,7 +86,6 @@ jobs:
         ./gradlew clean install check -P"test.include"="**/AbstractIntegrationTest*,**/LibertyTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/PollingDevTest*" \
         -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" \
         -Dfile.encoding=UTF-8 -Dorg.gradle.jvmargs="-Dfile.encoding=UTF-8" \
-        -Dorg.gradle.java.home="${{ env.GRADLE_JAVA_HOME }}" \
         --stacktrace --info --warning-mode=all
     # Copy build reports and upload artifact if build failed
     - name: Copy build/report/tests/test for upload
@@ -136,18 +131,6 @@ jobs:
         java-version: '17'
         cache: 'gradle'
         java-package: jdk
-    # Store Java 17 home for Gradle (Windows format)
-    - name: Set Gradle Java Home
-      id: gradle-java-home
-      if: runner.os == 'Windows'
-      shell: pwsh
-      run: |
-        echo "GRADLE_JAVA_HOME=$env:JAVA_HOME" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-    # Store Java 17 home for Gradle (Unix format)
-    - name: Set Gradle Java Home
-      id: gradle-java-home-unix
-      if: runner.os != 'Windows'
-      run: echo "GRADLE_JAVA_HOME=$JAVA_HOME" >> $GITHUB_ENV
     # Set up matrix Java version for testing
     - name: Setup Java ${{ matrix.java }}
       uses: actions/setup-java@v3
@@ -201,7 +184,6 @@ jobs:
         ./gradlew "clean" "install" "check" "-Ptest.include=**/AbstractIntegrationTest*,**/LibertyTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/PollingDevTest*" `
         "-Druntime=${{ matrix.RUNTIME }}" "-DruntimeVersion=${{ matrix.RUNTIME_VERSION }}" `
         "-Dfile.encoding=UTF-8" "-Dorg.gradle.jvmargs=-Dfile.encoding=UTF-8" `
-        "-Dorg.gradle.java.home=${{ env.GRADLE_JAVA_HOME }}" `
         "--stacktrace" "--info" "--warning-mode=all"
       timeout-minutes: 75
     # Copy build reports and upload artifact if build failed

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -19,12 +19,10 @@ jobs:
         # test against latest update of each major Java version, as well as specific updates of LTS versions:
         RUNTIME: [ol, wlp]
         RUNTIME_VERSION: [25.0.0.3]
-        java: [21, 17, 11, 8]
+        java: [21, 17]
         exclude:
-        - java: 8
+        - java: 17
           RUNTIME: wlp
-        - java: 11
-          RUNTIME: ol
     name: ${{ matrix.RUNTIME }} ${{ matrix.RUNTIME_VERSION }}, Java ${{ matrix.java }}, Linux
     steps:
     # Checkout repos
@@ -36,6 +34,7 @@ jobs:
         distribution: 'adopt'
         java-version: ${{ matrix.java }}
         cache: 'gradle'
+        java-package: jdk
     - name: Checkout ci.common
       uses: actions/checkout@v3
       with:
@@ -75,10 +74,11 @@ jobs:
 #        ./gradlew clean install check -P"test.include"="**/TestSpringBootApplication30*,**/TestCompileJSPSource17*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --warning-mode=all
     # Run tests
     - name: Run tests with Gradle on Ubuntu
-      run:
-#        ./gradlew clean install check -P"test.exclude"="**/TestSpringBootApplication30*,**/TestCompileJSPSource17*,**/DevContainerTest*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --warning-mode=all
-#        Commented out as it causes the build checks fails, we will enable it in the future
-        ./gradlew clean install check -P"test.include"="**/AbstractIntegrationTest*,**/LibertyTest*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --warning-mode=all
+      run: |
+        ./gradlew clean install check -P"test.include"="**/AbstractIntegrationTest*,**/LibertyTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/PollingDevTest*" \
+        -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" \
+        -Dfile.encoding=UTF-8 -Dorg.gradle.jvmargs="-Dfile.encoding=UTF-8" \
+        --stacktrace --info --warning-mode=all
     # Copy build reports and upload artifact if build failed
     - name: Copy build/report/tests/test for upload
       if: ${{ failure() }}
@@ -104,12 +104,10 @@ jobs:
         # test against latest update of each major Java version, as well as specific updates of LTS versions:
         RUNTIME: [ol, wlp]
         RUNTIME_VERSION: [25.0.0.3]
-        java: [21, 17, 11, 8]
+        java: [21, 17]
         exclude:
-        - java: 8
+        - java: 17
           RUNTIME: ol
-        - java: 11
-          RUNTIME: wlp
     name: ${{ matrix.RUNTIME }} ${{ matrix.RUNTIME_VERSION }}, Java ${{ matrix.java }}, Windows
     env: 
       TEST_EXCLUDE: ${{ ((matrix.java == '8') && '**/TestCreateWithConfigDir*,**/Polling*,**/LibertyTest*,**/GenerateFeaturesTest*,**/TestSpringBootApplication30*,**/TestCompileJSPSource17*,**/DevContainerTest*') || '**/Polling*,**/LibertyTest*,**/GenerateFeaturesTest*,**/TestSpringBootApplication30*,**/TestCompileJSPSource17*,**/DevContainerTest*' }}
@@ -123,6 +121,7 @@ jobs:
         distribution: 'adopt'
         java-version: ${{ matrix.java }}
         cache: 'gradle'
+        java-package: jdk
     # Moving and cloning to C: drive for Windows for more disk space
     - name: Clone ci.ant, ci.common, ci.gradle repos to C drive
       run: |
@@ -165,9 +164,11 @@ jobs:
       working-directory: ${{github.workspace}}
       # LibertyTest is excluded because test0_run hangs
       # For Java 8, TestCreateWithConfigDir is excluded because test_micro_clean_liberty_plugin_variable_config runs out of memory
-#      run: ./gradlew clean install check -P"test.exclude"="${{env.TEST_EXCLUDE}}" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --no-daemon
-#     Commented out as it causes the build checks fails, we will enable it in the future
-      run: ./gradlew clean install check -P"test.include"="**/AbstractIntegrationTest*,**/LibertyTest*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info
+      run: |
+        ./gradlew clean install check -P"test.include"="**/AbstractIntegrationTest*,**/LibertyTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/PollingDevTest*" \
+        -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" \
+        -Dfile.encoding=UTF-8 -Dorg.gradle.jvmargs="-Dfile.encoding=UTF-8" \
+        --stacktrace --info --warning-mode=all
       timeout-minutes: 75
     # Copy build reports and upload artifact if build failed
     - name: Copy build/report/tests/test for upload

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -28,12 +28,24 @@ jobs:
     # Checkout repos
     - name: Checkout ci.gradle
       uses: actions/checkout@v3
+    # Set up Java 17 for Gradle (regardless of matrix Java version)
+    - name: Setup Java 17 for Gradle
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'adopt'
+        java-version: '17'
+        cache: 'gradle'
+        java-package: jdk
+    # Store Java 17 home for Gradle
+    - name: Set Gradle Java Home
+      id: gradle-java-home
+      run: echo "GRADLE_JAVA_HOME=$JAVA_HOME" >> $GITHUB_ENV
+    # Set up matrix Java version for testing
     - name: Setup Java ${{ matrix.java }}
       uses: actions/setup-java@v3
       with:
         distribution: 'adopt'
         java-version: ${{ matrix.java }}
-        cache: 'gradle'
         java-package: jdk
     - name: Checkout ci.common
       uses: actions/checkout@v3
@@ -78,7 +90,7 @@ jobs:
         ./gradlew clean install check -P"test.include"="**/AbstractIntegrationTest*,**/LibertyTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/PollingDevTest*" \
         -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" \
         -Dfile.encoding=UTF-8 -Dorg.gradle.jvmargs="-Dfile.encoding=UTF-8" \
-        -Dorg.gradle.java.home="${{ env.JAVA_HOME }}" \
+        -Dorg.gradle.java.home="${{ env.GRADLE_JAVA_HOME }}" \
         --stacktrace --info --warning-mode=all
     # Copy build reports and upload artifact if build failed
     - name: Copy build/report/tests/test for upload
@@ -116,12 +128,24 @@ jobs:
     # Checkout repos
     - name: Checkout ci.gradle
       uses: actions/checkout@v3
+    # Set up Java 17 for Gradle (regardless of matrix Java version)
+    - name: Setup Java 17 for Gradle
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'adopt'
+        java-version: '17'
+        cache: 'gradle'
+        java-package: jdk
+    # Store Java 17 home for Gradle
+    - name: Set Gradle Java Home
+      id: gradle-java-home
+      run: echo "GRADLE_JAVA_HOME=$JAVA_HOME" >> $GITHUB_ENV
+    # Set up matrix Java version for testing
     - name: Setup Java ${{ matrix.java }}
       uses: actions/setup-java@v3
       with:
         distribution: 'adopt'
         java-version: ${{ matrix.java }}
-        cache: 'gradle'
         java-package: jdk
     # Moving and cloning to C: drive for Windows for more disk space
     - name: Clone ci.ant, ci.common, ci.gradle repos to C drive
@@ -169,7 +193,7 @@ jobs:
         ./gradlew "clean" "install" "check" "-P'test.include'='**/AbstractIntegrationTest*,**/LibertyTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/PollingDevTest*'" `
         "-Druntime=${{ matrix.RUNTIME }}" "-DruntimeVersion=${{ matrix.RUNTIME_VERSION }}" `
         "-Dfile.encoding=UTF-8" "-Dorg.gradle.jvmargs=-Dfile.encoding=UTF-8" `
-        "-Dorg.gradle.java.home=${{ env.JAVA_HOME }}" `
+        "-Dorg.gradle.java.home=${{ env.GRADLE_JAVA_HOME }}" `
         "--stacktrace" "--info" "--warning-mode=all"
       timeout-minutes: 75
     # Copy build reports and upload artifact if build failed

--- a/build.gradle
+++ b/build.gradle
@@ -176,7 +176,6 @@ tasks.withType(Test) {
     javaLauncher = javaToolchains.launcherFor {
         languageVersion = JavaLanguageVersion.of(8)
     }
-    options.encoding = 'UTF-8'
     systemProperty 'file.encoding', 'UTF-8'
     systemProperty 'org.gradle.java.home', System.getProperty('org.gradle.java.home')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,11 @@ tasks.withType(JavaCompile).configureEach {
     options.encoding = "UTF-8"
 }
 
+// Ensure test tasks use UTF-8 encoding via JVM args, not via options.encoding
+tasks.withType(Test).configureEach {
+    jvmArgs '-Dfile.encoding=UTF-8'
+}
+
 compileJava {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17

--- a/build.gradle
+++ b/build.gradle
@@ -46,23 +46,23 @@ tasks.withType(Test).configureEach {
 }
 
 compileJava {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 compileGroovy {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 compileTestGroovy {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 // In-order to support both Java 17 and Java 21, we configure the toolchain

--- a/build.gradle
+++ b/build.gradle
@@ -37,23 +37,33 @@ configurations {
 }
 
 compileJava {
+    options.encoding = 'UTF-8'
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 compileTestJava {
+    options.encoding = 'UTF-8'
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 compileGroovy {
+    options.encoding = 'UTF-8'
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 compileTestGroovy {
+    options.encoding = 'UTF-8'
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
 }
 
 def libertyAntVersion = "1.9.16"

--- a/build.gradle
+++ b/build.gradle
@@ -172,6 +172,15 @@ test {
     }
 }
 
+tasks.withType(Test) {
+    javaLauncher = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+    options.encoding = 'UTF-8'
+    systemProperty 'file.encoding', 'UTF-8'
+    systemProperty 'org.gradle.java.home', System.getProperty('org.gradle.java.home')
+}
+
 pluginBundle {
     website = 'https://github.com/OpenLiberty/ci.gradle'
     vcsUrl = 'https://github.com/OpenLiberty/ci.gradle'

--- a/build.gradle
+++ b/build.gradle
@@ -36,33 +36,33 @@ configurations {
     provided
 }
 
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = "UTF-8"
+}
+
 compileJava {
-    options.encoding = 'UTF-8'
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 compileTestJava {
-    options.encoding = 'UTF-8'
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 compileGroovy {
-    options.encoding = 'UTF-8'
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 compileTestGroovy {
-    options.encoding = 'UTF-8'
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(8)
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }
 
@@ -170,14 +170,6 @@ test {
             include pattern
         }
     }
-}
-
-tasks.withType(Test) {
-    javaLauncher = javaToolchains.launcherFor {
-        languageVersion = JavaLanguageVersion.of(8)
-    }
-    systemProperty 'file.encoding', 'UTF-8'
-    systemProperty 'org.gradle.java.home', System.getProperty('org.gradle.java.home')
 }
 
 pluginBundle {

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DeployTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DeployTask.groovy
@@ -36,6 +36,7 @@ import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.api.artifacts.ResolvedDependency
 import org.gradle.api.file.FileCollection
 import org.gradle.api.logging.LogLevel
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import org.w3c.dom.Element
 
@@ -115,7 +116,7 @@ class DeployTask extends AbstractServerTask {
         }
     }
 
-    private void installMultipleApps(List<Task> applications, String appsDir) {
+    protected void installMultipleApps(List<Task> applications, String appsDir) {
         applications.each{ Task task ->
             installProject(task, appsDir)
         }
@@ -258,7 +259,7 @@ class DeployTask extends AbstractServerTask {
         }
     }
 
-    private void installLooseApplication(Task task, String appsDir) throws Exception {
+    protected void installLooseApplication(Task task, String appsDir) throws Exception {
         String looseConfigFileName = getLooseConfigFileName(task)
         String application = looseConfigFileName.substring(0, looseConfigFileName.length()-4)
         File destDir = new File(getServerDir(project), appsDir)
@@ -299,7 +300,7 @@ class DeployTask extends AbstractServerTask {
         }
     }
 
-    private void installAndVerify(LooseConfigData config, File looseConfigFile, String applicationName, String appsDir) {
+    protected void installAndVerify(LooseConfigData config, File looseConfigFile, String applicationName, String appsDir) {
         deleteApplication(new File(getServerDir(project), "apps"), looseConfigFile)
         deleteApplication(new File(getServerDir(project), "dropins"), looseConfigFile)
         config.toXmlFile(looseConfigFile)
@@ -370,7 +371,7 @@ class DeployTask extends AbstractServerTask {
         return false;
     }
 
-    private void addWarEmbeddedLib(Element parent, LooseApplication looseApp, Task task) throws Exception {
+    protected void addWarEmbeddedLib(Element parent, LooseApplication looseApp, Task task) throws Exception {
         ArrayList<File> deps = new ArrayList<File>();
         task.classpath.each {
             deps.add(it)
@@ -592,7 +593,7 @@ class DeployTask extends AbstractServerTask {
         }
     }
 
-    private String getProjectPath(File parentProjectDir, File dep) {
+    protected String getProjectPath(File parentProjectDir, File dep) {
         String dependencyPathPortion = dep.getAbsolutePath().replace(parentProjectDir.getAbsolutePath(),"")
         String projectPath = dep.getAbsolutePath().replace(dependencyPathPortion,"")
         Pattern pattern
@@ -612,7 +613,8 @@ class DeployTask extends AbstractServerTask {
         return projectPath
     }
 
-    private boolean isSupportedType(){
+    @Internal
+    protected boolean isSupportedType(){
         switch (getPackagingType()) {
             case "ear":
             case "war":
@@ -679,7 +681,7 @@ class DeployTask extends AbstractServerTask {
         return applicationDirectory
     }
 
-    private boolean shouldValidateAppStart() throws GradleException {
+    protected boolean shouldValidateAppStart() throws GradleException {
         try {
             return new File(getServerDir(project).getCanonicalPath()  + "/workarea/.sRunning").exists()
         } catch (IOException ioe) {

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/StopTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/StopTask.groovy
@@ -41,16 +41,12 @@ class StopTask extends AbstractServerTask {
                 File serverXmlFile = new File(serverDir,"server.xml")
                 boolean defaultServerTemplateUsed = copyDefaultServerTemplate(getInstallDir(project),serverDir)
                 if (serverXmlFile.exists()) {
-                    println("SAJEER:::: Stopping server - found server.xml file")
                     ServerTask serverTaskStop = createServerTask(project, "stop");
                     serverTaskStop.setUseEmbeddedServer(server.embedded)
                     serverTaskStop.execute()
-                    println("SAJEER:::: Stopping server - executed stop task")
 
-                    println("SAJEER:::: Verifying server is stopped - found server.xml file")
                     // Verify server is fully stopped and resources are released
                     if (!ServerUtils.verifyServerFullyStopped(serverDir, logger)) {
-                        println("SAJEER:::: Force stopping server")
                         // If normal stop verification fails, try forced cleanup
                         ServerUtils.forceCleanupServerResources(serverDir, logger)
                     }

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/StopTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/StopTask.groovy
@@ -41,12 +41,16 @@ class StopTask extends AbstractServerTask {
                 File serverXmlFile = new File(serverDir,"server.xml")
                 boolean defaultServerTemplateUsed = copyDefaultServerTemplate(getInstallDir(project),serverDir)
                 if (serverXmlFile.exists()) {
+                    println("SAJEER:::: Stopping server - found server.xml file")
                     ServerTask serverTaskStop = createServerTask(project, "stop");
                     serverTaskStop.setUseEmbeddedServer(server.embedded)
                     serverTaskStop.execute()
-                    
+                    println("SAJEER:::: Stopping server - executed stop task")
+
+                    println("SAJEER:::: Verifying server is stopped - found server.xml file")
                     // Verify server is fully stopped and resources are released
                     if (!ServerUtils.verifyServerFullyStopped(serverDir, logger)) {
+                        println("SAJEER:::: Force stopping server")
                         // If normal stop verification fails, try forced cleanup
                         ServerUtils.forceCleanupServerResources(serverDir, logger)
                     }

--- a/src/test/groovy/io/openliberty/tools/gradle/LibertyTest.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/LibertyTest.groovy
@@ -101,7 +101,6 @@ class LibertyTest extends AbstractIntegrationTest{
     @Test
     public void test4_stop() {
         try{
-            println("SAJEER:::: Stopping server")
             runTasks(buildDir, 'libertyStop')
         } catch (Exception e) {
             throw new AssertionError ("Fail on task libertyStop.", e)

--- a/src/test/groovy/io/openliberty/tools/gradle/LibertyTest.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/LibertyTest.groovy
@@ -101,6 +101,7 @@ class LibertyTest extends AbstractIntegrationTest{
     @Test
     public void test4_stop() {
         try{
+            println("SAJEER:::: Stopping server")
             runTasks(buildDir, 'libertyStop')
         } catch (Exception e) {
             throw new AssertionError ("Fail on task libertyStop.", e)

--- a/src/test/resources/dev-test/basic-dev-project/build.gradle
+++ b/src/test/resources/dev-test/basic-dev-project/build.gradle
@@ -1,8 +1,11 @@
 apply plugin: "liberty"
 apply plugin: "war"
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 tasks.withType(JavaCompile) {
     options.encoding = "UTF-8"
 }

--- a/src/test/resources/dev-test/basic-dev-project/build.gradle
+++ b/src/test/resources/dev-test/basic-dev-project/build.gradle
@@ -2,8 +2,8 @@ apply plugin: "liberty"
 apply plugin: "war"
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 tasks.withType(JavaCompile) {

--- a/src/test/resources/dev-test/basic-dev-project/build.gradle
+++ b/src/test/resources/dev-test/basic-dev-project/build.gradle
@@ -2,8 +2,8 @@ apply plugin: "liberty"
 apply plugin: "war"
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 tasks.withType(JavaCompile) {

--- a/src/test/resources/dev-test/dev-container/build.gradle
+++ b/src/test/resources/dev-test/dev-container/build.gradle
@@ -1,8 +1,11 @@
 apply plugin: "liberty"
 apply plugin: "war"
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 tasks.withType(JavaCompile) {
     options.encoding = "UTF-8"
 }

--- a/src/test/resources/dev-test/dev-container/build.gradle
+++ b/src/test/resources/dev-test/dev-container/build.gradle
@@ -2,8 +2,8 @@ apply plugin: "liberty"
 apply plugin: "war"
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 tasks.withType(JavaCompile) {

--- a/src/test/resources/dev-test/dev-container/build.gradle
+++ b/src/test/resources/dev-test/dev-container/build.gradle
@@ -2,8 +2,8 @@ apply plugin: "liberty"
 apply plugin: "war"
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 tasks.withType(JavaCompile) {


### PR DESCRIPTION
Covers the Development Mode Test fixes of migration from Gradle 8 to 9. The remaining set of fixes will be raised as other PRs. Issue #868 

#### Below Development Mode Test Failures are Fixed
- `BaseDevTest.groovy` - Base development mode testing 
- `DevTest.groovy` - Development mode functionality  
- `DevRecompileTest.groovy` - Development mode recompilation 
- `PollingDevTest.groovy` - Polling development mode 

## Fixed failures in Development Mode Test Classes

#### Java Compilation Properties
- Updated Java compilation properties syntax to be Gradle 9 compatible in all test projects
- Changed from deprecated `sourceCompatibility = 1.8` syntax to:
  ```gradle
  java {
      sourceCompatibility = JavaVersion.VERSION_1_8
      targetCompatibility = JavaVersion.VERSION_1_8
  }
  ```
- Updated in:
  - `src/test/resources/dev-test/basic-dev-project/build.gradle`
  - `src/test/resources/dev-test/dev-container/build.gradle`
  - Other test project build files as needed

#### Method Visibility Changes in DeployTask
Changed several methods from `private` to `protected` to fix method resolution issues in Gradle 9:
- `installMultipleApps(List<Task> applications, String appsDir)`
- `installLooseApplication(Task task, String appsDir)`
- `addWarEmbeddedLib(Element parent, LooseApplication looseApp, Task task)`
- `isSupportedType()`
##### Reference
https://docs.gradle.org/current/userguide/upgrading_major_version_9.html#private_properties_and_methods_may_be_inaccessible_in_closures
As per this, when upgrading to Gradle 9 (which uses Groovy 4), closures defined in a parent class that reference its private properties or methods may no longer have access to them in subclasses. This is due to a Groovy bug that will not be resolved until Groovy 5. As a result, we might encounter MissingMethodException or similar errors when private methods are accessed from closures in subclasses, affecting both build scripts and plugins written in Groovy.

#### Known Issues
- Gradle 9 shows deprecation warnings that will make it incompatible with Gradle 10
