### PR TITLE
Gradle version migration - Eclipse Integration Tests

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Run tests with Gradle on Ubuntu
         run:
           # ./gradlew clean install check -P"test.exclude"="**/TestSpringBootApplication30*,**/TestCompileJSPSource17*,**/DevContainerTest*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --warning-mode=all
-          ./gradlew clean install check -P"test.include"="**/AbstractIntegrationTest*,**/LibertyTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/PollingDevTest*,**/*Install*Feature*,**/InstallLiberty*,**/InstallDir*,**/LibertyApplicationConfiguration*,**/TestAppConfig*,**/TestAppLists*,**/TestGetApp*,**/TestAppendServerEnvWith*,**/LibertyPackage_*,**/TestCreate*,**/NoServerNameTest*,**/NoAppsTemplateTest*,**/Verify*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --warning-mode=all
+          ./gradlew clean install check -P"test.include"="**/AbstractIntegrationTest*,**/LibertyTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/PollingDevTest*,**/*Install*Feature*,**/InstallLiberty*,**/InstallDir*,**/LibertyApplicationConfiguration*,**/TestAppConfig*,**/TestAppLists*,**/TestGetApp*,**/TestAppendServerEnvWith*,**/LibertyPackage_*,**/TestCreate*,**/NoServerNameTest*,**/NoAppsTemplateTest*,**/Verify*,**/TestEclipseFacets*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --warning-mode=all
       # Copy build reports and upload artifact if build failed
       - name: Copy build/report/tests/test for upload
         if: ${{ failure() }}
@@ -170,7 +170,7 @@ jobs:
         # For Java 8, TestCreateWithConfigDir is excluded because test_micro_clean_liberty_plugin_variable_config runs out of memory
         # run: ./gradlew clean install check -P"test.exclude"="${{env.TEST_EXCLUDE}}" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --no-daemon
         # run: ./gradlew clean install check -P"test.include"="'**/AbstractIntegrationTest*,**/LibertyTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/PollingDevTest*'" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --no-daemon
-        run: ./gradlew clean install check -P"test.include"="'**/AbstractIntegrationTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/*Install*Feature*,**/InstallLiberty*,**/InstallDir*,**/LibertyApplicationConfiguration*,**/TestAppConfig*,**/TestAppLists*,**/TestGetApp*,**/TestAppendServerEnvWith*,**/LibertyPackage_*,**/TestCreate*,**/NoServerNameTest*,**/NoAppsTemplateTest*,**/Verify*'" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --no-daemon
+        run: ./gradlew clean install check -P"test.include"="'**/AbstractIntegrationTest*,**/BaseDevTest*,**/DevTest*,**/DevRecompileTest*,**/*Install*Feature*,**/InstallLiberty*,**/InstallDir*,**/LibertyApplicationConfiguration*,**/TestAppConfig*,**/TestAppLists*,**/TestGetApp*,**/TestAppendServerEnvWith*,**/LibertyPackage_*,**/TestCreate*,**/NoServerNameTest*,**/NoAppsTemplateTest*,**/Verify*,**/TestEclipseFacets*'" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --no-daemon
         timeout-minutes: 75
       # Copy build reports and upload artifact if build failed
       - name: Copy build/report/tests/test for upload

