### PR TITLE
Gradle version migration - Application Configuration Tests

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Run tests with Gradle on Ubuntu
         run:
           # ./gradlew clean install check -P"test.exclude"="**/TestSpringBootApplication30*,**/TestCompileJSPSource17*,**/DevContainerTest*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --warning-mode=all
-          ./gradlew clean install check -P"test.include"="**/AbstractIntegrationTest*,**/LibertyTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/PollingDevTest*,**/*Install*Feature*,**/InstallLiberty*,**/InstallDir*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --warning-mode=all
+          ./gradlew clean install check -P"test.include"="**/AbstractIntegrationTest*,**/LibertyTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/PollingDevTest*,**/*Install*Feature*,**/InstallLiberty*,**/InstallDir*,**/LibertyApplicationConfiguration*,**/TestAppConfig*,**/TestAppLists*,**/TestGetApp*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --warning-mode=all
       # Copy build reports and upload artifact if build failed
       - name: Copy build/report/tests/test for upload
         if: ${{ failure() }}
@@ -170,7 +170,7 @@ jobs:
         # For Java 8, TestCreateWithConfigDir is excluded because test_micro_clean_liberty_plugin_variable_config runs out of memory
         # run: ./gradlew clean install check -P"test.exclude"="${{env.TEST_EXCLUDE}}" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --no-daemon
         # run: ./gradlew clean install check -P"test.include"="'**/AbstractIntegrationTest*,**/LibertyTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/PollingDevTest*'" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --no-daemon
