### PR TITLE
Gradle version migration - Feature Installation Tests

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -26,8 +26,6 @@ jobs:
     #          - java: 11
     #            RUNTIME: ol
     name: ${{ matrix.RUNTIME }} ${{ matrix.RUNTIME_VERSION }}, Java ${{ matrix.java }}, Linux
-    env:
-      TEST_INCLUDE: ${{ '**/AbstractIntegrationTest*,**/LibertyTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/PollingDevTest*,**/InstallFeature_acceptLicense*,**/InstallFeature_localEsa_Test*,**/InstallFeature_multiple*,**/InstallFeature_single*,**/DevSkipInstallFeatureTest*,**/DevSkipInstallFeatureConfigTest*,**/KernelInstallFeatureTest*,**/KernelInstallVersionlessFeatureTest*,**/WLPKernelInstallFeatureTest*,**/InstallUsrFeature_toExt*' }}
     steps:
       # Checkout repos
       - name: Checkout ci.gradle
@@ -81,7 +79,7 @@ jobs:
       - name: Run tests with Gradle on Ubuntu
         run:
           # ./gradlew clean install check -P"test.exclude"="**/TestSpringBootApplication30*,**/TestCompileJSPSource17*,**/DevContainerTest*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --warning-mode=all
-          ./gradlew clean install check -P"test.include"="${{TEST_INCLUDE}}" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --warning-mode=all
+          ./gradlew clean install check -P"test.include"="'**/AbstractIntegrationTest*,**/LibertyTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/PollingDevTest*,**/InstallFeature_acceptLicense*,**/InstallFeature_localEsa_Test*,**/InstallFeature_multiple*,**/InstallFeature_single*,**/DevSkipInstallFeatureTest*,**/DevSkipInstallFeatureConfigTest*,**/KernelInstallFeatureTest*,**/KernelInstallVersionlessFeatureTest*,**/WLPKernelInstallFeatureTest*,**/InstallUsrFeature_toExt*'" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --warning-mode=all
       # Copy build reports and upload artifact if build failed
       - name: Copy build/report/tests/test for upload
         if: ${{ failure() }}
@@ -115,7 +113,6 @@ jobs:
     #            RUNTIME: wlp
     name: ${{ matrix.RUNTIME }} ${{ matrix.RUNTIME_VERSION }}, Java ${{ matrix.java }}, Windows
     env:
-      TEST_INCLUDE: ${{ '**/AbstractIntegrationTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/InstallFeature_acceptLicense*,**/InstallFeature_localEsa_Test*,**/InstallFeature_multiple*,**/InstallFeature_single*,**/DevSkipInstallFeatureTest*,**/DevSkipInstallFeatureConfigTest*,**/KernelInstallFeatureTest*,**/KernelInstallVersionlessFeatureTest*,**/WLPKernelInstallFeatureTest*,**/InstallUsrFeature_toExt*' }}
 #      TEST_EXCLUDE: ${{ ((matrix.java == '8') && '**/TestCreateWithConfigDir*,**/Polling*,**/LibertyTest*,**/GenerateFeaturesTest*,**/TestSpringBootApplication30*,**/TestCompileJSPSource17*,**/DevContainerTest*') || '**/Polling*,**/LibertyTest*,**/GenerateFeaturesTest*,**/TestSpringBootApplication30*,**/TestCompileJSPSource17*,**/DevContainerTest*' }}
     steps:
       # Checkout repos
@@ -173,7 +170,7 @@ jobs:
         # For Java 8, TestCreateWithConfigDir is excluded because test_micro_clean_liberty_plugin_variable_config runs out of memory
         # run: ./gradlew clean install check -P"test.exclude"="${{env.TEST_EXCLUDE}}" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --no-daemon
         # run: ./gradlew clean install check -P"test.include"="'**/AbstractIntegrationTest*,**/LibertyTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/PollingDevTest*'" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --no-daemon
-        run: ./gradlew clean install check -P"test.include"="${{env.TEST_INCLUDE}}" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --no-daemon
+        run: ./gradlew clean install check -P"test.include"="'**/AbstractIntegrationTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/InstallFeature_acceptLicense*,**/InstallFeature_localEsa_Test*,**/InstallFeature_multiple*,**/InstallFeature_single*,**/DevSkipInstallFeatureTest*,**/DevSkipInstallFeatureConfigTest*,**/KernelInstallFeatureTest*,**/KernelInstallVersionlessFeatureTest*,**/WLPKernelInstallFeatureTest*,**/InstallUsrFeature_toExt*'" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --no-daemon
         timeout-minutes: 75
       # Copy build reports and upload artifact if build failed
       - name: Copy build/report/tests/test for upload

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -26,6 +26,8 @@ jobs:
     #          - java: 11
     #            RUNTIME: ol
     name: ${{ matrix.RUNTIME }} ${{ matrix.RUNTIME_VERSION }}, Java ${{ matrix.java }}, Linux