--- a/src/main/groovy/io/openliberty/tools/gradle/Liberty.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/Liberty.groovy
@@ -101,7 +101,8 @@ class Liberty implements Plugin<Project> {
                 Dependency[] deps = project.configurations.deploy.getAllDependencies().toArray()
                 deps.each { Dependency dep ->
                     if (dep instanceof ProjectDependency) {
-                        def projectDep = dep.getDependencyProject()
+                        def projectPath = dep.getPath()
+                        def projectDep = project.findProject(projectPath)
                         if (projectDep.plugins.hasPlugin('war')) {
                             setFacetVersion(projectDep, 'jst.web', JST_WEB_FACET_VERSION)
                         }

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DeployTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DeployTask.groovy
@@ -449,7 +449,7 @@ class DeployTask extends AbstractServerTask {
 
             if (dependency instanceof ProjectDependency) { 
                 def projectPath = dependency.getPath()
-                Project dependencyProject = task.project.findProject(projectPath)
+                Project dependencyProject = task.getProject().findProject(projectPath)
                 String projectType = FilenameUtils.getExtension(dependencyFile.toString())
                 switch (projectType) {
                     case "jar":
@@ -505,7 +505,7 @@ class DeployTask extends AbstractServerTask {
 
             if (dependency instanceof ProjectDependency) { //Adding the project archive and it's transitve dependencies to the loose ear
                 def projectPath = dependency.getPath()
-                Project dependencyProject = task.project.findProject(projectPath)
+                Project dependencyProject = task.getProject().findProject(projectPath)
 
                 ResolvedArtifact projectArtifact
 

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DeployTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DeployTask.groovy
@@ -447,8 +447,9 @@ class DeployTask extends AbstractServerTask {
             Dependency dependency = entry.getValue();
             File dependencyFile = entry.getKey();
 
-            if (dependency instanceof ProjectDependency) {
-                Project dependencyProject = dependency.getDependencyProject()
+            if (dependency instanceof ProjectDependency) { 
+                def projectPath = dependency.getPath()
+                Project dependencyProject = task.project.findProject(projectPath)
                 String projectType = FilenameUtils.getExtension(dependencyFile.toString())
                 switch (projectType) {
                     case "jar":
@@ -503,7 +504,8 @@ class DeployTask extends AbstractServerTask {
             ResolvedDependency resolvedDependency = entry.getValue();
 
             if (dependency instanceof ProjectDependency) { //Adding the project archive and it's transitve dependencies to the loose ear
-                Project dependencyProject = dependency.getDependencyProject()
+                def projectPath = dependency.getPath()
+                Project dependencyProject = task.project.findProject(projectPath)
 
                 ResolvedArtifact projectArtifact
 
@@ -723,4 +725,3 @@ class DeployTask extends AbstractServerTask {
         }
     }
 }
-

--- a/src/main/groovy/io/openliberty/tools/gradle/utils/DevTaskHelper.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/utils/DevTaskHelper.groovy
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2024
+ * (C) Copyright IBM Corporation 2024, 2025.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/io/openliberty/tools/gradle/utils/DevTaskHelper.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/utils/DevTaskHelper.groovy
@@ -88,7 +88,8 @@ public class DevTaskHelper {
                 Dependency[] deployDeps = element.getAllDependencies().toArray()
                 for (Dependency dependency1: deployDeps) {
                     if (dependency1 instanceof ProjectDependency) {
-                        Project dependencyProject = dependency1.getDependencyProject()
+                        def projectPath = dependency1.getPath()
+                        Project dependencyProject = project.findProject(projectPath)
                         allDependentProjects.add(dependencyProject)
                         allDependentProjects.addAll(getAllUpstreamProjects(dependencyProject))
                     }
@@ -128,7 +129,8 @@ public class DevTaskHelper {
             File dependencyFile = entry.getKey();
 
             if (dependency instanceof ProjectDependency) {
-                Project dependencyProject = dependency.getDependencyProject()
+                def projectPath = dependency.getPath()
+                Project dependencyProject = project.findProject(projectPath)
                 String projectType = FilenameUtils.getExtension(dependencyFile.toString())
                 switch (projectType) {
                     case "war":

--- a/src/test/resources/loose-ear-test/build.gradle
+++ b/src/test/resources/loose-ear-test/build.gradle
@@ -6,8 +6,11 @@ allprojects  {
 subprojects {
     apply plugin: 'java'
 
-    sourceCompatibility = 1.8
-    targetCompatibility = 1.8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
     tasks.withType(JavaCompile) {
         options.encoding = 'UTF-8'
     }


### PR DESCRIPTION
Covers the Eclipse Integration Test fixes of migration from Gradle 8 to 9. The remaining set of fixes will be raised as other PRs. Issue #868 

#### Below Eclipse Integration Test Failures are Fixed
- Eclipse project dependency resolution issues
- Project dependency handling in loose application packaging

## Fixed failures in Eclipse Integration Tests

#### ProjectDependency API Changes
- Updated ProjectDependency handling to be Gradle 9 compatible
- Changed from deprecated `getDependencyProject()` method to using `getPath()` and `findProject()`:
  ```gradle
  // Old approach (Gradle 8)
  def projectDep = dependency.getDependencyProject()
  
  // New approach (Gradle 9)
  def projectPath = dependency.getPath()
  def projectDep = project.findProject(projectPath)
  ```
- Updated in:
  - `src/main/groovy/io/openliberty/tools/gradle/Liberty.groovy`
  - `src/main/groovy/io/openliberty/tools/gradle/tasks/DeployTask.groovy`
  - `src/main/groovy/io/openliberty/tools/gradle/utils/DevTaskHelper.groovy`

#### Java Compilation Properties
- Updated Java compilation properties syntax to be Gradle 9 compatible in test projects
- Changed from deprecated `sourceCompatibility = 1.8` syntax to:
  ```gradle
  java {
      sourceCompatibility = JavaVersion.VERSION_1_8
      targetCompatibility = JavaVersion.VERSION_1_8
  }
  ```
- Updated in:
  - `src/test/resources/loose-ear-test/build.gradle`

##### Reference
https://docs.gradle.org/current/userguide/upgrading_major_version_9.html#project_dependencies_api_changes

As per this, when upgrading to Gradle 9, the `ProjectDependency.getDependencyProject()` method has been deprecated and will be removed in Gradle 10. This method directly accessed the project instance, which could lead to configuration-time project access. The recommended approach is to use `getPath()` to get the project path and then use `findProject()` to resolve the project when needed.

#### Known Issues
- Gradle 9 shows deprecation warnings that will make it incompatible with Gradle 10
