### PR TITLE
Adding support for java 25, updated spring boot tests to use 3.5.6 version

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -18,8 +18,8 @@ jobs:
       matrix:
         # test against latest update of each major Java version, as well as specific updates of LTS versions:
         RUNTIME: [ol, wlp]
-        RUNTIME_VERSION: [25.0.0.6]
-        java: [21, 17]
+        RUNTIME_VERSION: [25.0.0.10]
+        java: [25, 21, 17]
     name: ${{ matrix.RUNTIME }} ${{ matrix.RUNTIME_VERSION }}, Java ${{ matrix.java }}, Linux
     steps:
       # Checkout repos
@@ -91,8 +91,8 @@ jobs:
       matrix:
         # test against latest update of each major Java version, as well as specific updates of LTS versions:
         RUNTIME: [ol, wlp]
-        RUNTIME_VERSION: [25.0.0.6]
-        java: [21, 17]
+        RUNTIME_VERSION: [25.0.0.10]
+        java: [25, 21, 17]
     name: ${{ matrix.RUNTIME }} ${{ matrix.RUNTIME_VERSION }}, Java ${{ matrix.java }}, Windows
     env:
       TEST_EXCLUDE: ${{ '**/Polling*,**/LibertyTest*,**/GenerateFeaturesTest*,**/TestSpringBootApplication*,**/DevContainerTest*' }}