-        run: ./gradlew clean install check -P"test.include"="'**/AbstractIntegrationTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/*Install*Feature*,**/InstallLiberty*,**/InstallDir*'" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --no-daemon
+        run: ./gradlew clean install check -P"test.include"="'**/AbstractIntegrationTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/*Install*Feature*,**/InstallLiberty*,**/InstallDir*,**/LibertyApplicationConfiguration*,**/TestAppConfig*,**/TestAppLists*,**/TestGetApp*'" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --no-daemon
         timeout-minutes: 75
       # Copy build reports and upload artifact if build failed
       - name: Copy build/report/tests/test for upload

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractServerTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractServerTask.groovy
@@ -1095,19 +1095,30 @@ abstract class AbstractServerTask extends AbstractLibertyTask {
 
         //This loops thorugh all the Dependency objects that get created by the configuration
         for (Dependency dep : project.configurations.libertyApp.getDependencies()) {
+            Dependency depCopy = dep;
+            
+            // In Gradle 9.0.0, we cannot modify dependencies after a configuration has been resolved
+            // Create a detached configuration with a copy of the dependency
+            Configuration detachedConfig;
             if (dep instanceof ModuleDependency) { //Check that dep isn't a File dependency
-                dep.setTransitive(false) //Only want main artifacts, one for Maven and one or more for Gradle/Ivy dependencies
+                // Create a copy of the dependency that we can modify
+                ModuleDependency moduleDep = (ModuleDependency) dep;
+                ModuleDependency depClone = moduleDep.copy();
+                depClone.setTransitive(false); //Only want main artifacts, one for Maven and one or more for Gradle/Ivy dependencies
+                detachedConfig = project.configurations.detachedConfiguration(depClone);
+                depCopy = depClone;
+            } else {
+                detachedConfig = project.configurations.detachedConfiguration(dep);
             }
 
             // In Gradle 9.0.0, the files(dep) method on configurations is no longer supported for dependency objects.
             // Using detachedConfiguration(dep) creates an isolated configuration just for this dependency,
             // and resolve() returns the set of files that make up the artifacts.
-            Configuration detachedConfig = project.configurations.detachedConfiguration(dep)
             Set<File> depArtifacts = detachedConfig.resolve() //Resolve the artifacts
             for (File depArtifact : depArtifacts) {
                 File appFile = depArtifact
-                if (dep instanceof ModuleDependency && server.stripVersion && depArtifact.getName().contains(dep.getVersion())) {
-                    String noVersionName = depArtifact.getName().minus("-" + dep.getVersion()) //Assuming default Gradle naming scheme
+                if (depCopy instanceof ModuleDependency && server.stripVersion && depArtifact.getName().contains(((ModuleDependency)depCopy).getVersion())) {
+                    String noVersionName = depArtifact.getName().minus("-" + ((ModuleDependency)depCopy).getVersion()) //Assuming default Gradle naming scheme
                     File noVersionDependencyFile = new File(project.getLayout().getBuildDirectory().asFile.get(), 'libs/' + noVersionName) //Copying the file to build/libs with no version
                     FileUtils.copyFile(depArtifact, noVersionDependencyFile)
                     appFile = noVersionDependencyFile

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/StartTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/StartTask.groovy
@@ -20,6 +20,7 @@ import io.openliberty.tools.gradle.utils.CommonLogger
 import io.openliberty.tools.gradle.utils.ServerUtils
 import org.gradle.api.GradleException
 import org.gradle.api.Task
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 
 class StartTask extends AbstractServerTask {
@@ -78,6 +79,7 @@ class StartTask extends AbstractServerTask {
         }
     }
 
+    @Internal
     protected Set<String> getAppNamesFromServerXml() {
         Set<String> appNames
 

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/StartTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/StartTask.groovy
@@ -78,7 +78,7 @@ class StartTask extends AbstractServerTask {
         }
     }
 
-    private Set<String> getAppNamesFromServerXml() {
+    protected Set<String> getAppNamesFromServerXml() {
         Set<String> appNames
 
         File serverConfigFile = new File(getServerDir(project), 'server.xml')

--- a/src/test/resources/app-configuration-include-test/test-maven-war/build.gradle
+++ b/src/test/resources/app-configuration-include-test/test-maven-war/build.gradle
@@ -4,8 +4,10 @@ apply plugin: 'maven-publish'
 group = 'test'
 version = '1.0-SNAPSHOT'
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'

--- a/src/test/resources/app-configuration-m2-default-test/test-maven-war/build.gradle
+++ b/src/test/resources/app-configuration-m2-default-test/test-maven-war/build.gradle
@@ -4,8 +4,10 @@ apply plugin: 'maven-publish'
 group = 'test'
 version = '1.0-SNAPSHOT'
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'

--- a/src/test/resources/app-configuration-m2-test/test-maven-war/build.gradle
+++ b/src/test/resources/app-configuration-m2-test/test-maven-war/build.gradle
@@ -4,8 +4,10 @@ apply plugin: 'maven-publish'
 group = 'test'
 version = '1.0-SNAPSHOT'
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'

--- a/src/test/resources/sample.servlet-noWebAppConfig/getAppNamesFromConfigTest.gradle
+++ b/src/test/resources/sample.servlet-noWebAppConfig/getAppNamesFromConfigTest.gradle
@@ -18,8 +18,10 @@ buildscript {
 apply plugin: 'war'
 apply plugin: 'liberty'
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 compileJava.options.encoding = 'UTF-8'
 

--- a/src/test/resources/sample.servlet-noWebAppConfig/testAppListsWithObjects.gradle
+++ b/src/test/resources/sample.servlet-noWebAppConfig/testAppListsWithObjects.gradle
@@ -18,8 +18,10 @@ buildscript {
 apply plugin: 'war'
 apply plugin: 'liberty'
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 compileJava.options.encoding = 'UTF-8'
 

--- a/src/test/resources/sample.servlet/testAppConfig.gradle
+++ b/src/test/resources/sample.servlet/testAppConfig.gradle
@@ -18,8 +18,10 @@ buildscript {
 apply plugin: 'war'
 apply plugin: 'liberty'
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 compileJava.options.encoding = 'UTF-8'
 

--- a/src/test/resources/sample.servlet/testAppConfigFail.gradle
+++ b/src/test/resources/sample.servlet/testAppConfigFail.gradle
@@ -18,8 +18,10 @@ buildscript {
 apply plugin: 'war'
 apply plugin: 'liberty'
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 compileJava.options.encoding = 'UTF-8'
 


### PR DESCRIPTION
Covers the Application Configuration Test fixes of migration from Gradle 8 to 9. The remaining set of fixes will be raised as other PRs. Issue #868 

Below Application Configuration Test Failures are Fixed
- `LibertyApplicationConfigurationTest.groovy` - Basic app configuration
- `LibertyApplicationConfigurationIncludeTest.groovy` - Include configuration
- `LibertyApplicationConfigurationM2Test.groovy` - Maven 2 configuration
- `LibertyApplicationConfigurationM2DefaultTest.groovy` - Maven 2 default configuration
- `TestAppConfig.groovy` - Application configuration testing
- `TestAppConfigFail.groovy` - Application configuration failure scenarios
- `TestAppListsWithObjects.groovy` - Application lists with objects
- `TestGetAppNames.groovy` - Application name retrieval

## Fixed failures in Application Configuration Test Classes

#### Dependency Resolution Changes
- Fixed issues with modifying dependencies after configuration resolution (not allowed in Gradle 9)
- Implemented detached configuration approach for dependency resolution
```groovy
// Before:
dep.setTransitive(false)
Set depArtifacts = project.configurations.libertyApp.files(dep)

// After:
ModuleDependency depClone = moduleDep.copy();
depClone.setTransitive(false);
detachedConfig = project.configurations.detachedConfiguration(depClone);
Set depArtifacts = detachedConfig.resolve()
```
    
Reference: [https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/Configuration.html](https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/Configuration.html)

#### Java Compilation Properties
- Updated Java compilation properties syntax to be Gradle 9 compatible in all test projects
- Changed from deprecated `sourceCompatibility = 1.8` syntax to:
  ```gradle
  java {
      sourceCompatibility = JavaVersion.VERSION_1_8
      targetCompatibility = JavaVersion.VERSION_1_8
  }
  ```
- Updated in:
  - `src/test/resources/app-configuration-include-test/test-maven-war/build.gradle`
  - `src/test/resources/app-configuration-m2-default-test/test-maven-war/build.gradle`
  - `src/test/resources/app-configuration-m2-test/test-maven-war/build.gradle`
  - `src/test/resources/sample.servlet-noWebAppConfig/getAppNamesFromConfigTest.gradle`
  - `src/test/resources/sample.servlet-noWebAppConfig/testAppListsWithObjects.gradle`
  - `src/test/resources/sample.servlet/testAppConfig.gradle`
  - `src/test/resources/sample.servlet/testAppConfigFail.gradle`

#### Method Visibility Changes
Changed`getAppNamesFromServerXml()` method from `private` to `protected` to fix method resolution issues in Gradle 9, also added `@Internal` annotation
##### Reference
https://docs.gradle.org/current/userguide/upgrading_major_version_9.html#private_properties_and_methods_may_be_inaccessible_in_closures
As per this, when upgrading to Gradle 9 (which uses Groovy 4), closures defined in a parent class that reference its private properties or methods may no longer have access to them in subclasses. This is due to a Groovy bug that will not be resolved until Groovy 5. As a result, we might encounter MissingMethodException or similar errors when private methods are accessed from closures in subclasses, affecting both build scripts and plugins written in Groovy.


#### Known Issues
- Gradle 9 shows deprecation warnings that will make it incompatible with Gradle 10