### PR TITLE
Gradle version migration - Server Creation Tests

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Run tests with Gradle on Ubuntu
         run:
           # ./gradlew clean install check -P"test.exclude"="**/TestSpringBootApplication30*,**/TestCompileJSPSource17*,**/DevContainerTest*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --warning-mode=all
-          ./gradlew clean install check -P"test.include"="**/AbstractIntegrationTest*,**/LibertyTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/PollingDevTest*,**/*Install*Feature*,**/InstallLiberty*,**/InstallDir*,**/LibertyApplicationConfiguration*,**/TestAppConfig*,**/TestAppLists*,**/TestGetApp*,**/TestAppendServerEnvWith*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --warning-mode=all
+          ./gradlew clean install check -P"test.include"="**/AbstractIntegrationTest*,**/LibertyTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/PollingDevTest*,**/*Install*Feature*,**/InstallLiberty*,**/InstallDir*,**/LibertyApplicationConfiguration*,**/TestAppConfig*,**/TestAppLists*,**/TestGetApp*,**/TestAppendServerEnvWith*,**/TestCreate*,**/NoServerNameTest*,**/NoAppsTemplateTest*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --warning-mode=all
       # Copy build reports and upload artifact if build failed
       - name: Copy build/report/tests/test for upload
         if: ${{ failure() }}
@@ -170,7 +170,7 @@ jobs:
         # For Java 8, TestCreateWithConfigDir is excluded because test_micro_clean_liberty_plugin_variable_config runs out of memory
         # run: ./gradlew clean install check -P"test.exclude"="${{env.TEST_EXCLUDE}}" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --no-daemon
         # run: ./gradlew clean install check -P"test.include"="'**/AbstractIntegrationTest*,**/LibertyTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/PollingDevTest*'" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --no-daemon
-        run: ./gradlew clean install check -P"test.include"="'**/AbstractIntegrationTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/*Install*Feature*,**/InstallLiberty*,**/InstallDir*,**/LibertyApplicationConfiguration*,**/TestAppConfig*,**/TestAppLists*,**/TestGetApp*,**/TestAppendServerEnvWith*'" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --no-daemon
+        run: ./gradlew clean install check -P"test.include"="'**/AbstractIntegrationTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/*Install*Feature*,**/InstallLiberty*,**/InstallDir*,**/LibertyApplicationConfiguration*,**/TestAppConfig*,**/TestAppLists*,**/TestGetApp*,**/TestAppendServerEnvWith*,**/TestCreate*,**/NoServerNameTest*,**/NoAppsTemplateTest*'" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --no-daemon
         timeout-minutes: 75
       # Copy build reports and upload artifact if build failed
       - name: Copy build/report/tests/test for upload

--- a/src/test/resources/server-config-files/testCreateLibertyFiles.gradle
+++ b/src/test/resources/server-config-files/testCreateLibertyFiles.gradle
@@ -18,8 +18,10 @@ buildscript {
 apply plugin: 'java'
 apply plugin: 'liberty'
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 compileJava.options.encoding = 'UTF-8'
 

--- a/src/test/resources/server-config-files/testCreateLibertyInlineProperties.gradle
+++ b/src/test/resources/server-config-files/testCreateLibertyInlineProperties.gradle
@@ -18,8 +18,10 @@ buildscript {
 apply plugin: 'java'
 apply plugin: 'liberty'
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 compileJava.options.encoding = 'UTF-8'
 

--- a/src/test/resources/server-config/testCreateLibertyDefaultConfigDir.gradle
+++ b/src/test/resources/server-config/testCreateLibertyDefaultConfigDir.gradle
@@ -18,8 +18,10 @@ buildscript {
 apply plugin: 'java'
 apply plugin: 'liberty'
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 compileJava.options.encoding = 'UTF-8'
 


### PR DESCRIPTION
Covers the Server Creation Test fixes of migration from Gradle 8 to 9. The remaining set of fixes will be raised as other PRs. Issue #868 

#### Below Server Creation Test Failures are Fixed
- `testCreateLibertyFiles.gradle` - Server creation with files configuration
- `testCreateLibertyInlineProperties.gradle` - Server creation with inline properties
- `testCreateLibertyDefaultConfigDir.gradle` - Server creation with default config directory

## Fixed failures in Server Creation Test Classes

#### Java Compilation Properties
- Updated Java compilation properties syntax to be Gradle 9 compatible in test projects
- Changed from deprecated `sourceCompatibility = 1.8` syntax to:
  ```gradle
  java {
      sourceCompatibility = JavaVersion.VERSION_1_8
      targetCompatibility = JavaVersion.VERSION_1_8
  }
  ```
- Updated in:
  - `src/test/resources/server-config-files/testCreateLibertyFiles.gradle`
  - `src/test/resources/server-config-files/testCreateLibertyInlineProperties.gradle`
  - `src/test/resources/server-config/testCreateLibertyDefaultConfigDir.gradle`

#### Known Issues
- Gradle 9 shows deprecation warnings that will make it incompatible with Gradle 10
