### PR TITLE
Add nmcp plugins and refactor Maven release/snapshot config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,9 @@
+plugins {
+    id 'com.gradle.plugin-publish' version '0.12.0'
+    id("com.gradleup.nmcp").version("1.1.0")
+    id("com.gradleup.nmcp.aggregation").version("1.1.0")
+}
+
 apply plugin: 'groovy'
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
@@ -24,18 +30,6 @@ repositories {
         url = 'https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/maven/repository/'
     }
 
-}
-
-buildscript {
-    repositories {
-        mavenLocal()
-        maven {
-            url = "https://plugins.gradle.org/m2/"
-        }
-    }
-    dependencies {
-        classpath "com.gradle.publish:plugin-publish-plugin:0.12.0"
-    }
 }
 
 configurations {
@@ -226,21 +220,32 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
         signing {
             sign publishing.publications.libertyGradle
         }
+
+        // Publish with publishAggregationToCentralPortal task
+        // Docs: https://github.com/GradleUp/nmcp
+        nmcpAggregation {
+            centralPortal {
+                username = ossrhUsername
+                password = ossrhPassword
+                // Publish manually from the portal
+                publishingType = "USER_MANAGED"
+            }
+            // Required to find projects with the maven-publish plugin (this project)
+            publishAllProjectsProbablyBreakingProjectIsolation()
+        }    
     } else {
         signing.required = false
-    }
 
-    publishing {
-        repositories {
-            maven {
-                name = "Nexus"
-                def releasesRepoUrl = "https://central.sonatype.com/api/v1/publisher"
-                def snapshotsRepoUrl = "https://central.sonatype.com/repository/maven-snapshots/"
-                url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+        publishing {
+            repositories {
+                maven {
+                    name = "Nexus"
+                    url = "https://central.sonatype.com/repository/maven-snapshots/"
 
-                credentials {
-                    username = ossrhUsername
-                    password = ossrhPassword
+                    credentials {
+                        username = ossrhUsername
+                        password = ossrhPassword
+                    }
                 }
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,3 @@
-plugins {
-    id 'com.gradle.plugin-publish' version '0.12.0'
-    id("com.gradleup.nmcp").version("1.1.0")
-    id("com.gradleup.nmcp.aggregation").version("1.1.0")
-}
-
 apply plugin: 'groovy'
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
@@ -30,6 +24,18 @@ repositories {
         url = 'https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/maven/repository/'
     }
 
+}
+
+buildscript {
+    repositories {
+        mavenLocal()
+        maven {
+            url = "https://plugins.gradle.org/m2/"
+        }
+    }
+    dependencies {
+        classpath "com.gradle.publish:plugin-publish-plugin:0.12.0"
+    }
 }
 
 configurations {
@@ -217,22 +223,10 @@ publishing {
 if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')) {
 
     if (!version.endsWith("SNAPSHOT")) {
+        
         signing {
             sign publishing.publications.libertyGradle
         }
-
-        // Publish with publishAggregationToCentralPortal task
-        // Docs: https://github.com/GradleUp/nmcp
-        nmcpAggregation {
-            centralPortal {
-                username = ossrhUsername
-                password = ossrhPassword
-                // Publish manually from the portal
-                publishingType = "USER_MANAGED"
-            }
-            // Required to find projects with the maven-publish plugin (this project)
-            publishAllProjectsProbablyBreakingProjectIsolation()
-        }    
     } else {
         signing.required = false
 

--- a/release.gradle
+++ b/release.gradle
@@ -1,0 +1,33 @@
+buildscript {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        maven {
+            url = "https://plugins.gradle.org/m2/"
+        }
+    }
+    dependencies {
+        classpath "com.gradleup.nmcp:com.gradleup.nmcp.gradle.plugin:1.1.0"
+        // Need to pull the Gradle publish pugin here as well
+        classpath "com.gradle.publish:plugin-publish-plugin:0.12.0"
+    }
+}
+
+apply from: 'build.gradle'
+
+// NMCP Plugin configuration for Maven Central publishing
+apply plugin: 'com.gradleup.nmcp'
+apply plugin: 'com.gradleup.nmcp.aggregation'
+
+// Publish with publishAggregationToCentralPortal task
+// Docs: https://github.com/GradleUp/nmcp
+nmcpAggregation {
+    centralPortal {
+        username = project.findProperty('ossrhUsername')
+        password = project.findProperty('ossrhPassword')
+        // Publish manually from the portal
+        publishingType = "USER_MANAGED"
+    }
+    // Required to find projects with the maven-publish plugin (this project)
+    publishAllProjectsProbablyBreakingProjectIsolation()
+}


### PR DESCRIPTION
Changes to allow publishing to Maven Central:
- Added `nmcp` and `nmcp.aggregation` plugins
- Refactored release/snapshot config in build.gradle
- Moved Gradle `publish-plugin` to plugins block
- New publishing task: `publishAggregationToCentralPortal`