+    env:
+      TEST_INCLUDE: '**/AbstractIntegrationTest*,**/LibertyTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/PollingDevTest*,**/InstallFeature_acceptLicense*,**/InstallFeature_localEsa_Test*,**/InstallFeature_multiple*,**/InstallFeature_single*,**/DevSkipInstallFeatureTest*,**/DevSkipInstallFeatureConfigTest*,**/KernelInstallFeatureTest*,**/KernelInstallVersionlessFeatureTest*,**/WLPKernelInstallFeatureTest*,**/InstallUsrFeature_toExt*'
     steps:
       # Checkout repos
       - name: Checkout ci.gradle
@@ -79,7 +81,7 @@ jobs:
       - name: Run tests with Gradle on Ubuntu
         run:
           # ./gradlew clean install check -P"test.exclude"="**/TestSpringBootApplication30*,**/TestCompileJSPSource17*,**/DevContainerTest*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --warning-mode=all
-          ./gradlew clean install check -P"test.include"="**/AbstractIntegrationTest*,**/LibertyTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/PollingDevTest*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --warning-mode=all
+          ./gradlew clean install check -P"test.include"="${{TEST_INCLUDE}}" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --warning-mode=all
       # Copy build reports and upload artifact if build failed
       - name: Copy build/report/tests/test for upload
         if: ${{ failure() }}
@@ -112,7 +114,8 @@ jobs:
     #          - java: 11
     #            RUNTIME: wlp
     name: ${{ matrix.RUNTIME }} ${{ matrix.RUNTIME_VERSION }}, Java ${{ matrix.java }}, Windows
-#    env:
+    env:
+      TEST_INCLUDE: '**/AbstractIntegrationTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/InstallFeature_acceptLicense*,**/InstallFeature_localEsa_Test*,**/InstallFeature_multiple*,**/InstallFeature_single*,**/DevSkipInstallFeatureTest*,**/DevSkipInstallFeatureConfigTest*,**/KernelInstallFeatureTest*,**/KernelInstallVersionlessFeatureTest*,**/WLPKernelInstallFeatureTest*,**/InstallUsrFeature_toExt*'
 #      TEST_EXCLUDE: ${{ ((matrix.java == '8') && '**/TestCreateWithConfigDir*,**/Polling*,**/LibertyTest*,**/GenerateFeaturesTest*,**/TestSpringBootApplication30*,**/TestCompileJSPSource17*,**/DevContainerTest*') || '**/Polling*,**/LibertyTest*,**/GenerateFeaturesTest*,**/TestSpringBootApplication30*,**/TestCompileJSPSource17*,**/DevContainerTest*' }}
     steps:
       # Checkout repos
@@ -170,7 +173,7 @@ jobs:
         # For Java 8, TestCreateWithConfigDir is excluded because test_micro_clean_liberty_plugin_variable_config runs out of memory
         # run: ./gradlew clean install check -P"test.exclude"="${{env.TEST_EXCLUDE}}" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --no-daemon
         # run: ./gradlew clean install check -P"test.include"="'**/AbstractIntegrationTest*,**/LibertyTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/PollingDevTest*'" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --no-daemon
-        run: ./gradlew clean install check -P"test.include"="'**/AbstractIntegrationTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*'" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --no-daemon
+        run: ./gradlew clean install check -P"test.include"="${{env.TEST_INCLUDE}}" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --no-daemon
         timeout-minutes: 75
       # Copy build reports and upload artifact if build failed
       - name: Copy build/report/tests/test for upload

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Run tests with Gradle on Ubuntu
         run:
           # ./gradlew clean install check -P"test.exclude"="**/TestSpringBootApplication30*,**/TestCompileJSPSource17*,**/DevContainerTest*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --warning-mode=all