--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,11 @@ java {
         if (System.getProperty('java.version').startsWith('21')) {
             languageVersion = JavaLanguageVersion.of(21)
         }
+
+        // Allow Java 25 as a compatible alternative
+        if (System.getProperty('java.version').startsWith('25')) {
+            languageVersion = JavaLanguageVersion.of(25)
+        }
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/test/resources/sample.springboot3/test_spring_boot_apps_30.gradle
+++ b/src/test/resources/sample.springboot3/test_spring_boot_apps_30.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	ext {
-		springBootVersion = '3.1.3'
+		springBootVersion = '3.5.6'
 	}
 	repositories {
 	    mavenLocal()
@@ -21,7 +21,7 @@ apply plugin: 'liberty'
 
 group = 'liberty.gradle'
 version = '1.0-SNAPSHOT'
-sourceCompatibility = 17
+compileJava.options.release = 17
 
 repositories {
 	mavenCentral()
@@ -29,7 +29,7 @@ repositories {
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")
 	testImplementation('org.springframework.boot:spring-boot-starter-test')
-	libertyRuntime group: 'io.openliberty', name: 'openliberty-runtime', version: '23.0.0.10'
+	libertyRuntime group: 'io.openliberty', name: 'openliberty-runtime', version: runtimeVersion
 }
 
 liberty {

--- a/src/test/resources/sample.springboot3/test_spring_boot_classifier_apps_30.gradle
+++ b/src/test/resources/sample.springboot3/test_spring_boot_classifier_apps_30.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	ext {
-		springBootVersion = '3.1.3'
+		springBootVersion = '3.5.6'
 	}
 	repositories {
 	    mavenLocal()
@@ -21,7 +21,7 @@ apply plugin: 'liberty'
 
 group = 'liberty.gradle'
 version = '1.0-SNAPSHOT'
-sourceCompatibility = 17
+compileJava.options.release = 17
 
 repositories {
 	mavenCentral()
@@ -29,7 +29,7 @@ repositories {
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")
 	testImplementation('org.springframework.boot:spring-boot-starter-test')
-	libertyRuntime group: 'com.ibm.websphere.appserver.runtime', name: 'wlp-jakartaee10', version: '23.0.0.10'
+	libertyRuntime group: 'com.ibm.websphere.appserver.runtime', name: 'wlp-jakartaee10', version: runtimeVersion
 }
 
 bootJar {

--- a/src/test/resources/sample.springboot3/test_spring_boot_classifier_apps_30_no_feature.gradle
+++ b/src/test/resources/sample.springboot3/test_spring_boot_classifier_apps_30_no_feature.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	ext {
-		springBootVersion = '3.1.3'
+		springBootVersion = '3.5.6'
 	}
 	repositories {
 	    mavenLocal()
@@ -21,7 +21,7 @@ apply plugin: 'liberty'
 
 group = 'liberty.gradle'
 version = '1.0-SNAPSHOT'
-sourceCompatibility = 17
+compileJava.options.release = 17
 
 repositories {
 	mavenCentral()
@@ -29,7 +29,7 @@ repositories {
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")
 	testImplementation('org.springframework.boot:spring-boot-starter-test')
-	libertyRuntime group: 'com.ibm.websphere.appserver.runtime', name: 'wlp-jakartaee10', version: '23.0.0.10'
+	libertyRuntime group: 'com.ibm.websphere.appserver.runtime', name: 'wlp-jakartaee10', version: runtimeVersion
 }
 
 bootJar {

--- a/src/test/resources/sample.springboot3/test_spring_boot_dropins_30.gradle
+++ b/src/test/resources/sample.springboot3/test_spring_boot_dropins_30.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	ext {
-		springBootVersion = '3.1.3'
+		springBootVersion = '3.5.6'
 	}
 	repositories {
 	    mavenLocal()
@@ -21,7 +21,7 @@ apply plugin: 'liberty'
 
 group = 'liberty.gradle'
 version = '1.0-SNAPSHOT'
-sourceCompatibility = 17
+compileJava.options.release = 17
 
 repositories {
 	mavenCentral()
@@ -29,7 +29,7 @@ repositories {
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")
 	testImplementation('org.springframework.boot:spring-boot-starter-test')
-	libertyRuntime group: 'com.ibm.websphere.appserver.runtime', name: 'wlp-jakartaee10', version: '23.0.0.10'
+	libertyRuntime group: 'com.ibm.websphere.appserver.runtime', name: 'wlp-jakartaee10', version: runtimeVersion
 }
 
 

--- a/src/test/resources/sample.springboot3/test_spring_boot_plugins_dsl_apps_30.gradle
+++ b/src/test/resources/sample.springboot3/test_spring_boot_plugins_dsl_apps_30.gradle
@@ -1,13 +1,13 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.1.3'
+	id 'org.springframework.boot' version '3.5.6'
 	id 'io.spring.dependency-management' version '1.1.6'
 	id 'io.openliberty.tools.gradle.Liberty' version "$lgpVersion"
 }
 
 group = 'liberty.gradle'
 version = '1.0-SNAPSHOT'
-sourceCompatibility = 17
+compileJava.options.release = 17
 
 repositories {
 	mavenCentral()
@@ -15,7 +15,7 @@ repositories {
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	testImplementation('org.springframework.boot:spring-boot-starter-test')
-	libertyRuntime group: 'io.openliberty', name: 'openliberty-runtime', version: '23.0.0.10'
+	libertyRuntime group: 'io.openliberty', name: 'openliberty-runtime', version: runtimeVersion
 }
 
 liberty {

--- a/src/test/resources/sample.springboot3/test_spring_boot_war_apps_30.gradle
+++ b/src/test/resources/sample.springboot3/test_spring_boot_war_apps_30.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	ext {
-		springBootVersion = '3.1.3'
+		springBootVersion = '3.5.6'
 	}
 	repositories {
 	    mavenLocal()
@@ -21,7 +21,7 @@ apply plugin: 'liberty'
 
 group = 'liberty.gradle'
 version = '1.0-SNAPSHOT'
-sourceCompatibility = 17
+compileJava.options.release = 17
 
 repositories {
 	mavenCentral()
@@ -29,7 +29,7 @@ repositories {
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")
 	testImplementation('org.springframework.boot:spring-boot-starter-test')
-	libertyRuntime group: 'io.openliberty', name: 'openliberty-kernel', version: '23.0.0.10'
+	libertyRuntime group: 'io.openliberty', name: 'openliberty-kernel', version: runtimeVersion
 }
 
 liberty {

--- a/src/test/resources/sample.springboot3/test_spring_boot_war_classifier_apps_30.gradle
+++ b/src/test/resources/sample.springboot3/test_spring_boot_war_classifier_apps_30.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	ext {
-		springBootVersion = '3.1.3'
+		springBootVersion = '3.5.6'
 	}
 	repositories {
 	    mavenLocal()
@@ -21,7 +21,7 @@ apply plugin: 'liberty'
 
 group = 'liberty.gradle'
 version = '1.0-SNAPSHOT'
-sourceCompatibility = 17
+compileJava.options.release = 17
 
 repositories {
 	mavenCentral()
@@ -29,7 +29,7 @@ repositories {
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")
 	testImplementation('org.springframework.boot:spring-boot-starter-test')
-	libertyRuntime group: 'io.openliberty', name: 'openliberty-kernel', version: '23.0.0.10'
+	libertyRuntime group: 'io.openliberty', name: 'openliberty-kernel', version: runtimeVersion
 }
 
 bootWar {

--- a/src/test/resources/sample.springboot3/test_spring_boot_with_springbootapplication_apps_30.gradle
+++ b/src/test/resources/sample.springboot3/test_spring_boot_with_springbootapplication_apps_30.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	ext {
-		springBootVersion = '3.1.3'
+		springBootVersion = '3.5.6'
 	}
 	repositories {
 	    mavenLocal()
@@ -21,7 +21,7 @@ apply plugin: 'liberty'
 
 group = 'liberty.gradle'
 version = '1.0-SNAPSHOT'
-sourceCompatibility = 17
+compileJava.options.release = 17
 
 repositories {
 	mavenCentral()
@@ -29,7 +29,7 @@ repositories {
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")
 	testImplementation('org.springframework.boot:spring-boot-starter-test')
-	libertyRuntime group: 'io.openliberty', name: 'openliberty-runtime', version: '23.0.0.10'
+	libertyRuntime group: 'io.openliberty', name: 'openliberty-runtime', version: runtimeVersion
 }
 
 liberty {

--- a/src/test/resources/sample.springboot3/test_spring_boot_with_springbootapplication_nodes_apps_30.gradle
+++ b/src/test/resources/sample.springboot3/test_spring_boot_with_springbootapplication_nodes_apps_30.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	ext {
-		springBootVersion = '3.1.3'
+		springBootVersion = '3.5.6'
 	}
 	repositories {
 	    mavenLocal()
@@ -21,7 +21,7 @@ apply plugin: 'liberty'
 
 group = 'liberty.gradle'
 version = '1.0-SNAPSHOT'
-sourceCompatibility = 17
+compileJava.options.release = 17
 
 repositories {
 	mavenCentral()
@@ -29,7 +29,7 @@ repositories {
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")
 	testImplementation('org.springframework.boot:spring-boot-starter-test')
-	libertyRuntime group: 'io.openliberty', name: 'openliberty-runtime', version: '23.0.0.10'
+	libertyRuntime group: 'io.openliberty', name: 'openliberty-runtime', version: runtimeVersion
 }
 
 liberty {

--- a/src/test/resources/sample.springboot3/test_spring_boot_with_springbootapplication_nodes_apps_include_30.gradle
+++ b/src/test/resources/sample.springboot3/test_spring_boot_with_springbootapplication_nodes_apps_include_30.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	ext {
-		springBootVersion = '3.1.3'
+		springBootVersion = '3.5.6'
 	}
 	repositories {
 	    mavenLocal()
@@ -21,7 +21,7 @@ apply plugin: 'liberty'
 
 group = 'liberty.gradle'
 version = '1.0-SNAPSHOT'
-sourceCompatibility = 17
+compileJava.options.release = 17
 
 repositories {
 	mavenCentral()
@@ -29,7 +29,7 @@ repositories {
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")
 	testImplementation('org.springframework.boot:spring-boot-starter-test')
-	libertyRuntime group: 'io.openliberty', name: 'openliberty-runtime', version: '23.0.0.10'
+	libertyRuntime group: 'io.openliberty', name: 'openliberty-runtime', version: runtimeVersion
 }
 
 liberty {


### PR DESCRIPTION
Adding support for java 25, updated spring boot tests to use 3.5.6 version
also enabled spring boot 3.0 tests in pipeline