### PR TITLE
Gradle 8 to Gradle 9 Migration Guide for Liberty Gradle Plugin Users

### DIFF
--- a/docs/Gradle9MigrationGuide.md
+++ b/docs/Gradle9MigrationGuide.md
@@ -1,6 +1,6 @@
 # Gradle 8 to Gradle 9 Migration Guide for Liberty Gradle Plugin Users
 
-This guide provides step-by-step instructions for migrating your Liberty Gradle Plugin projects from Gradle 8 to Gradle 9. It focuses on the key changes that affect end users and provides practical examples to help you update your build scripts.
+This guide provides step-by-step instructions for migrating your projects that use the Liberty Gradle Plugin from Gradle 8 to Gradle 9. It focuses on the key changes that affect end users and provides practical examples to help you update your build scripts.
 
 ## Table of Contents
 
@@ -18,13 +18,13 @@ Gradle 9 requires updates to how you specify Java compatibility in your build sc
 
 ### Update Java Compatibility Settings
 
-**Before (Gradle 8):**
+**Before:**
 ```groovy
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 ```
 
-**After (Gradle 9):**
+**After:**
 ```groovy
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8
@@ -37,8 +37,8 @@ This change is required in all your build scripts that specify Java compatibilit
 **Why this change is necessary:** The Java toolchain approach provides better compatibility with Gradle 9's toolchain support and allows for more flexible Java version management. It also enables clearer error messages when Java version requirements are not met.
 
 **Reference Documentation:**
-- [Gradle 9.0 Upgrading Guide - Java Toolchain](https://docs.gradle.org/current/userguide/upgrading_major_version_9.html#java_toolchain)
-- [Java Plugin - Compatibility](https://docs.gradle.org/current/userguide/java_plugin.html#sec:java_cross_compilation)
+- [Toolchains for JVM projects](https://docs.gradle.org/9.0.0/userguide/toolchains.html#toolchains)
+- [Java Plugin - Compatibility](https://docs.gradle.org/9.0.0/userguide/java_plugin.html#sec:java_cross_compilation)
 
 ## Build Configuration Changes
 
@@ -46,14 +46,14 @@ This change is required in all your build scripts that specify Java compatibilit
 
 If you're using the test task in your build scripts, you may need to update your configuration for Gradle 9 compatibility:
 
-**Before (Gradle 8):**
+**Before:**
 ```groovy
 test {
     // Test configuration
 }
 ```
 
-**After (Gradle 9):**
+**After:**
 ```groovy
 test {
     // Add this line if you have conditional tests that might not always be present
@@ -72,8 +72,8 @@ test {
 Setting `failOnNoDiscoveredTests = false` allows your build to continue even when no tests are found in a particular module or configuration.
 
 **Reference Documentation:**
-- [Gradle Test Task - failOnNoDiscoveredTests property](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.testing.Test.html#org.gradle.api.tasks.testing.Test:failOnNoDiscoveredTests)
-- [Gradle 9.0 Upgrading Guide - Test Task Changes](https://docs.gradle.org/current/userguide/upgrading_major_version_9.html#test_task_fails_when_no_tests_are_discovered)
+- [Gradle Test Task - failOnNoDiscoveredTests property](https://docs.gradle.org/9.0.0/dsl/org.gradle.api.tasks.testing.Test.html#org.gradle.api.tasks.testing.Test:failOnNoDiscoveredTests)
+- [Gradle 9.0 Upgrading Guide - Test Task Changes](https://docs.gradle.org/9.0.0/userguide/upgrading_major_version_9.html#test_task_fails_when_no_tests_are_discovered)
 
 ### Liberty Server Task Ordering
 
@@ -81,15 +81,25 @@ Gradle 9 is more strict about task ordering and resource cleanup. If you're usin
 
 ```groovy
 // Ensure proper task ordering for Liberty server operations
+// Groovy-style syntax
 libertyStop.mustRunAfter libertyStart
 clean.mustRunAfter libertyStop
+
+// Java-style syntax
+libertyStop.mustRunAfter(libertyStart)
+clean.mustRunAfter(libertyStop)
 ```
 
 **Why this change is necessary:** Gradle 9 is more strict about task ordering and resource management. Without proper task ordering, you may encounter file locking issues when the clean task tries to delete files that are still in use by the Liberty server. This ensures that the server is properly stopped before any cleanup tasks run, preventing file locking issues.
 
 **Reference Documentation:**
-- [Gradle Task Ordering](https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:ordering_tasks)
-- [Gradle Task Execution](https://docs.gradle.org/current/userguide/build_lifecycle.html#sec:task_execution)
+- [Gradle Task Ordering](https://docs.gradle.org/9.0.0/userguide/controlling_task_execution.html#sec:ordering_tasks)
+- [Gradle Controlling Task Execution](https://docs.gradle.org/9.0.0/userguide/controlling_task_execution.html)
+- [Gradle Understanding Tasks](https://docs.gradle.org/9.0.0/userguide/more_about_tasks.html)
+
+### JSP Compilation
+
+When using JSP compilation in Gradle 9, the compiler will automatically use the Java version specified in your project's configuration. No specific changes are needed to your JSP compilation tasks beyond updating the Java compatibility syntax as described in the [Java Configuration Updates](#java-configuration-updates) section.
 
 ## Multi-Project Build Changes
 
@@ -120,8 +130,8 @@ artifacts {
 **Why this change is necessary:** In Gradle 9, the behavior of the EAR and WAR plugins has changed to include all artifacts in the `archives` configuration. This can lead to unexpected artifacts being included in your builds. Creating custom configurations gives you precise control over which artifacts are included in your EAR/WAR files and avoids including unnecessary transitive dependencies.
 
 **Reference Documentation:**
-- [Gradle 9.0 Upgrading Guide - EAR and WAR plugins contribute all artifacts to the archives configuration](https://docs.gradle.org/current/userguide/upgrading_major_version_9.html#ear_and_war_plugins_contribute_all_artifacts_to_the_archives_configuration)
-- [Gradle Configurations](https://docs.gradle.org/current/userguide/declaring_dependencies.html#sec:what-are-dependency-configurations)
+- [Gradle 9.0 Upgrading Guide - EAR and WAR plugins contribute all artifacts to the archives configuration](https://docs.gradle.org/9.0.0/userguide/upgrading_major_version_9.html#ear_and_war_plugins_contribute_all_artifacts_to_the_archives_configuration)
+- [Gradle Configurations](https://docs.gradle.org/9.0.0/userguide/declaring_dependencies.html#sec:what-are-dependency-configurations)
 
 ## EAR/WAR/JAR Configuration Changes
 
@@ -129,7 +139,7 @@ artifacts {
 
 If you're building EAR projects, update your EAR configuration to use the custom configurations:
 
-**Before (Gradle 8):**
+**Before:**
 ```groovy
 ear {
     deploymentDescriptor {
@@ -139,7 +149,7 @@ ear {
 }
 ```
 
-**After (Gradle 9):**
+**After:**
 ```groovy
 ear {
     deploymentDescriptor {
@@ -152,14 +162,14 @@ ear {
 **Why this change is necessary:** In Gradle 9, the `archives` configuration now includes all artifacts, which might lead to unexpected artifacts being included in your EAR file. Using custom configurations ensures that only the intended artifacts are included.
 
 **Reference Documentation:**
-- [Gradle 9.0 Upgrading Guide - EAR Plugin Changes](https://docs.gradle.org/current/userguide/upgrading_major_version_9.html#ear_and_war_plugins_contribute_all_artifacts_to_the_archives_configuration)
-- [Gradle EAR Plugin](https://docs.gradle.org/current/userguide/ear_plugin.html)
+- [Gradle 9.0 Upgrading Guide - EAR Plugin Changes](https://docs.gradle.org/9.0.0/userguide/upgrading_major_version_9.html#ear_and_war_plugins_contribute_all_artifacts_to_the_archives_configuration)
+- [Gradle EAR Plugin](https://docs.gradle.org/9.0.0/userguide/ear_plugin.html)
 
 ### WAR Project Configuration
 
 Similarly, update your WAR project configurations:
 
-**Before (Gradle 8):**
+**Before:**
 ```groovy
 war {
     // WAR configuration
@@ -167,7 +177,7 @@ war {
 }
 ```
 
-**After (Gradle 9):**
+**After:**
 ```groovy
 war {
     // WAR configuration
@@ -178,8 +188,8 @@ war {
 **Why this change is necessary:** Just like with EAR projects, the `archives` configuration in Gradle 9 now includes all artifacts. Using custom configurations ensures that only the intended artifacts are included in your WAR file.
 
 **Reference Documentation:**
-- [Gradle 9.0 Upgrading Guide - WAR Plugin Changes](https://docs.gradle.org/current/userguide/upgrading_major_version_9.html#ear_and_war_plugins_contribute_all_artifacts_to_the_archives_configuration)
-- [Gradle WAR Plugin](https://docs.gradle.org/current/userguide/war_plugin.html)
+- [Gradle 9.0 Upgrading Guide - WAR Plugin Changes](https://docs.gradle.org/9.0.0/userguide/upgrading_major_version_9.html#ear_and_war_plugins_contribute_all_artifacts_to_the_archives_configuration)
+- [Gradle WAR Plugin](https://docs.gradle.org/9.0.0/userguide/war_plugin.html)
 
 ## Project Dependencies
 
@@ -189,36 +199,36 @@ Gradle 9 has made significant changes to how project dependencies are handled, e
 
 When referencing project dependencies, you must now be explicit about which configuration to use:
 
-**Before (Gradle 8):**
+**Before:**
 ```groovy
 dependencies {
-    implementation project(':myLibProject')
+    implementation project(':jar')
 }
 ```
 
-**After (Gradle 9):**
+**After:**
 ```groovy
 dependencies {
-    implementation project(path: ':myLibProject', configuration: 'default')
+    implementation project(path: ':jar', configuration: 'jarOnly')
 }
 ```
 
 **Why this change is necessary:** Gradle 9 is more strict about configuration resolution and requires explicit configuration references to avoid ambiguity. This change ensures that the correct dependencies are resolved and included in your project.
 
 **Reference Documentation:**
-- [Gradle 9.0 Upgrading Guide - Project Dependencies API Changes](https://docs.gradle.org/current/userguide/upgrading_major_version_9.html#project_dependencies_api_changes)
-- [Gradle Project Dependencies](https://docs.gradle.org/current/userguide/declaring_dependencies.html#sub:project_dependencies)
+- [Gradle 9.0 Upgrading Guide - EAR and WAR plugins contribute all artifacts to the archives configuration](https://docs.gradle.org/9.0.0/userguide/upgrading_major_version_9.html#ear_and_war_plugins_contribute_all_artifacts_to_the_archives_configuration)
+- [Gradle Project Dependencies](https://docs.gradle.org/9.0.0/userguide/declaring_dependencies.html#2_project_dependencies)
 
 ### Task Dependencies
 
 If you have explicit task dependencies between projects, update them to be more specific:
 
-**Before (Gradle 8):**
+**Before:**
 ```groovy
 ear.dependsOn ':myWebProject:jar', ':myWebProject:war'
 ```
 
-**After (Gradle 9):**
+**After:**
 ```groovy
 ear.dependsOn ':myWebProject:war'
 ```
@@ -226,73 +236,16 @@ ear.dependsOn ':myWebProject:war'
 **Why this change is necessary:** In Gradle 9, task dependencies should be more explicit to avoid unnecessary task execution and improve build performance. This change ensures that only the required tasks are executed.
 
 **Reference Documentation:**
-- [Gradle Task Dependencies](https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:adding_dependencies_to_tasks)
+- [Gradle Task Dependencies](https://docs.gradle.org/9.0.0/userguide/controlling_task_execution.html#sec:more_task_dependencies)
 
-### Dependency Resolution Strategy
+### Dependency Resolution Considerations
 
-If you're experiencing dependency resolution issues after migrating to Gradle 9, consider adding a resolution strategy:
-
-```groovy
-configurations.all {
-    resolutionStrategy {
-        // Force specific versions if needed
-        force 'org.example:library:1.0.0'
-        
-        // Fail on version conflict
-        failOnVersionConflict()
-    }
-}
-```
-
-**Why this change is necessary:** Gradle 9's stricter dependency resolution might expose version conflicts that were previously hidden. Adding a resolution strategy helps resolve these conflicts explicitly and ensures that the correct dependencies are used.
+While migrating to Gradle 9, you may encounter dependency resolution issues due to Gradle 9's stricter dependency management. If you experience version conflicts or unexpected dependency behavior, refer to the following resources:
 
 **Reference Documentation:**
-- [Gradle Dependency Management](https://docs.gradle.org/current/userguide/dependency_management.html)
-
-## Testing Considerations
-
-### JSP Compilation Tests
-
-If you're using JSP compilation in your projects, be aware that the Java source level may need to be updated:
-
-**Before (Gradle 8):**
-```groovy
-compileJsp {
-    jspVersion = '2.3'
-    // JSP compilation configuration
-}
-```
-
-**After (Gradle 9):**
-```groovy
-compileJsp {
-    jspVersion = '2.3'
-    // JSP compilation configuration will use the Java version from your project
-}
-```
-
-**Why this change is necessary:** Gradle 9 has changed how Java source levels are handled, especially with the new Java toolchain approach. This change ensures that JSP compilation uses the correct Java source level from your project configuration.
-
-### Test Output Verification
-
-If your tests verify output messages from Liberty or Gradle tasks, update your verification code to check for key parts of messages instead of exact format:
-
-**Before (Gradle 8):**
-```groovy
-assert output.contains("Expected exact message format")
-```
-
-**After (Gradle 9):**
-```groovy
-assert output.contains("Expected keyword")
-assert output.contains("Another important term")
-```
-
-**Why this change is necessary:** Gradle 9 has changed how it formats output messages, including line breaks and indentation. Exact string matching is now brittle and prone to failure. Checking for key parts of messages is more robust against formatting changes.
-
-**Reference Documentation:**
-- [Gradle Testing](https://docs.gradle.org/current/userguide/java_testing.html)
-- [Gradle Test Task](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.testing.Test.html)
+- [Gradle Dependency Resolution](https://docs.gradle.org/9.0.0/userguide/dependency_resolution.html)
+- [Gradle Dependency Constraints](https://docs.gradle.org/9.0.0/userguide/dependency_constraints.html)
+- [Gradle Dependency Management Techniques](https://docs.gradle.org/9.0.0/userguide/dependency_management_for_java_projects.html)
 
 ## Known Issues and Workarounds
 
@@ -301,21 +254,19 @@ assert output.contains("Another important term")
 If you're using the Arquillian framework with your Liberty projects, be aware that Gradle 9 is not fully supported with the Arquillian framework. You have two options:
 
 1. Continue using Gradle 8.5 for projects that depend on Arquillian
-2. If you must use Gradle 9, specify Gradle 8.5 for Arquillian-specific tasks:
-
-```groovy
-GradleRunner.create()
-    .withProjectDir(buildDir)
-    .forwardOutput()
-    .withGradleVersion("8.5") // Specify compatible Gradle version for dependency management plugin
-    .withArguments("build", "-x", "test", "-i", "-s")
-    .build()
-```
-
-**Why this change is necessary:** The Arquillian framework has not been fully updated for Gradle 9 compatibility. Using Gradle 8.5 for Arquillian-specific tasks ensures that the tests can still run correctly while the rest of the project migrates to Gradle 9.
+2. If you must use Gradle 9 for your main project but need Arquillian compatibility, consider maintaining a separate standalone test project with Gradle 8.5 that imports your main project's artifacts for testing
 
 **Reference Documentation:**
-- [Gradle TestKit](https://docs.gradle.org/current/userguide/test_kit.html#sub:gradle-runner-gradle-versionl)
+- [Arquillian Documentation](https://arquillian.org/guides/)
+
+### Spring Boot Applications
+
+Spring Boot applications currently lack support for Gradle 9. If you're using Spring Boot with your Liberty projects, you will need to:
+
+1. Continue using Gradle 8.x for Spring Boot applications until official Gradle 9 support is added to Spring Boot
+2. If you must use Gradle 9, you may need to implement custom workarounds or wait for Spring Boot to release a version with Gradle 9 compatibility
+
+This is a known limitation affecting all current Spring Boot versions as of September 2025.
 
 ### File Locking Issues
 
@@ -337,17 +288,17 @@ Gradle 9 shows deprecation warnings that will make it incompatible with Gradle 1
 **Why this change is necessary:** Being aware of deprecation warnings helps you prepare for future Gradle versions. These warnings indicate features or APIs that will be removed in Gradle 10, so it's important to address them in future updates.
 
 **Reference Documentation:**
-- [Gradle Deprecation Handling](https://docs.gradle.org/current/userguide/feature_lifecycle.html#sec:deprecation_handling)
+- [Gradle Feature Lifecycle](https://docs.gradle.org/9.0.0/userguide/feature_lifecycle.html)
 
 ## Conclusion
 
-By following this guide, you should be able to successfully migrate your Liberty Gradle Plugin projects from Gradle 8 to Gradle 9. The key changes involve:
+This guide covers the most common changes needed when migrating from Gradle 8 to Gradle 9. While we've addressed the major compatibility issues, you may encounter project-specific challenges during your migration.
 
-1. Updating Java configuration syntax
-2. Adjusting build configuration settings
-3. Creating custom configurations for artifacts
-4. Updating project dependency references
-5. Modifying task dependencies
-6. Updating test verification methods
+If you experience issues not covered in this guide:
 
-If you encounter any issues not covered in this guide, please refer to the [Gradle 9 Release Notes](https://docs.gradle.org/9.0/release-notes.html) or the [Liberty Gradle Plugin documentation](https://github.com/OpenLiberty/ci.gradle).
+1. Check the [Gradle 9.0 Release Notes](https://docs.gradle.org/9.0.0/release-notes.html) for additional information
+2. Review the [Gradle 9.0 Upgrading Guide](https://docs.gradle.org/9.0.0/userguide/upgrading_major_version_9.html) for more detailed explanations
+3. Consult the [Liberty Gradle Plugin documentation](https://github.com/OpenLiberty/ci.gradle) for Liberty-specific guidance
+4. Report issues or request help through our [GitHub Issues](https://github.com/OpenLiberty/ci.gradle/issues) if you encounter problems that aren't addressed by the documentation
+
+We're committed to supporting your migration to Gradle 9 and will continue to update this guide based on community feedback.

--- a/docs/Gradle9MigrationGuide.md
+++ b/docs/Gradle9MigrationGuide.md
@@ -295,9 +295,9 @@ This guide covers the most common changes needed when migrating from Gradle 8 to
 
 If you experience issues not covered in this guide:
 
-1. Check the [Gradle 9.0 Release Notes](https://docs.gradle.org/9.0.0/release-notes.html) for additional information
-2. Review the [Gradle 9.0 Upgrading Guide](https://docs.gradle.org/9.0.0/userguide/upgrading_major_version_9.html) for more detailed explanations
-3. Consult the [Liberty Gradle Plugin documentation](https://github.com/OpenLiberty/ci.gradle) for Liberty-specific guidance
-4. Report issues or request help through our [GitHub Issues](https://github.com/OpenLiberty/ci.gradle/issues) if you encounter problems that aren't addressed by the documentation
+1. Check the [Gradle 9.0 Release Notes](https://docs.gradle.org/9.0.0/release-notes.html) for additional information.
+2. Review the [Gradle 9.0 Upgrading Guide](https://docs.gradle.org/9.0.0/userguide/upgrading_major_version_9.html) for more detailed explanations.
+3. Consult the [Liberty Gradle Plugin documentation](https://github.com/OpenLiberty/ci.gradle) for Liberty-specific guidance.
+4. Report issues or request help through our [GitHub Issues](https://github.com/OpenLiberty/ci.gradle/issues) if you encounter problems that aren't addressed by the documentation.
 
 We're committed to supporting your migration to Gradle 9 and will continue to update this guide based on community feedback.

--- a/docs/Gradle9MigrationGuide.md
+++ b/docs/Gradle9MigrationGuide.md
@@ -1,0 +1,353 @@
+# Gradle 8 to Gradle 9 Migration Guide for Liberty Gradle Plugin Users
+
+This guide provides step-by-step instructions for migrating your Liberty Gradle Plugin projects from Gradle 8 to Gradle 9. It focuses on the key changes that affect end users and provides practical examples to help you update your build scripts.
+
+## Table of Contents
+
+1. [Java Configuration Updates](#java-configuration-updates)
+2. [Build Configuration Changes](#build-configuration-changes)
+3. [Multi-Project Build Changes](#multi-project-build-changes)
+4. [EAR/WAR/JAR Configuration Changes](#earwarjar-configuration-changes)
+5. [Project Dependencies](#project-dependencies)
+6. [Testing Considerations](#testing-considerations)
+7. [Known Issues and Workarounds](#known-issues-and-workarounds)
+
+## Java Configuration Updates
+
+Gradle 9 requires updates to how you specify Java compatibility in your build scripts.
+
+### Update Java Compatibility Settings
+
+**Before (Gradle 8):**
+```groovy
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+```
+
+**After (Gradle 9):**
+```groovy
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+```
+
+This change is required in all your build scripts that specify Java compatibility. The old style is deprecated in Gradle 9 and will be removed in future versions.
+
+**Why this change is necessary:** The Java toolchain approach provides better compatibility with Gradle 9's toolchain support and allows for more flexible Java version management. It also enables clearer error messages when Java version requirements are not met.
+
+**Reference Documentation:**
+- [Gradle 9.0 Upgrading Guide - Java Toolchain](https://docs.gradle.org/current/userguide/upgrading_major_version_9.html#java_toolchain)
+- [Java Plugin - Compatibility](https://docs.gradle.org/current/userguide/java_plugin.html#sec:java_cross_compilation)
+
+## Build Configuration Changes
+
+### Test Task Configuration
+
+If you're using the test task in your build scripts, you may need to update your configuration for Gradle 9 compatibility:
+
+**Before (Gradle 8):**
+```groovy
+test {
+    // Test configuration
+}
+```
+
+**After (Gradle 9):**
+```groovy
+test {
+    // Add this line if you have conditional tests that might not always be present
+    failOnNoDiscoveredTests = false
+    
+    // Your existing test configuration
+}
+```
+
+**Why this change is necessary:** In Gradle 9, the `failOnNoDiscoveredTests` property is set to `true` by default. This means your build will fail if your test task doesn't find any tests to run. This can be problematic if you have:
+
+- Conditional tests that might not always be present
+- Test filtering that sometimes results in no tests
+- Multi-project builds where some projects might not have tests
+
+Setting `failOnNoDiscoveredTests = false` allows your build to continue even when no tests are found in a particular module or configuration.
+
+**Reference Documentation:**
+- [Gradle Test Task - failOnNoDiscoveredTests property](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.testing.Test.html#org.gradle.api.tasks.testing.Test:failOnNoDiscoveredTests)
+- [Gradle 9.0 Upgrading Guide - Test Task Changes](https://docs.gradle.org/current/userguide/upgrading_major_version_9.html#test_task_fails_when_no_tests_are_discovered)
+
+### Liberty Server Task Ordering
+
+Gradle 9 is more strict about task ordering and resource cleanup. If you're using Liberty server tasks in your build, ensure proper task ordering:
+
+```groovy
+// Ensure proper task ordering for Liberty server operations
+libertyStop.mustRunAfter libertyStart
+clean.mustRunAfter libertyStop
+```
+
+**Why this change is necessary:** Gradle 9 is more strict about task ordering and resource management. Without proper task ordering, you may encounter file locking issues when the clean task tries to delete files that are still in use by the Liberty server. This ensures that the server is properly stopped before any cleanup tasks run, preventing file locking issues.
+
+**Reference Documentation:**
+- [Gradle Task Ordering](https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:ordering_tasks)
+- [Gradle Task Execution](https://docs.gradle.org/current/userguide/build_lifecycle.html#sec:task_execution)
+
+## Multi-Project Build Changes
+
+Gradle 9 introduces significant changes to how artifacts and configurations are handled in multi-project builds.
+
+### Custom Configurations for Artifacts
+
+In Gradle 9, the EAR and WAR plugins now contribute **all** artifacts to the `archives` configuration. This is a change from Gradle 8, where applying the EAR plugin excluded JAR and WAR artifacts from archives.
+
+To maintain the same behavior as in Gradle 8, create custom configurations for your artifacts:
+
+```groovy
+// Create custom configurations for your artifacts
+configurations {
+    warOnly
+    jarOnly
+    earOnly
+}
+
+// Add artifacts to these configurations
+artifacts {
+    warOnly war
+    jarOnly jar
+    earOnly ear
+}
+```
+
+**Why this change is necessary:** In Gradle 9, the behavior of the EAR and WAR plugins has changed to include all artifacts in the `archives` configuration. This can lead to unexpected artifacts being included in your builds. Creating custom configurations gives you precise control over which artifacts are included in your EAR/WAR files and avoids including unnecessary transitive dependencies.
+
+**Reference Documentation:**
+- [Gradle 9.0 Upgrading Guide - EAR and WAR plugins contribute all artifacts to the archives configuration](https://docs.gradle.org/current/userguide/upgrading_major_version_9.html#ear_and_war_plugins_contribute_all_artifacts_to_the_archives_configuration)
+- [Gradle Configurations](https://docs.gradle.org/current/userguide/declaring_dependencies.html#sec:what-are-dependency-configurations)
+
+## EAR/WAR/JAR Configuration Changes
+
+### EAR Project Configuration
+
+If you're building EAR projects, update your EAR configuration to use the custom configurations:
+
+**Before (Gradle 8):**
+```groovy
+ear {
+    deploymentDescriptor {
+        // EAR configuration
+    }
+    earlib project(path: ':myWebModule', configuration: 'archives')
+}
+```
+
+**After (Gradle 9):**
+```groovy
+ear {
+    deploymentDescriptor {
+        // EAR configuration
+    }
+    earlib project(path: ':myWebModule', configuration: 'warOnly')
+}
+```
+
+**Why this change is necessary:** In Gradle 9, the `archives` configuration now includes all artifacts, which might lead to unexpected artifacts being included in your EAR file. Using custom configurations ensures that only the intended artifacts are included.
+
+**Reference Documentation:**
+- [Gradle 9.0 Upgrading Guide - EAR Plugin Changes](https://docs.gradle.org/current/userguide/upgrading_major_version_9.html#ear_and_war_plugins_contribute_all_artifacts_to_the_archives_configuration)
+- [Gradle EAR Plugin](https://docs.gradle.org/current/userguide/ear_plugin.html)
+
+### WAR Project Configuration
+
+Similarly, update your WAR project configurations:
+
+**Before (Gradle 8):**
+```groovy
+war {
+    // WAR configuration
+    classpath project(path: ':myLibModule', configuration: 'archives')
+}
+```
+
+**After (Gradle 9):**
+```groovy
+war {
+    // WAR configuration
+    classpath project(path: ':myLibModule', configuration: 'jarOnly')
+}
+```
+
+**Why this change is necessary:** Just like with EAR projects, the `archives` configuration in Gradle 9 now includes all artifacts. Using custom configurations ensures that only the intended artifacts are included in your WAR file.
+
+**Reference Documentation:**
+- [Gradle 9.0 Upgrading Guide - WAR Plugin Changes](https://docs.gradle.org/current/userguide/upgrading_major_version_9.html#ear_and_war_plugins_contribute_all_artifacts_to_the_archives_configuration)
+- [Gradle WAR Plugin](https://docs.gradle.org/current/userguide/war_plugin.html)
+
+## Project Dependencies
+
+Gradle 9 has made significant changes to how project dependencies are handled, especially in multi-project builds.
+
+### Project Dependency Configuration
+
+When referencing project dependencies, you must now be explicit about which configuration to use:
+
+**Before (Gradle 8):**
+```groovy
+dependencies {
+    implementation project(':myLibProject')
+}
+```
+
+**After (Gradle 9):**
+```groovy
+dependencies {
+    implementation project(path: ':myLibProject', configuration: 'default')
+}
+```
+
+**Why this change is necessary:** Gradle 9 is more strict about configuration resolution and requires explicit configuration references to avoid ambiguity. This change ensures that the correct dependencies are resolved and included in your project.
+
+**Reference Documentation:**
+- [Gradle 9.0 Upgrading Guide - Project Dependencies API Changes](https://docs.gradle.org/current/userguide/upgrading_major_version_9.html#project_dependencies_api_changes)
+- [Gradle Project Dependencies](https://docs.gradle.org/current/userguide/declaring_dependencies.html#sub:project_dependencies)
+
+### Task Dependencies
+
+If you have explicit task dependencies between projects, update them to be more specific:
+
+**Before (Gradle 8):**
+```groovy
+ear.dependsOn ':myWebProject:jar', ':myWebProject:war'
+```
+
+**After (Gradle 9):**
+```groovy
+ear.dependsOn ':myWebProject:war'
+```
+
+**Why this change is necessary:** In Gradle 9, task dependencies should be more explicit to avoid unnecessary task execution and improve build performance. This change ensures that only the required tasks are executed.
+
+**Reference Documentation:**
+- [Gradle Task Dependencies](https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:adding_dependencies_to_tasks)
+
+### Dependency Resolution Strategy
+
+If you're experiencing dependency resolution issues after migrating to Gradle 9, consider adding a resolution strategy:
+
+```groovy
+configurations.all {
+    resolutionStrategy {
+        // Force specific versions if needed
+        force 'org.example:library:1.0.0'
+        
+        // Fail on version conflict
+        failOnVersionConflict()
+    }
+}
+```
+
+**Why this change is necessary:** Gradle 9's stricter dependency resolution might expose version conflicts that were previously hidden. Adding a resolution strategy helps resolve these conflicts explicitly and ensures that the correct dependencies are used.
+
+**Reference Documentation:**
+- [Gradle Dependency Management](https://docs.gradle.org/current/userguide/dependency_management.html)
+
+## Testing Considerations
+
+### JSP Compilation Tests
+
+If you're using JSP compilation in your projects, be aware that the Java source level may need to be updated:
+
+**Before (Gradle 8):**
+```groovy
+compileJsp {
+    jspVersion = '2.3'
+    // JSP compilation configuration
+}
+```
+
+**After (Gradle 9):**
+```groovy
+compileJsp {
+    jspVersion = '2.3'
+    // JSP compilation configuration will use the Java version from your project
+}
+```
+
+**Why this change is necessary:** Gradle 9 has changed how Java source levels are handled, especially with the new Java toolchain approach. This change ensures that JSP compilation uses the correct Java source level from your project configuration.
+
+### Test Output Verification
+
+If your tests verify output messages from Liberty or Gradle tasks, update your verification code to check for key parts of messages instead of exact format:
+
+**Before (Gradle 8):**
+```groovy
+assert output.contains("Expected exact message format")
+```
+
+**After (Gradle 9):**
+```groovy
+assert output.contains("Expected keyword")
+assert output.contains("Another important term")
+```
+
+**Why this change is necessary:** Gradle 9 has changed how it formats output messages, including line breaks and indentation. Exact string matching is now brittle and prone to failure. Checking for key parts of messages is more robust against formatting changes.
+
+**Reference Documentation:**
+- [Gradle Testing](https://docs.gradle.org/current/userguide/java_testing.html)
+- [Gradle Test Task](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.testing.Test.html)
+
+## Known Issues and Workarounds
+
+### Arquillian Tests
+
+If you're using the Arquillian framework with your Liberty projects, be aware that Gradle 9 is not fully supported with the Arquillian framework. You have two options:
+
+1. Continue using Gradle 8.5 for projects that depend on Arquillian
+2. If you must use Gradle 9, specify Gradle 8.5 for Arquillian-specific tasks:
+
+```groovy
+GradleRunner.create()
+    .withProjectDir(buildDir)
+    .forwardOutput()
+    .withGradleVersion("8.5") // Specify compatible Gradle version for dependency management plugin
+    .withArguments("build", "-x", "test", "-i", "-s")
+    .build()
+```
+
+**Why this change is necessary:** The Arquillian framework has not been fully updated for Gradle 9 compatibility. Using Gradle 8.5 for Arquillian-specific tasks ensures that the tests can still run correctly while the rest of the project migrates to Gradle 9.
+
+**Reference Documentation:**
+- [Gradle TestKit](https://docs.gradle.org/current/userguide/test_kit.html#sub:gradle-runner-gradle-versionl)
+
+### File Locking Issues
+
+If you encounter file locking issues during the build, especially when stopping Liberty servers and then trying to clean directories, add a small delay between stopping the server and cleaning:
+
+```groovy
+libertyStop.doLast {
+    // Add a small delay to ensure file locks are fully released
+    sleep(2000)
+}
+```
+
+**Why this change is necessary:** Sometimes file locks aren't immediately released when stopping the Liberty server. Adding a small delay ensures that all file locks are fully released before any cleanup tasks run, preventing file locking issues.
+
+### Deprecation Warnings
+
+Gradle 9 shows deprecation warnings that will make it incompatible with Gradle 10. These warnings are informational at this point but will need to be addressed in future updates.
+
+**Why this change is necessary:** Being aware of deprecation warnings helps you prepare for future Gradle versions. These warnings indicate features or APIs that will be removed in Gradle 10, so it's important to address them in future updates.
+
+**Reference Documentation:**
+- [Gradle Deprecation Handling](https://docs.gradle.org/current/userguide/feature_lifecycle.html#sec:deprecation_handling)
+
+## Conclusion
+
+By following this guide, you should be able to successfully migrate your Liberty Gradle Plugin projects from Gradle 8 to Gradle 9. The key changes involve:
+
+1. Updating Java configuration syntax
+2. Adjusting build configuration settings
+3. Creating custom configurations for artifacts
+4. Updating project dependency references
+5. Modifying task dependencies
+6. Updating test verification methods
+
+If you encounter any issues not covered in this guide, please refer to the [Gradle 9 Release Notes](https://docs.gradle.org/9.0/release-notes.html) or the [Liberty Gradle Plugin documentation](https://github.com/OpenLiberty/ci.gradle).

--- a/docs/Gradle9MigrationGuide.md
+++ b/docs/Gradle9MigrationGuide.md
@@ -262,8 +262,8 @@ If you're using the Arquillian framework with your Liberty projects, be aware th
 
 Spring Boot applications currently lack support for Gradle 9. If you're using Spring Boot with your Liberty projects, you will need to:
 
-1. Continue using Gradle 8.x for Spring Boot applications until official Gradle 9 support is added to Spring Boot
-2. If you must use Gradle 9, you may need to implement custom workarounds or wait for Spring Boot to release a version with Gradle 9 compatibility
+1. Continue using Gradle 8.x for Spring Boot applications until official Gradle 9 support is added to Spring Boot.
+2. If you must use Gradle 9, you may need to implement custom workarounds or wait for Spring Boot to release a version with Gradle 9 compatibility.
 
 This is a known limitation affecting all current Spring Boot versions as of September 2025.
 

--- a/docs/Gradle9MigrationGuide.md
+++ b/docs/Gradle9MigrationGuide.md
@@ -65,9 +65,9 @@ test {
 
 **Why this change is necessary:** In Gradle 9, the `failOnNoDiscoveredTests` property is set to `true` by default. This means your build will fail if your test task doesn't find any tests to run. This can be problematic if you have:
 
-- Conditional tests that might not always be present.
-- Test filtering that sometimes results in no tests.
-- Multi-project builds where some projects might not have tests.
+- Conditional tests that might not always be present
+- Test filtering that sometimes results in no tests
+- Multi-project builds where some projects might not have tests
 
 Setting `failOnNoDiscoveredTests = false` allows your build to continue even when no tests are found in a particular module or configuration.
 

--- a/docs/Gradle9MigrationGuide.md
+++ b/docs/Gradle9MigrationGuide.md
@@ -65,9 +65,9 @@ test {
 
 **Why this change is necessary:** In Gradle 9, the `failOnNoDiscoveredTests` property is set to `true` by default. This means your build will fail if your test task doesn't find any tests to run. This can be problematic if you have:
 
-- Conditional tests that might not always be present
-- Test filtering that sometimes results in no tests
-- Multi-project builds where some projects might not have tests
+- Conditional tests that might not always be present.
+- Test filtering that sometimes results in no tests.
+- Multi-project builds where some projects might not have tests.
 
 Setting `failOnNoDiscoveredTests = false` allows your build to continue even when no tests are found in a particular module or configuration.
 
@@ -252,8 +252,8 @@ While migrating to Gradle 9, you may encounter dependency resolution issues due 
 
 If you're using the Arquillian framework with your Liberty projects, be aware that Gradle 9 is not fully supported with the Arquillian framework. You have two options:
 
-1. Continue using Gradle 8.5 for projects that depend on Arquillian
-2. If you must use Gradle 9 for your main project but need Arquillian compatibility, consider maintaining a separate standalone test project with Gradle 8.5 that imports your main project's artifacts for testing
+1. Continue using Gradle 8.5 for projects that depend on Arquillian.
+2. If you must use Gradle 9 for your main project but need Arquillian compatibility, consider maintaining a separate standalone test project with Gradle 8.5 that imports your main project's artifacts for testing.
 
 **Reference Documentation:**
 - [Arquillian Documentation](https://arquillian.org/guides/)

--- a/docs/Gradle9MigrationGuide.md
+++ b/docs/Gradle9MigrationGuide.md
@@ -94,7 +94,6 @@ clean.mustRunAfter(libertyStop)
 
 **Reference Documentation:**
 - [Gradle Task Ordering](https://docs.gradle.org/9.0.0/userguide/controlling_task_execution.html#sec:ordering_tasks)
-- [Gradle Controlling Task Execution](https://docs.gradle.org/9.0.0/userguide/controlling_task_execution.html)
 - [Gradle Understanding Tasks](https://docs.gradle.org/9.0.0/userguide/more_about_tasks.html)
 
 ### JSP Compilation

--- a/docs/Gradle9MigrationGuide.md
+++ b/docs/Gradle9MigrationGuide.md
@@ -38,7 +38,7 @@ This change is required in all your build scripts that specify Java compatibilit
 
 **Reference Documentation:**
 - [Toolchains for JVM projects](https://docs.gradle.org/9.0.0/userguide/toolchains.html#toolchains)
-- [Java Plugin - Compatibility](https://docs.gradle.org/9.0.0/userguide/java_plugin.html#sec:java_cross_compilation)
+- [Java Plugin - Compatibility](https://docs.gradle.org/current/userguide/java_plugin.html#toolchain_and_compatibility)
 
 ## Build Configuration Changes
 


### PR DESCRIPTION
This guide provides step-by-step instructions for migrating your Liberty Gradle Plugin projects from Gradle 8 to Gradle 9. It focuses on the key changes that affect end users and provides practical examples to help a user to update their build scripts.