-          ./gradlew clean install check -P"test.include"="'**/AbstractIntegrationTest*,**/LibertyTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/PollingDevTest*,**/InstallFeature_acceptLicense*,**/InstallFeature_localEsa_Test*,**/InstallFeature_multiple*,**/InstallFeature_single*,**/DevSkipInstallFeatureTest*,**/DevSkipInstallFeatureConfigTest*,**/KernelInstallFeatureTest*,**/KernelInstallVersionlessFeatureTest*,**/WLPKernelInstallFeatureTest*,**/InstallUsrFeature_toExt*'" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --warning-mode=all
+          ./gradlew clean install check -P"test.include"="**/AbstractIntegrationTest*,**/LibertyTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/PollingDevTest*,**/InstallFeature_acceptLicense*,**/InstallFeature_localEsa_Test*,**/InstallFeature_multiple*,**/InstallFeature_single*,**/DevSkipInstallFeatureTest*,**/DevSkipInstallFeatureConfigTest*,**/KernelInstallFeatureTest*,**/KernelInstallVersionlessFeatureTest*,**/WLPKernelInstallFeatureTest*,**/InstallUsrFeature_toExt*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --warning-mode=all
       # Copy build reports and upload artifact if build failed
       - name: Copy build/report/tests/test for upload
         if: ${{ failure() }}
@@ -112,7 +112,7 @@ jobs:
     #          - java: 11
     #            RUNTIME: wlp
     name: ${{ matrix.RUNTIME }} ${{ matrix.RUNTIME_VERSION }}, Java ${{ matrix.java }}, Windows
-    env:
+#    env:
 #      TEST_EXCLUDE: ${{ ((matrix.java == '8') && '**/TestCreateWithConfigDir*,**/Polling*,**/LibertyTest*,**/GenerateFeaturesTest*,**/TestSpringBootApplication30*,**/TestCompileJSPSource17*,**/DevContainerTest*') || '**/Polling*,**/LibertyTest*,**/GenerateFeaturesTest*,**/TestSpringBootApplication30*,**/TestCompileJSPSource17*,**/DevContainerTest*' }}
     steps:
       # Checkout repos

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -27,7 +27,7 @@ jobs:
     #            RUNTIME: ol
     name: ${{ matrix.RUNTIME }} ${{ matrix.RUNTIME_VERSION }}, Java ${{ matrix.java }}, Linux
     env:
-      TEST_INCLUDE: '**/AbstractIntegrationTest*,**/LibertyTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/PollingDevTest*,**/InstallFeature_acceptLicense*,**/InstallFeature_localEsa_Test*,**/InstallFeature_multiple*,**/InstallFeature_single*,**/DevSkipInstallFeatureTest*,**/DevSkipInstallFeatureConfigTest*,**/KernelInstallFeatureTest*,**/KernelInstallVersionlessFeatureTest*,**/WLPKernelInstallFeatureTest*,**/InstallUsrFeature_toExt*'
+      TEST_INCLUDE: ${{ '**/AbstractIntegrationTest*,**/LibertyTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/PollingDevTest*,**/InstallFeature_acceptLicense*,**/InstallFeature_localEsa_Test*,**/InstallFeature_multiple*,**/InstallFeature_single*,**/DevSkipInstallFeatureTest*,**/DevSkipInstallFeatureConfigTest*,**/KernelInstallFeatureTest*,**/KernelInstallVersionlessFeatureTest*,**/WLPKernelInstallFeatureTest*,**/InstallUsrFeature_toExt*' }}
     steps:
       # Checkout repos
       - name: Checkout ci.gradle
@@ -115,7 +115,7 @@ jobs:
     #            RUNTIME: wlp
     name: ${{ matrix.RUNTIME }} ${{ matrix.RUNTIME_VERSION }}, Java ${{ matrix.java }}, Windows
     env:
-      TEST_INCLUDE: '**/AbstractIntegrationTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/InstallFeature_acceptLicense*,**/InstallFeature_localEsa_Test*,**/InstallFeature_multiple*,**/InstallFeature_single*,**/DevSkipInstallFeatureTest*,**/DevSkipInstallFeatureConfigTest*,**/KernelInstallFeatureTest*,**/KernelInstallVersionlessFeatureTest*,**/WLPKernelInstallFeatureTest*,**/InstallUsrFeature_toExt*'
+      TEST_INCLUDE: ${{ '**/AbstractIntegrationTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/InstallFeature_acceptLicense*,**/InstallFeature_localEsa_Test*,**/InstallFeature_multiple*,**/InstallFeature_single*,**/DevSkipInstallFeatureTest*,**/DevSkipInstallFeatureConfigTest*,**/KernelInstallFeatureTest*,**/KernelInstallVersionlessFeatureTest*,**/WLPKernelInstallFeatureTest*,**/InstallUsrFeature_toExt*' }}
 #      TEST_EXCLUDE: ${{ ((matrix.java == '8') && '**/TestCreateWithConfigDir*,**/Polling*,**/LibertyTest*,**/GenerateFeaturesTest*,**/TestSpringBootApplication30*,**/TestCompileJSPSource17*,**/DevContainerTest*') || '**/Polling*,**/LibertyTest*,**/GenerateFeaturesTest*,**/TestSpringBootApplication30*,**/TestCompileJSPSource17*,**/DevContainerTest*' }}
     steps:
       # Checkout repos

