### PR TITLE
Test added to verify no duplicate compilation for java files

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -39,7 +39,8 @@ jobs:
     - name: Checkout ci.common
       uses: actions/checkout@v3
       with:
-        repository: OpenLiberty/ci.common
+        repository: sajeerzeji/ci.common
+        ref: resolveVars
         path: ci.common
     - name: Checkout ci.ant
       uses: actions/checkout@v3
@@ -127,7 +128,7 @@ jobs:
     - name: Clone ci.ant, ci.common, ci.gradle repos to C drive
       run: |
         echo ${{github.workspace}}
-        git clone https://github.com/OpenLiberty/ci.common.git ${{github.workspace}}/ci.common
+        git clone https://github.com/sajeerzeji/ci.common.git --branch resolveVars --single-branch ${{github.workspace}}/ci.common
         git clone https://github.com/OpenLiberty/ci.ant.git ${{github.workspace}}/ci.ant
     # Cache mvn/gradle packages
     - name: Cache Maven packages

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -39,8 +39,7 @@ jobs:
     - name: Checkout ci.common
       uses: actions/checkout@v3
       with:
-        repository: sajeerzeji/ci.common
-        reference: GH752-duplicate_processFileChanges_calls_for_java_source_files_in_devmode
+        repository: OpenLiberty/ci.common
         path: ci.common
     - name: Checkout ci.ant
       uses: actions/checkout@v3
@@ -128,7 +127,7 @@ jobs:
     - name: Clone ci.ant, ci.common, ci.gradle repos to C drive
       run: |
         echo ${{github.workspace}}
-        git clone https://github.com/sajeerzeji/ci.common.git --branch GH752-duplicate_processFileChanges_calls_for_java_source_files_in_devmode --single-branch ${{github.workspace}}/ci.common
+        git clone https://github.com/OpenLiberty/ci.common.git ${{github.workspace}}/ci.common
         git clone https://github.com/OpenLiberty/ci.ant.git ${{github.workspace}}/ci.ant
     # Cache mvn/gradle packages
     - name: Cache Maven packages

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -40,7 +40,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: sajeerzeji/ci.common
-        reference: resolveVars
+        reference: GH752-duplicate_processFileChanges_calls_for_java_source_files_in_devmode
         path: ci.common
     - name: Checkout ci.ant
       uses: actions/checkout@v3
@@ -128,7 +128,7 @@ jobs:
     - name: Clone ci.ant, ci.common, ci.gradle repos to C drive
       run: |
         echo ${{github.workspace}}
-        git clone https://github.com/sajeerzeji/ci.common.git --branch resolveVars --single-branch ${{github.workspace}}/ci.common
+        git clone https://github.com/sajeerzeji/ci.common.git --branch GH752-duplicate_processFileChanges_calls_for_java_source_files_in_devmode --single-branch ${{github.workspace}}/ci.common
         git clone https://github.com/OpenLiberty/ci.ant.git ${{github.workspace}}/ci.ant
     # Cache mvn/gradle packages
     - name: Cache Maven packages

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -40,7 +40,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: sajeerzeji/ci.common
-        ref: resolveVars
+        reference: resolveVars
         path: ci.common
     - name: Checkout ci.ant
       uses: actions/checkout@v3

