### PR TITLE
Loose EAR Manifest Class-Path Issue Fix

### DIFF
--- a/src/main/groovy/io/openliberty/tools/gradle/utils/LooseEarApplication.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/utils/LooseEarApplication.groovy
@@ -126,39 +126,49 @@ public class LooseEarApplication extends LooseApplication {
     }
 
     /**
-     * Add dependency class directories so EJB modules can see classes from their dependencies
-     * @param moduleArchive
-     * @param proj
+     * Recursively collect all project dependencies (including transitive)
+     * @param project The project to collect dependencies from
+     * @param collected The set to add dependencies to
      */
+    private void collectProjectDependenciesRecursively(Project project, Set<Project> collected) {
+        // Add the project itself
+        collected.add(project)
+        
+        // Recursively collect dependencies from compileClasspath
+        if (project.configurations.findByName('compileClasspath') != null) {
+            project.configurations.compileClasspath.allDependencies.each { dep ->
+                if (dep instanceof ProjectDependency) {
+                    Project depProj = project.rootProject.findProject(dep.path)
+                    if (depProj != null && !collected.contains(depProj)) {
+                        collectProjectDependenciesRecursively(depProj, collected)
+                    }
+                }
+            }
+        }
+        
+        // Recursively collect dependencies from runtimeClasspath
+        if (project.configurations.findByName('runtimeClasspath') != null) {
+            project.configurations.runtimeClasspath.allDependencies.each { dep ->
+                if (dep instanceof ProjectDependency) {
+                    Project depProj = project.rootProject.findProject(dep.path)
+                    if (depProj != null && !collected.contains(depProj)) {
+                        collectProjectDependenciesRecursively(depProj, collected)
+                    }
+                }
+            }
+        }
+    }
+    
     private void addDependencyClassDirectories(Element moduleArchive, Project proj) {
         try {
             Set<Project> projectDependencies = new HashSet<Project>();
             
-            // Check compileClasspath for compile-time dependencies
-            if (proj.configurations.findByName('compileClasspath') != null) {
-                proj.configurations.compileClasspath.allDependencies.each { dep ->
-                    if (dep instanceof ProjectDependency) { // Ensure it's a project dependency
-                        Project depProj = proj.rootProject.findProject(dep.path)
-                        if (depProj != null) {
-                            projectDependencies.add(depProj)
-                        }
-                    }
-                }
-            }
+            // Collect all project dependencies (including transitive) recursively
+            collectProjectDependenciesRecursively(proj, projectDependencies)
+            // Remove the project itself - we only want dependencies
+            projectDependencies.remove(proj)
             
-            // Check runtimeClasspath for runtime dependencies
-            if (proj.configurations.findByName('runtimeClasspath') != null) {
-                proj.configurations.runtimeClasspath.allDependencies.each { dep ->
-                    if (dep instanceof ProjectDependency) { // Ensure it's a project dependency
-                        Project depProj = proj.rootProject.findProject(dep.path)
-                        if (depProj != null) {
-                            projectDependencies.add(depProj)
-                        }
-                    }
-                }
-            }
-            
-            logger.debug("Found ${projectDependencies.size()} project dependencies for ${proj.name}")
+            logger.debug("Found ${projectDependencies.size()} project dependencies (including transitive) for ${proj.name}")
             
             // Process each project dependency
             projectDependencies.each { dependencyProject ->

--- a/src/main/groovy/io/openliberty/tools/gradle/utils/LooseEarApplication.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/utils/LooseEarApplication.groovy
@@ -172,20 +172,20 @@ public class LooseEarApplication extends LooseApplication {
                 // Add all class directories
                 dependencyProject.sourceSets.main.output.classesDirs.files.each { File classesDirectory ->
                     if (classesDirectory.exists()) {
-                        logger.debug("  Adding class dir: ${classesDirectory}")
+                        logger.debug("Adding class dir: ${classesDirectory}")
                         config.addDir(moduleArchive, classesDirectory, "/")
                     } else {
-                        logger.debug("  Skipping non-existent class dir: ${classesDirectory}")
+                        logger.debug("Skipping non-existent class dir: ${classesDirectory}")
                     }
                 }
                 
                 // Add resource directory
                 def resourcesDirectory = dependencyProject.sourceSets.main.output.resourcesDir
                 if (resourcesDirectory?.exists()) {
-                    logger.debug("  Adding resource dir: ${resourcesDirectory}")
+                    logger.debug("Adding resource dir: ${resourcesDirectory}")
                     config.addDir(moduleArchive, resourcesDirectory, "/")
                 } else {
-                    logger.debug("  No resources dir or doesn't exist: ${resourcesDirectory}")
+                    logger.debug("No resources dir or doesn't exist: ${resourcesDirectory}")
                 }
             }
         } catch (Exception e) {

--- a/src/main/groovy/io/openliberty/tools/gradle/utils/LooseEarApplication.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/utils/LooseEarApplication.groovy
@@ -24,8 +24,10 @@ import org.gradle.api.logging.Logger
 import org.gradle.plugins.ear.Ear
 import org.w3c.dom.Element
 
+import java.util.jar.Manifest
+
 public class LooseEarApplication extends LooseApplication {
-    
+
     protected Task task;
     protected Logger logger;
 
@@ -61,7 +63,7 @@ public class LooseEarApplication extends LooseApplication {
             config.addFile(applicationXmlFile, "/META-INF/application.xml")
         }
     }
-    
+
     public Element addWarModule(Project proj) throws Exception {
         Element warArchive = config.addArchive("/" + proj.war.getArchiveFileName().get());
         if (proj.war.getWebAppDirectory().getAsFile().get() != null) {
@@ -98,8 +100,9 @@ public class LooseEarApplication extends LooseApplication {
         addModules(moduleArchive, proj)
         return moduleArchive;
     }
-    
+
     private void addModules(Element moduleArchive, Project proj) {
+        boolean manifestAdded = false
         for (File f : proj.jar.source.getFiles()) {
             String extension = FilenameUtils.getExtension(f.getAbsolutePath())
             switch(extension) {
@@ -109,15 +112,69 @@ public class LooseEarApplication extends LooseApplication {
                     config.addFile(moduleArchive, f, "/WEB-INF/lib/" + f.getName());
                     break
                 case "MF":
-                    //This checks the manifest file and resource directory of the project's jar source set.
-                    //The location of the resource directory should be the same as proj.getProjectDir()/build/resources.
-                    //If the manifest file exists, it is copied to proj.getProjectDir()/build/resources/tmp/META-INF. If it does not exist, one is created there.
-                    addManifestFileWithParent(moduleArchive, f, proj.sourceSets.main.getOutput().getResourcesDir().getParentFile().getCanonicalPath())
+                    // Prefer the jar task's generated manifest (build/tmp/jar/MANIFEST.MF) which has
+                    // the correct Class-Path entries from jar { manifest { attributes } } in build.gradle.
+                    // This avoids incomplete Class-Path entries in any static MANIFEST.MF in resources.
+                    File jarTaskManifest = new File(proj.jar.temporaryDir, "MANIFEST.MF")
+                    if (jarTaskManifest.exists()) {
+                        config.addFile(moduleArchive, jarTaskManifest, "/META-INF/MANIFEST.MF")
+                        // Parse Class-Path and add dependency class directories to module archive
+                        addManifestClassPathDependencies(moduleArchive, jarTaskManifest, proj)
+                    } else {
+                        addManifestFileWithParent(moduleArchive, f, proj.sourceSets.main.getOutput().getResourcesDir().getParentFile().getCanonicalPath())
+                    }
+                    manifestAdded = true
                     break
                 default:
                     break
             }
         }
+        // If no .MF file was found in the jar source set (e.g. no static MANIFEST.MF in resources),
+        // still add the jar task's generated manifest if it exists.
+        if (!manifestAdded) {
+            File jarTaskManifest = new File(proj.jar.temporaryDir, "MANIFEST.MF")
+            if (jarTaskManifest.exists()) {
+                config.addFile(moduleArchive, jarTaskManifest, "/META-INF/MANIFEST.MF")
+                // Parse Class-Path and add dependency class directories to module archive
+                addManifestClassPathDependencies(moduleArchive, jarTaskManifest, proj)
+            }
+        }
     }
-    
+
+    private void addManifestClassPathDependencies(Element moduleArchive, File manifestFile, Project proj) {
+        try {
+            def manifest = new Manifest(new FileInputStream(manifestFile))
+            String classPath = manifest.getMainAttributes().getValue("Class-Path")
+            logger.info("Processing manifest Class-Path for ${proj.name}: ${classPath}")
+            if (classPath) {
+                classPath.split(/\s+/).each { String jarName ->
+                    if (jarName && jarName.endsWith(".jar")) {
+                        String depName = jarName.replace(".jar", "")
+
+                        def depProj = proj.rootProject.findProject(":${depName}")
+                        logger.info("Looking for dependency project: ${depName}, found: ${depProj != null}")
+
+                        if (depProj && depProj.hasProperty('sourceSets')) {
+                            depProj.sourceSets.main.output.classesDirs.files.each {
+                                File classesDir ->
+                                    if (classesDir.exists()) {
+                                        logger.info("Adding dependency class dir to ${proj.name}: ${classesDir}")
+                                        config.addDir(moduleArchive, classesDir, "/")
+                                    }
+                            }
+
+                            def resourcesDir = depProj.sourceSets.main.output.resourcesDir
+                            if (resourcesDir && resourcesDir.exists()) {
+                                logger.info("Adding dependency resource dir to ${proj.name}: ${resourcesDir}")
+                                config.addDir(moduleArchive, resourcesDir, "/")
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            logger.warn("Could not parse manifest Class-Path from ${manifestFile}: ${e.message}", e)
+        }
+    }
+
 }

--- a/src/main/groovy/io/openliberty/tools/gradle/utils/LooseEarApplication.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/utils/LooseEarApplication.groovy
@@ -20,6 +20,7 @@ import io.openliberty.tools.common.plugins.config.LooseConfigData
 import org.apache.commons.io.FilenameUtils
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.logging.Logger
 import org.gradle.plugins.ear.Ear
 import org.w3c.dom.Element
@@ -90,12 +91,16 @@ public class LooseEarApplication extends LooseApplication {
     }
 
     public Element addJarModule(Project proj) throws Exception {
+        logger.debug("Adding JAR module for project: ${proj.name}")
         Element moduleArchive = config.addArchive("/" + proj.jar.getArchiveFileName().get());
         proj.sourceSets.main.getOutput().getClassesDirs().each{config.addDir(moduleArchive, it, "/");}
         if (resourcesDirContentsExist(proj)) {
             config.addDir(moduleArchive, proj.sourceSets.main.getOutput().getResourcesDir(), "/");
         }
         addModules(moduleArchive, proj)
+        
+        addDependencyClassDirectories(moduleArchive, proj)
+        
         return moduleArchive;
     }
     
@@ -117,6 +122,74 @@ public class LooseEarApplication extends LooseApplication {
                 default:
                     break
             }
+        }
+    }
+
+    /**
+     * Add dependency class directories so EJB modules can see classes from their dependencies
+     * @param moduleArchive
+     * @param proj
+     */
+    private void addDependencyClassDirectories(Element moduleArchive, Project proj) {
+        try {
+            Set<Project> projectDependencies = new HashSet<Project>();
+            
+            // Check compileClasspath for compile-time dependencies
+            if (proj.configurations.findByName('compileClasspath') != null) {
+                proj.configurations.compileClasspath.allDependencies.each { dep ->
+                    if (dep instanceof ProjectDependency) { // Ensure it's a project dependency
+                        Project depProj = proj.rootProject.findProject(dep.path)
+                        if (depProj != null) {
+                            projectDependencies.add(depProj)
+                        }
+                    }
+                }
+            }
+            
+            // Check runtimeClasspath for runtime dependencies
+            if (proj.configurations.findByName('runtimeClasspath') != null) {
+                proj.configurations.runtimeClasspath.allDependencies.each { dep ->
+                    if (dep instanceof ProjectDependency) { // Ensure it's a project dependency
+                        Project depProj = proj.rootProject.findProject(dep.path)
+                        if (depProj != null) {
+                            projectDependencies.add(depProj)
+                        }
+                    }
+                }
+            }
+            
+            logger.debug("Found ${projectDependencies.size()} project dependencies for ${proj.name}")
+            
+            // Process each project dependency
+            projectDependencies.each { dependencyProject ->
+                if (!dependencyProject.hasProperty('sourceSets')) { // Not a Java project
+                    logger.debug("Skipping ${dependencyProject.name} - no sourceSets found (not a Java project)")
+                    return
+                }
+                
+                logger.debug("Adding dependency ${dependencyProject.name} class directories to ${proj.name}")
+                
+                // Add all class directories
+                dependencyProject.sourceSets.main.output.classesDirs.files.each { File classesDirectory ->
+                    if (classesDirectory.exists()) {
+                        logger.debug("  Adding class dir: ${classesDirectory}")
+                        config.addDir(moduleArchive, classesDirectory, "/")
+                    } else {
+                        logger.debug("  Skipping non-existent class dir: ${classesDirectory}")
+                    }
+                }
+                
+                // Add resource directory
+                def resourcesDirectory = dependencyProject.sourceSets.main.output.resourcesDir
+                if (resourcesDirectory?.exists()) {
+                    logger.debug("  Adding resource dir: ${resourcesDirectory}")
+                    config.addDir(moduleArchive, resourcesDirectory, "/")
+                } else {
+                    logger.debug("  No resources dir or doesn't exist: ${resourcesDirectory}")
+                }
+            }
+        } catch (Exception e) {
+            logger.warn("Could not add dependency class directories for ${proj.name}: ${e.message}", e)
         }
     }
     

--- a/src/main/groovy/io/openliberty/tools/gradle/utils/LooseEarApplication.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/utils/LooseEarApplication.groovy
@@ -24,10 +24,8 @@ import org.gradle.api.logging.Logger
 import org.gradle.plugins.ear.Ear
 import org.w3c.dom.Element
 
-import java.util.jar.Manifest
-
 public class LooseEarApplication extends LooseApplication {
-
+    
     protected Task task;
     protected Logger logger;
 
@@ -63,7 +61,7 @@ public class LooseEarApplication extends LooseApplication {
             config.addFile(applicationXmlFile, "/META-INF/application.xml")
         }
     }
-
+    
     public Element addWarModule(Project proj) throws Exception {
         Element warArchive = config.addArchive("/" + proj.war.getArchiveFileName().get());
         if (proj.war.getWebAppDirectory().getAsFile().get() != null) {
@@ -100,9 +98,8 @@ public class LooseEarApplication extends LooseApplication {
         addModules(moduleArchive, proj)
         return moduleArchive;
     }
-
+    
     private void addModules(Element moduleArchive, Project proj) {
-        boolean manifestAdded = false
         for (File f : proj.jar.source.getFiles()) {
             String extension = FilenameUtils.getExtension(f.getAbsolutePath())
             switch(extension) {
@@ -112,69 +109,15 @@ public class LooseEarApplication extends LooseApplication {
                     config.addFile(moduleArchive, f, "/WEB-INF/lib/" + f.getName());
                     break
                 case "MF":
-                    // Prefer the jar task's generated manifest (build/tmp/jar/MANIFEST.MF) which has
-                    // the correct Class-Path entries from jar { manifest { attributes } } in build.gradle.
-                    // This avoids incomplete Class-Path entries in any static MANIFEST.MF in resources.
-                    File jarTaskManifest = new File(proj.jar.temporaryDir, "MANIFEST.MF")
-                    if (jarTaskManifest.exists()) {
-                        config.addFile(moduleArchive, jarTaskManifest, "/META-INF/MANIFEST.MF")
-                        // Parse Class-Path and add dependency class directories to module archive
-                        addManifestClassPathDependencies(moduleArchive, jarTaskManifest, proj)
-                    } else {
-                        addManifestFileWithParent(moduleArchive, f, proj.sourceSets.main.getOutput().getResourcesDir().getParentFile().getCanonicalPath())
-                    }
-                    manifestAdded = true
+                    //This checks the manifest file and resource directory of the project's jar source set.
+                    //The location of the resource directory should be the same as proj.getProjectDir()/build/resources.
+                    //If the manifest file exists, it is copied to proj.getProjectDir()/build/resources/tmp/META-INF. If it does not exist, one is created there.
+                    addManifestFileWithParent(moduleArchive, f, proj.sourceSets.main.getOutput().getResourcesDir().getParentFile().getCanonicalPath())
                     break
                 default:
                     break
             }
         }
-        // If no .MF file was found in the jar source set (e.g. no static MANIFEST.MF in resources),
-        // still add the jar task's generated manifest if it exists.
-        if (!manifestAdded) {
-            File jarTaskManifest = new File(proj.jar.temporaryDir, "MANIFEST.MF")
-            if (jarTaskManifest.exists()) {
-                config.addFile(moduleArchive, jarTaskManifest, "/META-INF/MANIFEST.MF")
-                // Parse Class-Path and add dependency class directories to module archive
-                addManifestClassPathDependencies(moduleArchive, jarTaskManifest, proj)
-            }
-        }
     }
-
-    private void addManifestClassPathDependencies(Element moduleArchive, File manifestFile, Project proj) {
-        try {
-            def manifest = new Manifest(new FileInputStream(manifestFile))
-            String classPath = manifest.getMainAttributes().getValue("Class-Path")
-            logger.info("Processing manifest Class-Path for ${proj.name}: ${classPath}")
-            if (classPath) {
-                classPath.split(/\s+/).each { String jarName ->
-                    if (jarName && jarName.endsWith(".jar")) {
-                        String depName = jarName.replace(".jar", "")
-
-                        def depProj = proj.rootProject.findProject(":${depName}")
-                        logger.info("Looking for dependency project: ${depName}, found: ${depProj != null}")
-
-                        if (depProj && depProj.hasProperty('sourceSets')) {
-                            depProj.sourceSets.main.output.classesDirs.files.each {
-                                File classesDir ->
-                                    if (classesDir.exists()) {
-                                        logger.info("Adding dependency class dir to ${proj.name}: ${classesDir}")
-                                        config.addDir(moduleArchive, classesDir, "/")
-                                    }
-                            }
-
-                            def resourcesDir = depProj.sourceSets.main.output.resourcesDir
-                            if (resourcesDir && resourcesDir.exists()) {
-                                logger.info("Adding dependency resource dir to ${proj.name}: ${resourcesDir}")
-                                config.addDir(moduleArchive, resourcesDir, "/")
-                            }
-                        }
-                    }
-                }
-            }
-        } catch (Exception e) {
-            logger.warn("Could not parse manifest Class-Path from ${manifestFile}: ${e.message}", e)
-        }
-    }
-
+    
 }

--- a/src/test/groovy/io/openliberty/tools/gradle/TestMultiModuleLooseEarEjbDependency.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/TestMultiModuleLooseEarEjbDependency.groovy
@@ -1,0 +1,124 @@
+package io.openliberty.tools.gradle
+
+import org.junit.AfterClass
+import org.junit.BeforeClass
+import org.junit.Test
+
+import java.io.File
+import java.io.FileInputStream
+
+import javax.xml.parsers.DocumentBuilder
+import javax.xml.parsers.DocumentBuilderFactory
+import javax.xml.xpath.XPath
+import javax.xml.xpath.XPathConstants
+import javax.xml.xpath.XPathFactory
+
+import org.junit.Assert
+import org.w3c.dom.Document
+import org.w3c.dom.NodeList
+import org.w3c.dom.Node
+
+public class TestMultiModuleLooseEarEjbDependency extends AbstractIntegrationTest {
+    static File resourceDir = new File("build/resources/test/multi-module-loose-ear-ejb-dependency-test")
+    static File buildDir = new File(integTestDir, "/multi-module-loose-ear-ejb-dependency-test")
+    static String buildFilename = "build.gradle"
+
+    @BeforeClass
+    public static void setup() {
+        createDir(buildDir)
+        createTestProject(buildDir, resourceDir, buildFilename)
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        runTasks(buildDir, 'libertyStop')
+    }
+
+    @Test
+    public void test_loose_config_file_exists() {
+        try {
+            runTasks(buildDir, 'deploy')
+        } catch (Exception e) {
+            throw new AssertionError("Fail on task deploy.", e)
+        }
+        
+        File looseXml = new File('build/testBuilds/multi-module-loose-ear-ejb-dependency-test/ear/build/wlp/usr/servers/testServer/apps/ejb-dependency-ear-1.0.ear.xml')
+        assert looseXml.exists() : 'Loose application config file was not created'
+    }
+
+    @Test
+    public void test_ejb_module_includes_dependency_classes() {
+        File looseXml = new File('build/testBuilds/multi-module-loose-ear-ejb-dependency-test/ear/build/wlp/usr/servers/testServer/apps/ejb-dependency-ear-1.0.ear.xml')
+        FileInputStream input = new FileInputStream(looseXml)
+
+        DocumentBuilderFactory inputBuilderFactory = DocumentBuilderFactory.newInstance()
+        inputBuilderFactory.setIgnoringComments(true)
+        inputBuilderFactory.setCoalescing(true)
+        inputBuilderFactory.setIgnoringElementContentWhitespace(true)
+        inputBuilderFactory.setValidating(false)
+        inputBuilderFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-dtd-grammar", false)
+        inputBuilderFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+        DocumentBuilder inputBuilder = inputBuilderFactory.newDocumentBuilder()
+        Document inputDoc = inputBuilder.parse(input)
+
+        XPath xPath = XPathFactory.newInstance().newXPath()
+
+        String expression = "/archive/archive[@targetInArchive='/ejb-dependency-ejb-jar-1.0.jar']"
+        NodeList ejbModuleNodes = (NodeList) xPath.compile(expression).evaluate(inputDoc, XPathConstants.NODESET)
+        Assert.assertEquals("Should have exactly one EJB module archive", 1, ejbModuleNodes.getLength())
+
+        Node ejbModuleNode = ejbModuleNodes.item(0)
+
+        expression = "dir"
+        NodeList dirNodes = (NodeList) xPath.compile(expression).evaluate(ejbModuleNode, XPathConstants.NODESET)
+
+        Assert.assertTrue("EJB module should have at least 2 <dir> elements (own classes + dependency classes)", 
+                         dirNodes.getLength() >= 2)
+
+        // Verify that one of the directories is from lib-jar module
+        boolean foundLibJarClasses = false
+        for (int i = 0; i < dirNodes.getLength(); i++) {
+            Node dirNode = dirNodes.item(i)
+            String sourceOnDisk = dirNode.getAttributes().getNamedItem("sourceOnDisk").getNodeValue()
+            
+            if (sourceOnDisk.contains("lib-jar") && sourceOnDisk.contains("classes")) {
+                foundLibJarClasses = true
+                
+                // Verify targetInArchive is "/"
+                String targetInArchive = dirNode.getAttributes().getNamedItem("targetInArchive").getNodeValue()
+                Assert.assertEquals("Dependency classes should be at root of EJB JAR", "/", targetInArchive)
+                break
+            }
+        }
+        
+        Assert.assertTrue("EJB module should include lib-jar classes directory", foundLibJarClasses)
+    }
+
+    @Test
+    public void test_ejb_module_own_classes_included() {
+        File looseXml = new File('build/testBuilds/multi-module-loose-ear-ejb-dependency-test/ear/build/wlp/usr/servers/testServer/apps/ejb-dependency-ear-1.0.ear.xml')
+        FileInputStream input = new FileInputStream(looseXml)
+
+        DocumentBuilderFactory inputBuilderFactory = DocumentBuilderFactory.newInstance()
+        inputBuilderFactory.setIgnoringComments(true)
+        inputBuilderFactory.setCoalescing(true)
+        inputBuilderFactory.setIgnoringElementContentWhitespace(true)
+        inputBuilderFactory.setValidating(false)
+        inputBuilderFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-dtd-grammar", false)
+        inputBuilderFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+        DocumentBuilder inputBuilder = inputBuilderFactory.newDocumentBuilder()
+        Document inputDoc = inputBuilder.parse(input)
+
+        XPath xPath = XPathFactory.newInstance().newXPath()
+
+        String expression = "/archive/archive[@targetInArchive='/ejb-dependency-ejb-jar-1.0.jar']/dir[contains(@sourceOnDisk, 'ejb-jar') and contains(@sourceOnDisk, 'classes')]"
+        NodeList ejbModuleOwnClasses = (NodeList) xPath.compile(expression).evaluate(inputDoc, XPathConstants.NODESET)
+        
+        Assert.assertTrue("EJB module should include its own classes directory", ejbModuleOwnClasses.getLength() > 0)
+
+        // Verify it targets root of JAR
+        Node dirNode = ejbModuleOwnClasses.item(0)
+        String targetInArchive = dirNode.getAttributes().getNamedItem("targetInArchive").getNodeValue()
+        Assert.assertEquals("EJB module's own classes should be at root of JAR", "/", targetInArchive)
+    }
+}

--- a/src/test/groovy/io/openliberty/tools/gradle/TestMultiModuleLooseEarEjbDependency.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/TestMultiModuleLooseEarEjbDependency.groovy
@@ -34,16 +34,8 @@ public class TestMultiModuleLooseEarEjbDependency extends AbstractIntegrationTes
             throw new AssertionError("The source file '${resourceDir.canonicalPath}' doesn't exist.", null)
         }
         try {
-            FileUtils.copyDirectory(resourceDir, buildDir, new FileFilter() {
-               public boolean accept (File pathname) {
-                   return ((!pathname.getPath().endsWith(".gradle") && 
-                            !pathname.getPath().endsWith(".gradle.kts")) ||
-                            pathname.getPath().endsWith("settings.gradle") ||
-                            pathname.getPath().endsWith("build.gradle"))
-               }
-            });
-            // Copy build.gradle
-            copyFile(new File(resourceDir, buildFilename), new File(buildDir, "build.gradle"))
+            // Copy all resources
+            FileUtils.copyDirectory(resourceDir, buildDir)
             // Copy gradle.properties with absolute path
             copyFile(new File(projectDir, "build/gradle.properties"), new File(buildDir, "gradle.properties"))
         } catch (IOException e) {

--- a/src/test/groovy/io/openliberty/tools/gradle/TestMultiModuleLooseEarEjbDependency.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/TestMultiModuleLooseEarEjbDependency.groovy
@@ -21,23 +21,22 @@ import org.w3c.dom.NodeList
 import org.w3c.dom.Node
 
 public class TestMultiModuleLooseEarEjbDependency extends AbstractIntegrationTest {
-    static File projectDir = new File(TestMultiModuleLooseEarEjbDependency.getProtectionDomain().getCodeSource().getLocation().toURI()).getParentFile().getParentFile().getParentFile().getParentFile()
-    static File resourceDir = new File(projectDir, "build/resources/test/multi-module-loose-ear-ejb-dependency-test")
-    static File buildDir = new File(projectDir, "build/testBuilds/multi-module-loose-ear-ejb-dependency-test")
+    static File resourceDir = new File("build/resources/test/multi-module-loose-ear-ejb-dependency-test")
+    static File buildDir = new File(integTestDir, "/multi-module-loose-ear-ejb-dependency-test")
     static String buildFilename = "build.gradle"
 
     @BeforeClass
     public static void setup() {
         createDir(buildDir)
-        // Inline createTestProject logic with absolute paths
+        // Inline createTestProject logic
         if (!resourceDir.exists()){
             throw new AssertionError("The source file '${resourceDir.canonicalPath}' doesn't exist.", null)
         }
         try {
             // Copy all resources
             FileUtils.copyDirectory(resourceDir, buildDir)
-            // Copy gradle.properties with absolute path
-            copyFile(new File(projectDir, "build/gradle.properties"), new File(buildDir, "gradle.properties"))
+            // Copy gradle.properties
+            copyFile(new File("build/gradle.properties"), new File(buildDir, "gradle.properties"))
         } catch (IOException e) {
             throw new AssertionError("Unable to copy directory '${buildDir.canonicalPath}'.", e)
         }

--- a/src/test/groovy/io/openliberty/tools/gradle/TestMultiModuleLooseEarEjbDependency.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/TestMultiModuleLooseEarEjbDependency.groovy
@@ -23,7 +23,6 @@ import org.w3c.dom.Node
 public class TestMultiModuleLooseEarEjbDependency extends AbstractIntegrationTest {
     static File resourceDir = new File("build/resources/test/multi-module-loose-ear-ejb-dependency-test")
     static File buildDir = new File(integTestDir, "/multi-module-loose-ear-ejb-dependency-test")
-    static String buildFilename = "build.gradle"
 
     @BeforeClass
     public static void setup() {

--- a/src/test/groovy/io/openliberty/tools/gradle/TestMultiModuleLooseEarEjbDependency.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/TestMultiModuleLooseEarEjbDependency.groovy
@@ -72,8 +72,8 @@ public class TestMultiModuleLooseEarEjbDependency extends AbstractIntegrationTes
         expression = "dir"
         NodeList dirNodes = (NodeList) xPath.compile(expression).evaluate(ejbModuleNode, XPathConstants.NODESET)
 
-        Assert.assertTrue("EJB module should have at least 2 <dir> elements (own classes + dependency classes)", 
-                         dirNodes.getLength() >= 2)
+        Assert.assertEquals("EJB module should have exactly 2 <dir> elements (own classes + dependency classes)",
+                         2, dirNodes.getLength())
 
         // Verify that one of the directories is from lib-jar module
         boolean foundLibJarClasses = false

--- a/src/test/groovy/io/openliberty/tools/gradle/TestMultiModuleLooseEarMixedDependency.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/TestMultiModuleLooseEarMixedDependency.groovy
@@ -37,17 +37,8 @@ public class TestMultiModuleLooseEarMixedDependency extends AbstractIntegrationT
             throw new AssertionError("The source file '${resourceDir.canonicalPath}' doesn't exist.", null)
         }
         try {
-            // Copy all resources except .gradle files (include settings.gradle and build.gradle)
-            FileUtils.copyDirectory(resourceDir, buildDir, new FileFilter() {
-               public boolean accept (File pathname) {
-                   return ((!pathname.getPath().endsWith(".gradle") && 
-                            !pathname.getPath().endsWith(".gradle.kts")) ||
-                            pathname.getPath().endsWith("settings.gradle") ||
-                            pathname.getPath().endsWith("build.gradle"))
-               }
-            });
-            // Copy build.gradle
-            copyFile(new File(resourceDir, buildFilename), new File(buildDir, "build.gradle"))
+            // Copy all resources
+            FileUtils.copyDirectory(resourceDir, buildDir)
             // Copy gradle.properties with absolute path
             copyFile(new File(projectDir, "build/gradle.properties"), new File(buildDir, "gradle.properties"))
         } catch (IOException e) {

--- a/src/test/groovy/io/openliberty/tools/gradle/TestMultiModuleLooseEarMixedDependency.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/TestMultiModuleLooseEarMixedDependency.groovy
@@ -26,7 +26,6 @@ import org.w3c.dom.Node
 public class TestMultiModuleLooseEarMixedDependency extends AbstractIntegrationTest {
     static File resourceDir = new File("build/resources/test/multi-module-loose-ear-mixed-test")
     static File buildDir = new File(integTestDir, "/multi-module-loose-ear-mixed-test")
-    static String buildFilename = "build.gradle"
 
     @BeforeClass
     public static void setup() {

--- a/src/test/groovy/io/openliberty/tools/gradle/TestMultiModuleLooseEarMixedDependency.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/TestMultiModuleLooseEarMixedDependency.groovy
@@ -3,6 +3,8 @@ package io.openliberty.tools.gradle
 import org.junit.AfterClass
 import org.junit.BeforeClass
 import org.junit.Test
+import org.junit.FixMethodOrder
+import org.junit.runners.MethodSorters
 
 import java.io.File
 import java.io.FileInputStream
@@ -20,10 +22,11 @@ import org.w3c.dom.Document
 import org.w3c.dom.NodeList
 import org.w3c.dom.Node
 
-public class TestMultiModuleLooseEarEjbDependency extends AbstractIntegrationTest {
-    static File projectDir = new File(TestMultiModuleLooseEarEjbDependency.getProtectionDomain().getCodeSource().getLocation().toURI()).getParentFile().getParentFile().getParentFile().getParentFile()
-    static File resourceDir = new File(projectDir, "build/resources/test/multi-module-loose-ear-ejb-dependency-test")
-    static File buildDir = new File(projectDir, "build/testBuilds/multi-module-loose-ear-ejb-dependency-test")
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class TestMultiModuleLooseEarMixedDependency extends AbstractIntegrationTest {
+    static File projectDir = new File(TestMultiModuleLooseEarMixedDependency.getProtectionDomain().getCodeSource().getLocation().toURI()).getParentFile().getParentFile().getParentFile().getParentFile()
+    static File resourceDir = new File(projectDir, "build/resources/test/multi-module-loose-ear-mixed-test")
+    static File buildDir = new File(projectDir, "build/testBuilds/multi-module-loose-ear-mixed-test")
     static String buildFilename = "build.gradle"
 
     @BeforeClass
@@ -34,6 +37,7 @@ public class TestMultiModuleLooseEarEjbDependency extends AbstractIntegrationTes
             throw new AssertionError("The source file '${resourceDir.canonicalPath}' doesn't exist.", null)
         }
         try {
+            // Copy all resources except .gradle files (include settings.gradle and build.gradle)
             FileUtils.copyDirectory(resourceDir, buildDir, new FileFilter() {
                public boolean accept (File pathname) {
                    return ((!pathname.getPath().endsWith(".gradle") && 
@@ -64,13 +68,13 @@ public class TestMultiModuleLooseEarEjbDependency extends AbstractIntegrationTes
             throw new AssertionError("Fail on task deploy.", e)
         }
         
-        File looseXml = new File('build/testBuilds/multi-module-loose-ear-ejb-dependency-test/ear/build/wlp/usr/servers/testServer/apps/ejb-dependency-ear-1.0.ear.xml')
+        File looseXml = new File('build/testBuilds/multi-module-loose-ear-mixed-test/ear/build/wlp/usr/servers/testServer/apps/ejb-mixed-dependency-ear-1.0.ear.xml')
         assert looseXml.exists() : 'Loose application config file was not created'
     }
 
     @Test
-    public void test_ejb_module_includes_dependency_classes() {
-        File looseXml = new File('build/testBuilds/multi-module-loose-ear-ejb-dependency-test/ear/build/wlp/usr/servers/testServer/apps/ejb-dependency-ear-1.0.ear.xml')
+    public void test_project_dependencies_included() {
+        File looseXml = new File('build/testBuilds/multi-module-loose-ear-mixed-test/ear/build/wlp/usr/servers/testServer/apps/ejb-mixed-dependency-ear-1.0.ear.xml')
         FileInputStream input = new FileInputStream(looseXml)
 
         DocumentBuilderFactory inputBuilderFactory = DocumentBuilderFactory.newInstance()
@@ -85,62 +89,36 @@ public class TestMultiModuleLooseEarEjbDependency extends AbstractIntegrationTes
 
         XPath xPath = XPathFactory.newInstance().newXPath()
 
-        String expression = "/archive/archive[@targetInArchive='/ejb-dependency-ejb-jar-1.0.jar']"
+        String expression = "/archive/archive[@targetInArchive='/ejb-mixed-dependency-ejb-jar-1.0.jar']"
         NodeList ejbModuleNodes = (NodeList) xPath.compile(expression).evaluate(inputDoc, XPathConstants.NODESET)
         Assert.assertEquals("Should have exactly one EJB module archive", 1, ejbModuleNodes.getLength())
 
         Node ejbModuleNode = ejbModuleNodes.item(0)
 
+        // Check for <dir> elements (project dependencies)
         expression = "dir"
         NodeList dirNodes = (NodeList) xPath.compile(expression).evaluate(ejbModuleNode, XPathConstants.NODESET)
 
-        Assert.assertEquals("EJB module should have exactly 2 <dir> elements (own classes + dependency classes)",
+        // Should have exactly 2 <dir> elements: ejb-jar's own classes + lib-jar classes
+        Assert.assertEquals("EJB module should have exactly 2 <dir> elements (own classes + lib-jar project dependency)",
                          2, dirNodes.getLength())
 
         // Verify that one of the directories is from lib-jar module
         boolean foundLibJarClasses = false
+        boolean foundEjbClasses = false
         for (int i = 0; i < dirNodes.getLength(); i++) {
             Node dirNode = dirNodes.item(i)
             String sourceOnDisk = dirNode.getAttributes().getNamedItem("sourceOnDisk").getNodeValue()
             
             if (sourceOnDisk.contains("lib-jar") && sourceOnDisk.contains("classes")) {
                 foundLibJarClasses = true
-                
-                // Verify targetInArchive is "/"
-                String targetInArchive = dirNode.getAttributes().getNamedItem("targetInArchive").getNodeValue()
-                Assert.assertEquals("Dependency classes should be at root of EJB JAR", "/", targetInArchive)
-                break
+            }
+            if (sourceOnDisk.contains("ejb-jar") && sourceOnDisk.contains("classes")) {
+                foundEjbClasses = true
             }
         }
         
-        Assert.assertTrue("EJB module should include lib-jar classes directory", foundLibJarClasses)
-    }
-
-    @Test
-    public void test_ejb_module_own_classes_included() {
-        File looseXml = new File('build/testBuilds/multi-module-loose-ear-ejb-dependency-test/ear/build/wlp/usr/servers/testServer/apps/ejb-dependency-ear-1.0.ear.xml')
-        FileInputStream input = new FileInputStream(looseXml)
-
-        DocumentBuilderFactory inputBuilderFactory = DocumentBuilderFactory.newInstance()
-        inputBuilderFactory.setIgnoringComments(true)
-        inputBuilderFactory.setCoalescing(true)
-        inputBuilderFactory.setIgnoringElementContentWhitespace(true)
-        inputBuilderFactory.setValidating(false)
-        inputBuilderFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-dtd-grammar", false)
-        inputBuilderFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
-        DocumentBuilder inputBuilder = inputBuilderFactory.newDocumentBuilder()
-        Document inputDoc = inputBuilder.parse(input)
-
-        XPath xPath = XPathFactory.newInstance().newXPath()
-
-        String expression = "/archive/archive[@targetInArchive='/ejb-dependency-ejb-jar-1.0.jar']/dir[contains(@sourceOnDisk, 'ejb-jar') and contains(@sourceOnDisk, 'classes')]"
-        NodeList ejbModuleOwnClasses = (NodeList) xPath.compile(expression).evaluate(inputDoc, XPathConstants.NODESET)
-        
-        Assert.assertTrue("EJB module should include its own classes directory", ejbModuleOwnClasses.getLength() > 0)
-
-        // Verify it targets root of JAR
-        Node dirNode = ejbModuleOwnClasses.item(0)
-        String targetInArchive = dirNode.getAttributes().getNamedItem("targetInArchive").getNodeValue()
-        Assert.assertEquals("EJB module's own classes should be at root of JAR", "/", targetInArchive)
+        Assert.assertTrue("EJB module should include its own classes directory", foundEjbClasses)
+        Assert.assertTrue("EJB module should include lib-jar classes directory (project dependency)", foundLibJarClasses)
     }
 }

--- a/src/test/groovy/io/openliberty/tools/gradle/TestMultiModuleLooseEarMixedDependency.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/TestMultiModuleLooseEarMixedDependency.groovy
@@ -24,23 +24,22 @@ import org.w3c.dom.Node
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class TestMultiModuleLooseEarMixedDependency extends AbstractIntegrationTest {
-    static File projectDir = new File(TestMultiModuleLooseEarMixedDependency.getProtectionDomain().getCodeSource().getLocation().toURI()).getParentFile().getParentFile().getParentFile().getParentFile()
-    static File resourceDir = new File(projectDir, "build/resources/test/multi-module-loose-ear-mixed-test")
-    static File buildDir = new File(projectDir, "build/testBuilds/multi-module-loose-ear-mixed-test")
+    static File resourceDir = new File("build/resources/test/multi-module-loose-ear-mixed-test")
+    static File buildDir = new File(integTestDir, "/multi-module-loose-ear-mixed-test")
     static String buildFilename = "build.gradle"
 
     @BeforeClass
     public static void setup() {
         createDir(buildDir)
-        // Inline createTestProject logic with absolute paths
+        // Inline createTestProject logic
         if (!resourceDir.exists()){
             throw new AssertionError("The source file '${resourceDir.canonicalPath}' doesn't exist.", null)
         }
         try {
             // Copy all resources
             FileUtils.copyDirectory(resourceDir, buildDir)
-            // Copy gradle.properties with absolute path
-            copyFile(new File(projectDir, "build/gradle.properties"), new File(buildDir, "gradle.properties"))
+            // Copy gradle.properties
+            copyFile(new File("build/gradle.properties"), new File(buildDir, "gradle.properties"))
         } catch (IOException e) {
             throw new AssertionError("Unable to copy directory '${buildDir.canonicalPath}'.", e)
         }

--- a/src/test/groovy/io/openliberty/tools/gradle/TestMultiModuleLooseEarTransitiveDependency.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/TestMultiModuleLooseEarTransitiveDependency.groovy
@@ -20,10 +20,10 @@ import org.w3c.dom.Document
 import org.w3c.dom.NodeList
 import org.w3c.dom.Node
 
-public class TestMultiModuleLooseEarEjbDependency extends AbstractIntegrationTest {
-    static File projectDir = new File(TestMultiModuleLooseEarEjbDependency.getProtectionDomain().getCodeSource().getLocation().toURI()).getParentFile().getParentFile().getParentFile().getParentFile()
-    static File resourceDir = new File(projectDir, "build/resources/test/multi-module-loose-ear-ejb-dependency-test")
-    static File buildDir = new File(projectDir, "build/testBuilds/multi-module-loose-ear-ejb-dependency-test")
+public class TestMultiModuleLooseEarTransitiveDependency extends AbstractIntegrationTest {
+    static File projectDir = new File(TestMultiModuleLooseEarTransitiveDependency.getProtectionDomain().getCodeSource().getLocation().toURI()).getParentFile().getParentFile().getParentFile().getParentFile()
+    static File resourceDir = new File(projectDir, "build/resources/test/multi-module-loose-ear-transitive-test")
+    static File buildDir = new File(projectDir, "build/testBuilds/multi-module-loose-ear-transitive-test")
     static String buildFilename = "build.gradle"
 
     @BeforeClass
@@ -34,6 +34,7 @@ public class TestMultiModuleLooseEarEjbDependency extends AbstractIntegrationTes
             throw new AssertionError("The source file '${resourceDir.canonicalPath}' doesn't exist.", null)
         }
         try {
+            // Copy all resources except .gradle files (include settings.gradle and build.gradle)
             FileUtils.copyDirectory(resourceDir, buildDir, new FileFilter() {
                public boolean accept (File pathname) {
                    return ((!pathname.getPath().endsWith(".gradle") && 
@@ -64,13 +65,13 @@ public class TestMultiModuleLooseEarEjbDependency extends AbstractIntegrationTes
             throw new AssertionError("Fail on task deploy.", e)
         }
         
-        File looseXml = new File('build/testBuilds/multi-module-loose-ear-ejb-dependency-test/ear/build/wlp/usr/servers/testServer/apps/ejb-dependency-ear-1.0.ear.xml')
+        File looseXml = new File('build/testBuilds/multi-module-loose-ear-transitive-test/ear/build/wlp/usr/servers/testServer/apps/ejb-transitive-dependency-ear-1.0.ear.xml')
         assert looseXml.exists() : 'Loose application config file was not created'
     }
 
     @Test
-    public void test_ejb_module_includes_dependency_classes() {
-        File looseXml = new File('build/testBuilds/multi-module-loose-ear-ejb-dependency-test/ear/build/wlp/usr/servers/testServer/apps/ejb-dependency-ear-1.0.ear.xml')
+    public void test_ejb_module_includes_transitive_dependencies() {
+        File looseXml = new File('build/testBuilds/multi-module-loose-ear-transitive-test/ear/build/wlp/usr/servers/testServer/apps/ejb-transitive-dependency-ear-1.0.ear.xml')
         FileInputStream input = new FileInputStream(looseXml)
 
         DocumentBuilderFactory inputBuilderFactory = DocumentBuilderFactory.newInstance()
@@ -85,7 +86,7 @@ public class TestMultiModuleLooseEarEjbDependency extends AbstractIntegrationTes
 
         XPath xPath = XPathFactory.newInstance().newXPath()
 
-        String expression = "/archive/archive[@targetInArchive='/ejb-dependency-ejb-jar-1.0.jar']"
+        String expression = "/archive/archive[@targetInArchive='/ejb-transitive-dependency-ejb-jar-1.0.jar']"
         NodeList ejbModuleNodes = (NodeList) xPath.compile(expression).evaluate(inputDoc, XPathConstants.NODESET)
         Assert.assertEquals("Should have exactly one EJB module archive", 1, ejbModuleNodes.getLength())
 
@@ -94,53 +95,35 @@ public class TestMultiModuleLooseEarEjbDependency extends AbstractIntegrationTes
         expression = "dir"
         NodeList dirNodes = (NodeList) xPath.compile(expression).evaluate(ejbModuleNode, XPathConstants.NODESET)
 
-        Assert.assertEquals("EJB module should have exactly 2 <dir> elements (own classes + dependency classes)",
-                         2, dirNodes.getLength())
+        Assert.assertEquals("EJB module should have exactly 3 <dir> elements (own classes + lib-jar + base-jar)", 
+                         3, dirNodes.getLength())
 
-        // Verify that one of the directories is from lib-jar module
+        // Verify that directories are from all three modules
+        boolean foundEjbClasses = false
         boolean foundLibJarClasses = false
+        boolean foundBaseJarClasses = false
+        
         for (int i = 0; i < dirNodes.getLength(); i++) {
             Node dirNode = dirNodes.item(i)
             String sourceOnDisk = dirNode.getAttributes().getNamedItem("sourceOnDisk").getNodeValue()
             
-            if (sourceOnDisk.contains("lib-jar") && sourceOnDisk.contains("classes")) {
-                foundLibJarClasses = true
-                
-                // Verify targetInArchive is "/"
+            if (sourceOnDisk.contains("ejb-jar") && sourceOnDisk.contains("classes")) {
+                foundEjbClasses = true
                 String targetInArchive = dirNode.getAttributes().getNamedItem("targetInArchive").getNodeValue()
-                Assert.assertEquals("Dependency classes should be at root of EJB JAR", "/", targetInArchive)
-                break
+                Assert.assertEquals("EJB module's own classes should be at root of JAR", "/", targetInArchive)
+            } else if (sourceOnDisk.contains("lib-jar") && sourceOnDisk.contains("classes")) {
+                foundLibJarClasses = true
+                String targetInArchive = dirNode.getAttributes().getNamedItem("targetInArchive").getNodeValue()
+                Assert.assertEquals("Direct dependency classes should be at root of EJB JAR", "/", targetInArchive)
+            } else if (sourceOnDisk.contains("base-jar") && sourceOnDisk.contains("classes")) {
+                foundBaseJarClasses = true
+                String targetInArchive = dirNode.getAttributes().getNamedItem("targetInArchive").getNodeValue()
+                Assert.assertEquals("Transitive dependency classes should be at root of EJB JAR", "/", targetInArchive)
             }
         }
         
-        Assert.assertTrue("EJB module should include lib-jar classes directory", foundLibJarClasses)
-    }
-
-    @Test
-    public void test_ejb_module_own_classes_included() {
-        File looseXml = new File('build/testBuilds/multi-module-loose-ear-ejb-dependency-test/ear/build/wlp/usr/servers/testServer/apps/ejb-dependency-ear-1.0.ear.xml')
-        FileInputStream input = new FileInputStream(looseXml)
-
-        DocumentBuilderFactory inputBuilderFactory = DocumentBuilderFactory.newInstance()
-        inputBuilderFactory.setIgnoringComments(true)
-        inputBuilderFactory.setCoalescing(true)
-        inputBuilderFactory.setIgnoringElementContentWhitespace(true)
-        inputBuilderFactory.setValidating(false)
-        inputBuilderFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-dtd-grammar", false)
-        inputBuilderFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
-        DocumentBuilder inputBuilder = inputBuilderFactory.newDocumentBuilder()
-        Document inputDoc = inputBuilder.parse(input)
-
-        XPath xPath = XPathFactory.newInstance().newXPath()
-
-        String expression = "/archive/archive[@targetInArchive='/ejb-dependency-ejb-jar-1.0.jar']/dir[contains(@sourceOnDisk, 'ejb-jar') and contains(@sourceOnDisk, 'classes')]"
-        NodeList ejbModuleOwnClasses = (NodeList) xPath.compile(expression).evaluate(inputDoc, XPathConstants.NODESET)
-        
-        Assert.assertTrue("EJB module should include its own classes directory", ejbModuleOwnClasses.getLength() > 0)
-
-        // Verify it targets root of JAR
-        Node dirNode = ejbModuleOwnClasses.item(0)
-        String targetInArchive = dirNode.getAttributes().getNamedItem("targetInArchive").getNodeValue()
-        Assert.assertEquals("EJB module's own classes should be at root of JAR", "/", targetInArchive)
+        Assert.assertTrue("EJB module should include its own classes directory", foundEjbClasses)
+        Assert.assertTrue("EJB module should include lib-jar classes directory (direct dependency)", foundLibJarClasses)
+        Assert.assertTrue("EJB module should include base-jar classes directory (transitive dependency)", foundBaseJarClasses)
     }
 }

--- a/src/test/groovy/io/openliberty/tools/gradle/TestMultiModuleLooseEarTransitiveDependency.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/TestMultiModuleLooseEarTransitiveDependency.groovy
@@ -34,17 +34,8 @@ public class TestMultiModuleLooseEarTransitiveDependency extends AbstractIntegra
             throw new AssertionError("The source file '${resourceDir.canonicalPath}' doesn't exist.", null)
         }
         try {
-            // Copy all resources except .gradle files (include settings.gradle and build.gradle)
-            FileUtils.copyDirectory(resourceDir, buildDir, new FileFilter() {
-               public boolean accept (File pathname) {
-                   return ((!pathname.getPath().endsWith(".gradle") && 
-                            !pathname.getPath().endsWith(".gradle.kts")) ||
-                            pathname.getPath().endsWith("settings.gradle") ||
-                            pathname.getPath().endsWith("build.gradle"))
-               }
-            });
-            // Copy build.gradle
-            copyFile(new File(resourceDir, buildFilename), new File(buildDir, "build.gradle"))
+            // Copy all resources
+            FileUtils.copyDirectory(resourceDir, buildDir)
             // Copy gradle.properties with absolute path
             copyFile(new File(projectDir, "build/gradle.properties"), new File(buildDir, "gradle.properties"))
         } catch (IOException e) {

--- a/src/test/groovy/io/openliberty/tools/gradle/TestMultiModuleLooseEarTransitiveDependency.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/TestMultiModuleLooseEarTransitiveDependency.groovy
@@ -21,23 +21,22 @@ import org.w3c.dom.NodeList
 import org.w3c.dom.Node
 
 public class TestMultiModuleLooseEarTransitiveDependency extends AbstractIntegrationTest {
-    static File projectDir = new File(TestMultiModuleLooseEarTransitiveDependency.getProtectionDomain().getCodeSource().getLocation().toURI()).getParentFile().getParentFile().getParentFile().getParentFile()
-    static File resourceDir = new File(projectDir, "build/resources/test/multi-module-loose-ear-transitive-test")
-    static File buildDir = new File(projectDir, "build/testBuilds/multi-module-loose-ear-transitive-test")
+    static File resourceDir = new File("build/resources/test/multi-module-loose-ear-transitive-test")
+    static File buildDir = new File(integTestDir, "/multi-module-loose-ear-transitive-test")
     static String buildFilename = "build.gradle"
 
     @BeforeClass
     public static void setup() {
         createDir(buildDir)
-        // Inline createTestProject logic with absolute paths
+        // Inline createTestProject logic
         if (!resourceDir.exists()){
             throw new AssertionError("The source file '${resourceDir.canonicalPath}' doesn't exist.", null)
         }
         try {
             // Copy all resources
             FileUtils.copyDirectory(resourceDir, buildDir)
-            // Copy gradle.properties with absolute path
-            copyFile(new File(projectDir, "build/gradle.properties"), new File(buildDir, "gradle.properties"))
+            // Copy gradle.properties
+            copyFile(new File("build/gradle.properties"), new File(buildDir, "gradle.properties"))
         } catch (IOException e) {
             throw new AssertionError("Unable to copy directory '${buildDir.canonicalPath}'.", e)
         }

--- a/src/test/groovy/io/openliberty/tools/gradle/TestMultiModuleLooseEarTransitiveDependency.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/TestMultiModuleLooseEarTransitiveDependency.groovy
@@ -23,7 +23,6 @@ import org.w3c.dom.Node
 public class TestMultiModuleLooseEarTransitiveDependency extends AbstractIntegrationTest {
     static File resourceDir = new File("build/resources/test/multi-module-loose-ear-transitive-test")
     static File buildDir = new File(integTestDir, "/multi-module-loose-ear-transitive-test")
-    static String buildFilename = "build.gradle"
 
     @BeforeClass
     public static void setup() {

--- a/src/test/resources/loose-ear-manifest-classpath-test/sample-lib/src/main/java/sample/lib/Model.java
+++ b/src/test/resources/loose-ear-manifest-classpath-test/sample-lib/src/main/java/sample/lib/Model.java
@@ -1,0 +1,8 @@
+package sample.lib;
+
+public class Model {
+
+    public String name() {
+        return "model";
+    }
+}

--- a/src/test/resources/multi-module-loose-ear-ejb-dependency-test/build.gradle
+++ b/src/test/resources/multi-module-loose-ear-ejb-dependency-test/build.gradle
@@ -1,0 +1,22 @@
+allprojects  {
+    group = 'sample'
+    version = '1.0'
+}
+
+subprojects {
+    apply plugin: 'java'
+
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    tasks.withType(JavaCompile) {
+        options.encoding = 'UTF-8'
+    }
+    
+    repositories {
+        mavenLocal()
+        mavenCentral()
+    }
+}

--- a/src/test/resources/multi-module-loose-ear-ejb-dependency-test/ear/build.gradle
+++ b/src/test/resources/multi-module-loose-ear-ejb-dependency-test/ear/build.gradle
@@ -1,0 +1,48 @@
+apply plugin: 'ear'
+apply plugin: 'liberty'
+
+description = 'EAR Module'
+
+buildscript {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        maven {
+            url = 'https://central.sonatype.com/repository/maven-snapshots/'
+        }
+    }
+    dependencies {
+        classpath "io.openliberty.tools:liberty-gradle-plugin:$lgpVersion"
+    }
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    deploy project(path:':ejb-jar', configuration:'archives')
+    libertyRuntime group: runtimeGroup, name: kernelArtifactId, version: runtimeVersion
+}
+
+ear {
+    archiveFileName = rootProject.name+"-"+getArchiveBaseName().get() +"-"+rootProject.version+ '.' + getArchiveExtension().get()
+    deploymentDescriptor {
+        module ('ejb-dependency-ejb-jar-1.0.jar', 'ejb')
+    }
+}
+
+liberty {
+    server {
+        name = "testServer"
+        deploy {
+            apps = [ear]
+        }
+        verifyAppStartTimeout = 30
+        looseApplication = true
+    }
+}
+
+deploy.dependsOn 'ear'
+ear.dependsOn ':ejb-jar:jar', ':lib-jar:jar'

--- a/src/test/resources/multi-module-loose-ear-ejb-dependency-test/ear/src/main/liberty/config/server.xml
+++ b/src/test/resources/multi-module-loose-ear-ejb-dependency-test/ear/src/main/liberty/config/server.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="Test server">
+    <featureManager>
+        <feature>ejb-3.2</feature>
+    </featureManager>
+
+    <httpEndpoint id="defaultHttpEndpoint"
+                  host="*"
+                  httpPort="9080"
+                  httpsPort="9443" />
+
+    <application location="ejb-dependency-ear-1.0.ear"/>
+</server>

--- a/src/test/resources/multi-module-loose-ear-ejb-dependency-test/ejb-jar/build.gradle
+++ b/src/test/resources/multi-module-loose-ear-ejb-dependency-test/ejb-jar/build.gradle
@@ -1,0 +1,10 @@
+description = 'EJB Module'
+
+dependencies {
+    compileOnly group: 'javax', name: 'javaee-api', version:'7.0'
+    compileOnly project(':lib-jar')
+}
+
+jar {
+    archiveFileName = rootProject.name+"-"+getArchiveBaseName().get() +"-"+rootProject.version+ '.' + getArchiveExtension().get()
+}

--- a/src/test/resources/multi-module-loose-ear-ejb-dependency-test/ejb-jar/src/main/java/wasdev/sample/SampleBean.java
+++ b/src/test/resources/multi-module-loose-ear-ejb-dependency-test/ejb-jar/src/main/java/wasdev/sample/SampleBean.java
@@ -1,0 +1,11 @@
+package wasdev.sample;
+
+import javax.ejb.Stateless;
+
+@Stateless
+public class SampleBean {
+    
+    public DataBean getData() {
+        return new DataBean("test");
+    }
+}

--- a/src/test/resources/multi-module-loose-ear-ejb-dependency-test/lib-jar/build.gradle
+++ b/src/test/resources/multi-module-loose-ear-ejb-dependency-test/lib-jar/build.gradle
@@ -1,0 +1,9 @@
+description = 'Library JAR Module'
+
+dependencies {
+    compileOnly group: 'javax', name: 'javaee-api', version:'7.0'
+}
+
+jar {
+    archiveFileName = rootProject.name+"-"+getArchiveBaseName().get() +"-"+rootProject.version+ '.' + getArchiveExtension().get()
+}

--- a/src/test/resources/multi-module-loose-ear-ejb-dependency-test/lib-jar/src/main/java/wasdev/sample/DataBean.java
+++ b/src/test/resources/multi-module-loose-ear-ejb-dependency-test/lib-jar/src/main/java/wasdev/sample/DataBean.java
@@ -1,0 +1,20 @@
+package wasdev.sample;
+
+public class DataBean {
+    private String value;
+    
+    public DataBean() {
+    }
+    
+    public DataBean(String value) {
+        this.value = value;
+    }
+    
+    public String getValue() {
+        return value;
+    }
+    
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/src/test/resources/multi-module-loose-ear-ejb-dependency-test/settings.gradle
+++ b/src/test/resources/multi-module-loose-ear-ejb-dependency-test/settings.gradle
@@ -1,0 +1,8 @@
+rootProject.name = 'ejb-dependency'
+include ':lib-jar'
+include ':ejb-jar'
+include ':ear'
+
+project(':lib-jar').projectDir = "$rootDir/lib-jar" as File
+project(':ejb-jar').projectDir = "$rootDir/ejb-jar" as File
+project(':ear').projectDir = "$rootDir/ear" as File

--- a/src/test/resources/multi-module-loose-ear-mixed-test/build.gradle
+++ b/src/test/resources/multi-module-loose-ear-mixed-test/build.gradle
@@ -1,0 +1,22 @@
+allprojects  {
+    group = 'ejb.mixed.dependency'
+    version = '1.0'
+}
+
+subprojects {
+    apply plugin: 'java'
+
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    tasks.withType(JavaCompile) {
+        options.encoding = 'UTF-8'
+    }
+
+    repositories {
+        mavenLocal()
+        mavenCentral()
+    }
+}

--- a/src/test/resources/multi-module-loose-ear-mixed-test/ear/build.gradle
+++ b/src/test/resources/multi-module-loose-ear-mixed-test/ear/build.gradle
@@ -1,0 +1,48 @@
+apply plugin: 'ear'
+apply plugin: 'liberty'
+
+description = 'EAR Module'
+
+buildscript {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        maven {
+            url = 'https://central.sonatype.com/repository/maven-snapshots/'
+        }
+    }
+    dependencies {
+        classpath "io.openliberty.tools:liberty-gradle-plugin:$lgpVersion"
+    }
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    deploy project(path:':ejb-jar', configuration:'archives')
+    libertyRuntime group: runtimeGroup, name: kernelArtifactId, version: runtimeVersion
+}
+
+ear {
+    archiveFileName = rootProject.name+"-"+getArchiveBaseName().get() +"-"+rootProject.version+ '.' + getArchiveExtension().get()
+    deploymentDescriptor {
+        module ('ejb-mixed-dependency-ejb-jar-1.0.jar', 'ejb')
+    }
+}
+
+liberty {
+    server {
+        name = "testServer"
+        deploy {
+            apps = [ear]
+        }
+        verifyAppStartTimeout = 30
+        looseApplication = true
+    }
+}
+
+deploy.dependsOn 'ear'
+ear.dependsOn ':ejb-jar:jar', ':lib-jar:jar'

--- a/src/test/resources/multi-module-loose-ear-mixed-test/ejb-jar/build.gradle
+++ b/src/test/resources/multi-module-loose-ear-mixed-test/ejb-jar/build.gradle
@@ -1,8 +1,9 @@
-description = 'EJB Module'
+description = 'EJB Module (has both project dependency and external JAR)'
 
 dependencies {
     compileOnly group: 'javax', name: 'javaee-api', version:'7.0'
     implementation project(':lib-jar')
+    implementation 'org.apache.commons:commons-lang3:3.12.0'
 }
 
 jar {

--- a/src/test/resources/multi-module-loose-ear-mixed-test/ejb-jar/src/main/java/io/openliberty/test/ejb/MixedDependencyBean.java
+++ b/src/test/resources/multi-module-loose-ear-mixed-test/ejb-jar/src/main/java/io/openliberty/test/ejb/MixedDependencyBean.java
@@ -1,0 +1,15 @@
+package io.openliberty.test.ejb;
+
+import io.openliberty.test.lib.LibraryService;
+import org.apache.commons.lang3.StringUtils;
+import javax.ejb.Stateless;
+
+@Stateless
+public class MixedDependencyBean {
+    public void testMethod() {
+        LibraryService service = new LibraryService();
+        String message = service.getMessage();
+        // Use commons-lang3 to demonstrate external JAR dependency
+        String capitalized = StringUtils.capitalize(message);
+    }
+}

--- a/src/test/resources/multi-module-loose-ear-mixed-test/lib-jar/build.gradle
+++ b/src/test/resources/multi-module-loose-ear-mixed-test/lib-jar/build.gradle
@@ -1,8 +1,7 @@
-description = 'EJB Module'
+description = 'Library Module'
 
 dependencies {
     compileOnly group: 'javax', name: 'javaee-api', version:'7.0'
-    implementation project(':lib-jar')
 }
 
 jar {

--- a/src/test/resources/multi-module-loose-ear-mixed-test/lib-jar/src/main/java/io/openliberty/test/lib/LibraryService.java
+++ b/src/test/resources/multi-module-loose-ear-mixed-test/lib-jar/src/main/java/io/openliberty/test/lib/LibraryService.java
@@ -1,0 +1,7 @@
+package io.openliberty.test.lib;
+
+public class LibraryService {
+    public String getMessage() {
+        return "Hello from library";
+    }
+}

--- a/src/test/resources/multi-module-loose-ear-mixed-test/settings.gradle
+++ b/src/test/resources/multi-module-loose-ear-mixed-test/settings.gradle
@@ -1,0 +1,4 @@
+rootProject.name = 'ejb-mixed-dependency'
+include ':lib-jar'
+include ':ejb-jar'
+include ':ear'

--- a/src/test/resources/multi-module-loose-ear-transitive-test/base-jar/build.gradle
+++ b/src/test/resources/multi-module-loose-ear-transitive-test/base-jar/build.gradle
@@ -1,8 +1,7 @@
-description = 'EJB Module'
+description = 'Base Library Module'
 
 dependencies {
     compileOnly group: 'javax', name: 'javaee-api', version:'7.0'
-    implementation project(':lib-jar')
 }
 
 jar {

--- a/src/test/resources/multi-module-loose-ear-transitive-test/base-jar/src/main/java/io/openliberty/test/base/BaseEntity.java
+++ b/src/test/resources/multi-module-loose-ear-transitive-test/base-jar/src/main/java/io/openliberty/test/base/BaseEntity.java
@@ -1,0 +1,13 @@
+package io.openliberty.test.base;
+
+public class BaseEntity {
+    private Long id;
+    
+    public Long getId() {
+        return id;
+    }
+    
+    public void setId(Long id) {
+        this.id = id;
+    }
+}

--- a/src/test/resources/multi-module-loose-ear-transitive-test/build.gradle
+++ b/src/test/resources/multi-module-loose-ear-transitive-test/build.gradle
@@ -1,0 +1,22 @@
+allprojects  {
+    group = 'sample'
+    version = '1.0'
+}
+
+subprojects {
+    apply plugin: 'java'
+
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    tasks.withType(JavaCompile) {
+        options.encoding = 'UTF-8'
+    }
+    
+    repositories {
+        mavenLocal()
+        mavenCentral()
+    }
+}

--- a/src/test/resources/multi-module-loose-ear-transitive-test/ear/build.gradle
+++ b/src/test/resources/multi-module-loose-ear-transitive-test/ear/build.gradle
@@ -1,0 +1,48 @@
+apply plugin: 'ear'
+apply plugin: 'liberty'
+
+description = 'EAR Module'
+
+buildscript {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        maven {
+            url = 'https://central.sonatype.com/repository/maven-snapshots/'
+        }
+    }
+    dependencies {
+        classpath "io.openliberty.tools:liberty-gradle-plugin:$lgpVersion"
+    }
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    deploy project(path:':ejb-jar', configuration:'archives')
+    libertyRuntime group: runtimeGroup, name: kernelArtifactId, version: runtimeVersion
+}
+
+ear {
+    archiveFileName = rootProject.name+"-"+getArchiveBaseName().get() +"-"+rootProject.version+ '.' + getArchiveExtension().get()
+    deploymentDescriptor {
+        module ('ejb-transitive-dependency-ejb-jar-1.0.jar', 'ejb')
+    }
+}
+
+liberty {
+    server {
+        name = "testServer"
+        deploy {
+            apps = [ear]
+        }
+        verifyAppStartTimeout = 30
+        looseApplication = true
+    }
+}
+
+deploy.dependsOn 'ear'
+ear.dependsOn ':ejb-jar:jar', ':lib-jar:jar', ':base-jar:jar'

--- a/src/test/resources/multi-module-loose-ear-transitive-test/ejb-jar/build.gradle
+++ b/src/test/resources/multi-module-loose-ear-transitive-test/ejb-jar/build.gradle
@@ -1,4 +1,4 @@
-description = 'EJB Module'
+description = 'EJB Module (depends on lib-jar, transitively on base-jar)'
 
 dependencies {
     compileOnly group: 'javax', name: 'javaee-api', version:'7.0'

--- a/src/test/resources/multi-module-loose-ear-transitive-test/ejb-jar/src/main/java/io/openliberty/test/ejb/TransitiveTestBean.java
+++ b/src/test/resources/multi-module-loose-ear-transitive-test/ejb-jar/src/main/java/io/openliberty/test/ejb/TransitiveTestBean.java
@@ -1,0 +1,12 @@
+package io.openliberty.test.ejb;
+
+import io.openliberty.test.lib.LibraryService;
+import javax.ejb.Stateless;
+
+@Stateless
+public class TransitiveTestBean {
+    public void testMethod() {
+        LibraryService service = new LibraryService();
+        service.processEntity();
+    }
+}

--- a/src/test/resources/multi-module-loose-ear-transitive-test/lib-jar/build.gradle
+++ b/src/test/resources/multi-module-loose-ear-transitive-test/lib-jar/build.gradle
@@ -1,8 +1,8 @@
-description = 'EJB Module'
+description = 'Library Module (depends on base-jar)'
 
 dependencies {
     compileOnly group: 'javax', name: 'javaee-api', version:'7.0'
-    implementation project(':lib-jar')
+    implementation project(':base-jar')
 }
 
 jar {

--- a/src/test/resources/multi-module-loose-ear-transitive-test/lib-jar/src/main/java/io/openliberty/test/lib/LibraryService.java
+++ b/src/test/resources/multi-module-loose-ear-transitive-test/lib-jar/src/main/java/io/openliberty/test/lib/LibraryService.java
@@ -1,0 +1,10 @@
+package io.openliberty.test.lib;
+
+import io.openliberty.test.base.BaseEntity;
+
+public class LibraryService {
+    public void processEntity() {
+        BaseEntity entity = new BaseEntity();
+        entity.setId(1L);
+    }
+}

--- a/src/test/resources/multi-module-loose-ear-transitive-test/settings.gradle
+++ b/src/test/resources/multi-module-loose-ear-transitive-test/settings.gradle
@@ -1,0 +1,10 @@
+rootProject.name = 'ejb-transitive-dependency'
+include ':base-jar'
+include ':lib-jar'
+include ':ejb-jar'
+include ':ear'
+
+project(':base-jar').projectDir = "$rootDir/base-jar" as File
+project(':lib-jar').projectDir = "$rootDir/lib-jar" as File
+project(':ejb-jar').projectDir = "$rootDir/ejb-jar" as File
+project(':ear').projectDir = "$rootDir/ear" as File


### PR DESCRIPTION
Fixes #766 

### Issue
The application failed to start in loose EAR mode with,
```
StateChangeException: Error while loading class com.ibm.websphere.svt.gs.gsdb.session.MfgCategorySessionBean
ResourceLoadingException: Error while loading JPA entity classes (MfgCategory, Category, etc.)
```

In packaged EAR mode, JAR files are physically present in the EAR, and Liberty's classloader uses the manifest Class-Path entries to locate dependency JARs within the EAR.

In loose EAR mode (looseApplication = true), there are no physical JAR files. Instead, the plugin generates an XML descriptor (GarageSaleLibertyEAR.ear.xml) that maps source directories. Liberty's classloader needs to know which class directories belong to each module.

**The Problem**
- EJB modules depend on other modules (e.g., JPA modules) via `compileOnly` or `implementation` dependencies
- The plugin only added the EJB module's own classes to the loose XML
- Dependency class directories were not included, causing ClassNotFoundException at runtime

**Previous Approach (Reverted)**
The previous fix attempted to use manifest Class-Path entries to determine dependencies, requiring users to manually declare Class-Path in their build.gradle files. This approach was reverted after cross-checking with Maven plugin implementation.

**Current Approach**
Added `addDependencyClassDirectories()` method that,
1. Scans both `compileClasspath` and `runtimeClasspath` for project dependencies
2. Automatically adds each dependency's class and resource directories to the module in loose XML
3. Works without requiring manifest Class-Path configuration

**How it works**
- Plugin automatically detects project dependencies from Gradle configurations
- For each EJB/JAR module, it finds all project dependencies
- Adds dependency class directories as `<dir>` elements in the loose XML
- Liberty's classloader can now find all required classes at runtime

**Usage Requirements**
No special configuration needed. The plugin automatically handles dependencies declared in build.gradle.

**Backward Compatibility**
- Packaged EAR mode (`looseApplication = false`) continues to work unchanged
- Existing projects work without modification

**Testing**
Added a new test `TestMultiModuleLooseEarEjbDependency` that verifies
- Loose application XML is generated correctly
- EJB modules include dependency class directories
- Module's own classes are still included

**Before**
<img width="1642" height="531" alt="image" src="https://github.com/user-attachments/assets/027d325b-79d7-4030-b868-8fe3077120c7" />

**After**
<img width="1643" height="531" alt="image" src="https://github.com/user-attachments/assets/1ac9c1dc-5e35-422a-b4ab-b2a6435d3c29" />