--- a/src/test/resources/dev-test/dev-skip-feature-install/build.gradle
+++ b/src/test/resources/dev-test/dev-skip-feature-install/build.gradle
@@ -2,8 +2,8 @@ apply plugin: "liberty"
 apply plugin: "war"
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 tasks.withType(JavaCompile) {

--- a/src/test/resources/dev-test/dev-skip-feature-install/build.gradle
+++ b/src/test/resources/dev-test/dev-skip-feature-install/build.gradle
@@ -1,8 +1,11 @@
 apply plugin: "liberty"
 apply plugin: "war"
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
 tasks.withType(JavaCompile) {
     options.encoding = "UTF-8"
 }

--- a/src/test/resources/dev-test/dev-skip-feature-install/buildInstallLiberty.gradle
+++ b/src/test/resources/dev-test/dev-skip-feature-install/buildInstallLiberty.gradle
@@ -2,8 +2,8 @@ apply plugin: "liberty"
 apply plugin: "war"
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 tasks.withType(JavaCompile) {

--- a/src/test/resources/dev-test/dev-skip-feature-install/buildInstallLiberty.gradle
+++ b/src/test/resources/dev-test/dev-skip-feature-install/buildInstallLiberty.gradle
@@ -1,8 +1,11 @@
 apply plugin: "liberty"
 apply plugin: "war"
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
 tasks.withType(JavaCompile) {
     options.encoding = "UTF-8"
 }

--- a/src/test/resources/dev-test/dev-skip-feature-install/buildSkipInstallFeature.gradle
+++ b/src/test/resources/dev-test/dev-skip-feature-install/buildSkipInstallFeature.gradle
@@ -2,8 +2,8 @@ apply plugin: "liberty"
 apply plugin: "war"
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 tasks.withType(JavaCompile) {

--- a/src/test/resources/dev-test/dev-skip-feature-install/buildSkipInstallFeature.gradle
+++ b/src/test/resources/dev-test/dev-skip-feature-install/buildSkipInstallFeature.gradle
@@ -1,8 +1,11 @@
 apply plugin: "liberty"
 apply plugin: "war"
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
 tasks.withType(JavaCompile) {
     options.encoding = "UTF-8"
 }


### PR DESCRIPTION
Covers the Feature Installation Test fixes of migration from Gradle 8 to 9. The remaining set of fixes will be raised as other PRs. Issue #868 

Below Feature Installation Test Failures are Fixed
- `DevSkipInstallFeatureTest.groovy` - Skip feature installation in dev mode 
- `DevSkipInstallFeatureConfigTest.groovy` - Skip feature installation configuration

Other tests in the below list were working correctly
- `InstallFeature_acceptLicense.groovy` - License acceptance testing 
- `InstallFeature_localEsa_Test.groovy` - Local ESA feature installation 
- `InstallFeature_multiple.groovy` - Multiple feature installation 
- `InstallFeature_single.groovy` - Single feature installation 
- `KernelInstallFeatureTest.groovy` - Kernel feature installation 
- `KernelInstallVersionlessFeatureTest.groovy` - Versionless feature installation 
- `WLPKernelInstallFeatureTest.groovy` - WLP kernel feature installation 
- `InstallUsrFeature_toExt.groovy` - User feature to extension installation

## Fixed failures in Feature Installation Test Classes

#### Java Compilation Properties
- Updated Java compilation properties syntax to be Gradle 9 compatible in all test projects
- Changed from deprecated `sourceCompatibility = 1.8` syntax to:
  ```gradle
  java {
      sourceCompatibility = JavaVersion.VERSION_1_8
      targetCompatibility = JavaVersion.VERSION_1_8
  }
  ```
- Updated in:
  - `src/test/resources/dev-test/dev-skip-feature-install/build.gradle`
  - `src/test/resources/dev-test/dev-skip-feature-install/buildInstallLiberty.gradle`
  - `src/test/resources/dev-test/dev-skip-feature-install/buildSkipInstallFeature.gradle`