--- a/src/test/groovy/io/openliberty/tools/gradle/DevNoDuplicateCompilationTest.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/DevNoDuplicateCompilationTest.groovy
@@ -1,0 +1,134 @@
+package io.openliberty.tools.gradle;
+
+import static org.junit.Assert.*;
+
+import java.io.BufferedWriter;
+import org.apache.commons.io.FileUtils;
+import java.io.File;
+import java.io.FileWriter;
+import org.junit.BeforeClass;
+import org.junit.AfterClass;
+import org.junit.Test;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+class DevNoDuplicateCompilationTest extends BaseDevTest {
+    static final String projectName = "basic-dev-project";
+
+    static File resourceDir = new File("build/resources/test/dev-test/" + projectName);
+    static File buildDir = new File(integTestDir, "dev-test/" + projectName + System.currentTimeMillis());
+
+    @BeforeClass
+    public static void setup() throws IOException, InterruptedException, FileNotFoundException {
+        createDir(buildDir);
+        createTestProject(buildDir, resourceDir, buildFilename);
+        runDevMode(buildDir);
+    }
+
+    @Test
+    public void testNoDuplicateCompilation() throws Exception {
+        assertTrue(verifyLogMessage(10000, "Liberty is running in dev mode."));
+        assertTrue(verifyLogMessage(20000, WEB_APP_AVAILABLE, errFile));
+
+        File srcHelloWorld = new File(buildDir, "src/main/java/com/demo/HelloWorld.java");
+        File targetHelloWorld = new File(targetDir, "classes/java/main/com/demo/HelloWorld.class");
+        assertTrue(srcHelloWorld.exists());
+        assertTrue(targetHelloWorld.exists());
+
+        // Count initial compilation messages
+        int initialCompilationCount = countOccurrences(COMPILATION_SUCCESSFUL, logFile);
+        int initialHotReloadCount = countOccurrences(SERVER_CONFIG_SUCCESS, errFile);
+
+        waitLongEnough();
+        long lastModified = targetHelloWorld.lastModified();
+
+        String modification = "// Test modification for duplicate compilation check";
+        BufferedWriter javaWriter = null;
+        try {
+            javaWriter = new BufferedWriter(new FileWriter(srcHelloWorld, true));
+            javaWriter.append('\n');
+            javaWriter.append(modification);
+        } finally {
+            if (javaWriter != null) {
+                javaWriter.close();
+            }
+        }
+
+        assertTrue("Class file was not recompiled", waitForCompilation(targetHelloWorld, lastModified, 10000));
+        assertTrue("Source compilation message not found", 
+            verifyLogMessage(10000, COMPILATION_SUCCESSFUL, ++initialCompilationCount));
+        assertTrue("Liberty hot reload message (CWWKZ0003I) not found",
+            verifyLogMessage(10000, SERVER_CONFIG_SUCCESS, errFile, ++initialHotReloadCount));
+
+        Thread.sleep(3000);
+
+        // Count final compilation messages
+        int finalCompilationCount = countOccurrences(COMPILATION_SUCCESSFUL, logFile);
+        int finalHotReloadCount = countOccurrences(SERVER_CONFIG_SUCCESS, errFile);
+
+        assertEquals("Duplicate compilation detected - compilation happened more than once",
+            initialCompilationCount, finalCompilationCount);
+        assertEquals("Multiple hot reloads detected - should only reload once per change",
+            initialHotReloadCount, finalHotReloadCount);
+    }
+
+    @Test
+    public void testMultipleSequentialChanges() throws Exception {
+        assertTrue(verifyLogMessage(10000, "Liberty is running in dev mode."));
+        assertTrue(verifyLogMessage(20000, WEB_APP_AVAILABLE, errFile));
+
+        File srcHelloWorld = new File(buildDir, "src/main/java/com/demo/HelloWorld.java");
+        File targetHelloWorld = new File(targetDir, "classes/java/main/com/demo/HelloWorld.class");
+        assertTrue(srcHelloWorld.exists());
+        assertTrue(targetHelloWorld.exists());
+
+        for (int i = 1; i <= 3; i++) {
+            int compilationCountBefore = countOccurrences(COMPILATION_SUCCESSFUL, logFile);
+            int hotReloadCountBefore = countOccurrences(SERVER_CONFIG_SUCCESS, errFile);
+
+            waitLongEnough();
+            long lastModified = targetHelloWorld.lastModified();
+
+            String modification = "// Test modification #" + i + " for duplicate compilation check";
+            BufferedWriter javaWriter = null;
+            try {
+                javaWriter = new BufferedWriter(new FileWriter(srcHelloWorld, true));
+                javaWriter.append('\n');
+                javaWriter.append(modification);
+            } finally {
+                if (javaWriter != null) {
+                    javaWriter.close();
+                }
+            }
+
+            assertTrue("Class file was not recompiled for change #" + i,
+                waitForCompilation(targetHelloWorld, lastModified, 10000));
+            assertTrue("Source compilation message not found for change #" + i,
+                verifyLogMessage(10000, COMPILATION_SUCCESSFUL, ++compilationCountBefore));
+            assertTrue("Liberty hot reload message (CWWKZ0003I) not found for change #" + i,
+                verifyLogMessage(10000, SERVER_CONFIG_SUCCESS, errFile, ++hotReloadCountBefore));
+
+            Thread.sleep(3000);
+
+            // Count compilation messages after change
+            int compilationCountAfter = countOccurrences(COMPILATION_SUCCESSFUL, logFile);
+            int hotReloadCountAfter = countOccurrences(SERVER_CONFIG_SUCCESS, errFile);
+
+            assertEquals("Duplicate compilation detected for change #" + i,
+                compilationCountBefore, compilationCountAfter);
+            assertEquals("Multiple hot reloads detected for change #" + i,
+                hotReloadCountBefore, hotReloadCountAfter);
+        }
+    }
+
+    @AfterClass
+    public static void cleanUpAfterClass() throws Exception {
+        String stdout = getContents(logFile, "Dev mode std output");
+        System.out.println(stdout);
+        String stderr = getContents(errFile, "Dev mode std error");
+        System.out.println(stderr);
+        cleanUpAfterClass(true);
+    }
+}


### PR DESCRIPTION
Relates to the PR: [ci.common: #505](https://github.com/OpenLiberty/ci.common/pull/505) which fixes an issue mentioned in the comments of [Maven:#752](https://github.com/OpenLiberty/ci.maven/issues/752).
This PR contains Tests that verifies changes in ci.common is working correctly.