### PR TITLE
Gradle version migration - Packaging Tests

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Run tests with Gradle on Ubuntu
         run:
           # ./gradlew clean install check -P"test.exclude"="**/TestSpringBootApplication30*,**/TestCompileJSPSource17*,**/DevContainerTest*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --warning-mode=all
-          ./gradlew clean install check -P"test.include"="**/AbstractIntegrationTest*,**/LibertyTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/PollingDevTest*,**/*Install*Feature*,**/InstallLiberty*,**/InstallDir*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --warning-mode=all
+          ./gradlew clean install check -P"test.include"="**/AbstractIntegrationTest*,**/LibertyTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/PollingDevTest*,**/*Install*Feature*,**/InstallLiberty*,**/InstallDir*,**/LibertyPackage_*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --warning-mode=all
       # Copy build reports and upload artifact if build failed
       - name: Copy build/report/tests/test for upload
         if: ${{ failure() }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -170,7 +170,7 @@ jobs:
         # For Java 8, TestCreateWithConfigDir is excluded because test_micro_clean_liberty_plugin_variable_config runs out of memory
         # run: ./gradlew clean install check -P"test.exclude"="${{env.TEST_EXCLUDE}}" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --no-daemon
         # run: ./gradlew clean install check -P"test.include"="'**/AbstractIntegrationTest*,**/LibertyTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/PollingDevTest*'" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --no-daemon
-        run: ./gradlew clean install check -P"test.include"="'**/AbstractIntegrationTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/*Install*Feature*,**/InstallLiberty*,**/InstallDir*'" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --no-daemon
+        run: ./gradlew clean install check -P"test.include"="'**/AbstractIntegrationTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/*Install*Feature*,**/InstallLiberty*,**/InstallDir*,**/LibertyPackage_*'" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --no-daemon
         timeout-minutes: 75
       # Copy build reports and upload artifact if build failed
       - name: Copy build/report/tests/test for upload

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractServerTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractServerTask.groovy
@@ -374,7 +374,7 @@ abstract class AbstractServerTask extends AbstractLibertyTask {
         writeServerPropertiesToXml(project)
     }
 
-    private void loadLibertyConfigFromProperties() {
+    protected void loadLibertyConfigFromProperties() {
         Set<Entry<Object, Object>> entries = project.getProperties().entrySet()
         for (Entry<Object, Object> entry : entries) {
             String key = (String) entry.getKey()
@@ -426,7 +426,7 @@ abstract class AbstractServerTask extends AbstractLibertyTask {
         }
     }
 
-    private void addProjectProperty(String propName, String propValue, PropertyType propType) {
+    protected void addProjectProperty(String propName, String propValue, PropertyType propType) {
         if (propValue != null) {
             logger.debug("Processing Liberty configuration from property with type "+ propType +" and name "+ propName +" and value "+ propValue)
         } else {
@@ -631,8 +631,9 @@ abstract class AbstractServerTask extends AbstractLibertyTask {
 
         return new Tuple(appTasks, appFiles)
     }
-    
-    private boolean isSupportedType(){
+
+    @Internal
+    protected boolean isSupportedType(){
       switch (getPackagingType()) {
         case "ear":
         case "war":
@@ -762,7 +763,7 @@ abstract class AbstractServerTask extends AbstractLibertyTask {
         logger.info ("Adding Liberty plugin config info to ${project.getLayout().getBuildDirectory().getAsFile().get()}/liberty-plugin-config.xml.")
     }
 
-    private void writeBootstrapProperties(File file, Properties properties, Map<String, String> projectProperties) throws IOException {
+    protected void writeBootstrapProperties(File file, Properties properties, Map<String, String> projectProperties) throws IOException {
         Map<String,String> convertedProps = convertPropertiesToMap(properties)
         if (! projectProperties.isEmpty()) {
             if (properties == null) {
@@ -812,7 +813,7 @@ abstract class AbstractServerTask extends AbstractLibertyTask {
         return uniqueValues
     }
 
-    private void writeJvmOptions(File file, List<String> options, List<String> projectProperties) throws IOException {
+    protected void writeJvmOptions(File file, List<String> options, List<String> projectProperties) throws IOException {
         List<String> uniqueOptions = getUniqueValues(options)
         List<String> uniqueProps = getUniqueValues(projectProperties)
 
@@ -845,7 +846,7 @@ abstract class AbstractServerTask extends AbstractLibertyTask {
         }
     }
 
-    private String handleServerEnvFileAndProperties(String serverEnvPath, String serverDirectory) {
+    protected String handleServerEnvFileAndProperties(String serverEnvPath, String serverDirectory) {
         File envFile = new File(serverDirectory, "server.env")
         Properties configuredProps = combineServerEnvProperties(server.env, envProjectProps);
 
@@ -857,7 +858,7 @@ abstract class AbstractServerTask extends AbstractLibertyTask {
         }
     }
 
-    private String setServerEnvWithAppendServerEnvHelper(File envFile, String serverEnvPath, Properties configuredProps) {
+    protected String setServerEnvWithAppendServerEnvHelper(File envFile, String serverEnvPath, Properties configuredProps) {
         Properties serverEnvProps = convertServerEnvToProperties(envFile);
         Properties mergedProperties = new Properties();
 
@@ -896,7 +897,7 @@ abstract class AbstractServerTask extends AbstractLibertyTask {
         return serverEnvPath;
     }
 
-    private String setServerEnvPathHelperForAppendServerEnv(File envFile, Properties configuredProps, String serverEnvPath) {
+    protected String setServerEnvPathHelperForAppendServerEnv(File envFile, Properties configuredProps, String serverEnvPath) {
         boolean configDirEnvMerged = serverEnvPath != null;
         boolean serverEnvFileMerged = server.serverEnvFile != null && server.serverEnvFile.exists()
         boolean inlineEnvPropsMerged = !configuredProps.isEmpty()
@@ -926,7 +927,7 @@ abstract class AbstractServerTask extends AbstractLibertyTask {
         return updatedServerEnvPath.toString();
     }
 
-    private String setServerEnvHelper(File envFile, String serverEnvPath, Properties configuredProps) {
+    protected String setServerEnvHelper(File envFile, String serverEnvPath, Properties configuredProps) {
         if ((server.env != null && !server.env.isEmpty()) || !envProjectProps.isEmpty()) {
             Properties envPropsToWrite = configuredProps
             if (serverEnvPath == null && server.serverEnvFile == null) {
@@ -952,7 +953,7 @@ abstract class AbstractServerTask extends AbstractLibertyTask {
      * envProps, to which any of a list of special properties found in envFile have been added.  We give precedence
      * to properties already in envProps.
      */
-    private Properties mergeSpecialPropsFromInstallServerEnvIfAbsent(File envFile, Properties envProps) throws IOException {
+    protected Properties mergeSpecialPropsFromInstallServerEnvIfAbsent(File envFile, Properties envProps) throws IOException {
 
         // Make a copy to avoid side effects 
         Properties mergedProps = new Properties()
@@ -970,7 +971,7 @@ abstract class AbstractServerTask extends AbstractLibertyTask {
     }
 
 
-    private Properties convertServerEnvToProperties(File serverEnv) {
+    protected Properties convertServerEnvToProperties(File serverEnv) {
         Properties serverEnvProps = new Properties();
 
         if ((serverEnv == null) || !serverEnv.exists()) {
@@ -996,7 +997,7 @@ abstract class AbstractServerTask extends AbstractLibertyTask {
         return serverEnvProps;
     }
 
-    private Properties combineServerEnvProperties(Properties properties, Properties projectProperties) {
+    protected Properties combineServerEnvProperties(Properties properties, Properties projectProperties) {
         Properties combinedEnvProperties = new Properties()
         if (! projectProperties.isEmpty()) {
             if (properties.isEmpty()) {
@@ -1013,7 +1014,7 @@ abstract class AbstractServerTask extends AbstractLibertyTask {
         return combinedEnvProperties;
     }
     
-    private void writeServerEnvProperties(File file, Properties combinedEnvProperties) throws IOException {
+    protected void writeServerEnvProperties(File file, Properties combinedEnvProperties) throws IOException {
         makeParentDirectory(file)
         PrintWriter writer = null
         try {
@@ -1032,7 +1033,7 @@ abstract class AbstractServerTask extends AbstractLibertyTask {
     }
 
 
-    private void writeConfigDropinsServerVariables(File file, Properties varProps, Properties varProjectProps, boolean isDefaultVar) throws IOException, TransformerException, ParserConfigurationException {
+    protected void writeConfigDropinsServerVariables(File file, Properties varProps, Properties varProjectProps, boolean isDefaultVar) throws IOException, TransformerException, ParserConfigurationException {
 
         ServerConfigXmlDocument configDocument = ServerConfigXmlDocument.newInstance()
 
@@ -1052,7 +1053,7 @@ abstract class AbstractServerTask extends AbstractLibertyTask {
 
     }
 
-    private void makeParentDirectory(File file) {
+    protected void makeParentDirectory(File file) {
         File parentDir = file.getParentFile()
         if (parentDir != null) {
             parentDir.mkdirs()

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DeployTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DeployTask.groovy
@@ -362,7 +362,7 @@ class DeployTask extends AbstractServerTask {
         looseWar.addManifestFile(manifestFile)
     }
 
-    private boolean hasJavaSourceFiles(FileCollection classpath, File outputDir){
+    protected boolean hasJavaSourceFiles(FileCollection classpath, File outputDir){
         for(File f: classpath) {
             if(f.getAbsolutePath().equals(outputDir.getCanonicalPath())) {
                 return true;
@@ -578,7 +578,7 @@ class DeployTask extends AbstractServerTask {
         }
     }
 
-    private void addLibrary(Element parent, LooseApplication looseApp, String dir, File lib) throws GradleException {
+    protected void addLibrary(Element parent, LooseApplication looseApp, String dir, File lib) throws GradleException {
         if(server.deploy.copyLibsDirectory != null) {
             if(!server.deploy.copyLibsDirectory.exists()) {
                 server.deploy.copyLibsDirectory.mkdirs()

--- a/src/test/resources/liberty-package-test/liberty-package-looseApplication.gradle
+++ b/src/test/resources/liberty-package-test/liberty-package-looseApplication.gradle
@@ -21,8 +21,10 @@ buildscript {
 apply plugin: 'war'
 apply plugin: 'liberty'
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 compileJava.options.encoding = 'UTF-8'
 


### PR DESCRIPTION
Covers the Packaging Test fixes of migration from Gradle 8 to 9. The remaining set of fixes will be raised as other PRs. Issue #868 

#### Below Packaging Test Failures are Fixed
- `LibertyPackage_looseApplication_Test.groovy` - Loose application packaging
- Other packaging tests

## Fixed failures in Packaging Test Classes

#### Java Compilation Properties
- Updated Java compilation properties syntax to be Gradle 9 compatible in test projects
- Changed from deprecated `sourceCompatibility = 1.8` syntax to:
  ```gradle
  java {
      sourceCompatibility = JavaVersion.VERSION_1_8
      targetCompatibility = JavaVersion.VERSION_1_8
  }
  ```
- Updated in:
  - `src/test/resources/liberty-package-test/liberty-package-looseApplication.gradle`

#### Method Visibility Changes in DeployTask
Changed several methods from `private` to `protected` to fix method resolution issues in Gradle 9:
- `hasJavaSourceFiles(FileCollection classpath, File outputDir)`
- `addLibrary(Element parent, LooseApplication looseApp, String dir, File lib)`

##### Reference
https://docs.gradle.org/current/userguide/upgrading_major_version_9.html#private_properties_and_methods_may_be_inaccessible_in_closures
As per this, when upgrading to Gradle 9 (which uses Groovy 4), closures defined in a parent class that reference its private properties or methods may no longer have access to them in subclasses. This is due to a Groovy bug that will not be resolved until Groovy 5. As a result, we might encounter MissingMethodException or similar errors when private methods are accessed from closures in subclasses, affecting both build scripts and plugins written in Groovy.

#### Known Issues
- Gradle 9 shows deprecation warnings that will make it incompatible with Gradle 10
