### PR TITLE
Fixed the race condition: removed premature runHotkeyReaderThread() call before watchFiles()

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -39,7 +39,8 @@ jobs:
     - name: Checkout ci.common
       uses: actions/checkout@v3
       with:
-        repository: OpenLiberty/ci.common
+        repository: sajeerzeji/ci.common
+        ref: GHLMP2070-Fix_race_condition_in_DevMojo_doDevMode
         path: ci.common
     - name: Checkout ci.ant
       uses: actions/checkout@v3
@@ -120,7 +121,7 @@ jobs:
     - name: Clone ci.ant, ci.common, ci.gradle repos to C drive
       run: |
         echo ${{github.workspace}}
-        git clone https://github.com/OpenLiberty/ci.common.git ${{github.workspace}}/ci.common
+        git clone https://github.com/sajeerzeji/ci.common.git --branch GHLMP2070-Fix_race_condition_in_DevMojo_doDevMode --single-branch ${{github.workspace}}/ci.common
         git clone https://github.com/OpenLiberty/ci.ant.git ${{github.workspace}}/ci.ant
     # Cache mvn/gradle packages
     - name: Cache Maven packages

--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ java {
 }
 
 def libertyAntVersion = "1.9.18"
-def libertyCommonVersion = "1.8.42"
+def libertyCommonVersion = "1.8.43-SNAPSHOT"
 
 
 dependencies {

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
@@ -379,16 +379,16 @@ class DevTask extends AbstractFeatureTask {
                     boolean  hotTests, boolean  skipTests, boolean skipInstallFeature, String artifactId, int serverStartTimeout,
                     int verifyAppStartTimeout, int appUpdateTimeout, double compileWait,
                     boolean libertyDebug, boolean pollingTest, boolean container, File containerfile, File containerBuildContext,
-                    String containerRunOpts, int containerBuildTimeout, boolean skipDefaultPorts, boolean keepTempContainerfile, 
-                    String mavenCacheLocation, String packagingType, File buildFile, boolean generateFeatures, List<Path> webResourceDirs,
-                    List<ProjectModule> projectModuleList, Map<String, List<String>> parentBuildGradle, File serverOutputDir
+                    String containerRunOpts, int containerBuildTimeout, boolean skipDefaultPorts, boolean keepTempContainerfile,
+                    String mavenCacheLocation, String packagingType, File buildFile, boolean generateFeatures, boolean generateToSrc,
+                    List<Path> webResourceDirs, List<ProjectModule> projectModuleList, Map<String, List<String>> parentBuildGradle, File serverOutputDir
         ) throws IOException, PluginExecutionException {
             super(buildDir, serverDirectory, sourceDirectory, testSourceDirectory, configDirectory, projectDirectory, /* multi module project directory */ projectDirectory,
                     resourceDirs, changeOnDemandTestsAction, hotTests, skipTests, false /* skipUTs */, false /* skipITs */, skipInstallFeature, artifactId,  serverStartTimeout,
                     verifyAppStartTimeout, appUpdateTimeout, ((long) (compileWait * 1000L)), libertyDebug,
                     true /* useBuildRecompile */, true /* gradle */, pollingTest, container, containerfile, containerBuildContext, containerRunOpts, containerBuildTimeout, skipDefaultPorts,
                     null /* compileOptions not needed since useBuildRecompile is true */, keepTempContainerfile, mavenCacheLocation, projectModuleList /* multi module upstream projects */,
-                    projectModuleList.size() > 0 /* recompileDependencies as true for multi module */, packagingType, buildFile, parentBuildGradle /* parent build files */, generateFeatures, null /* compileArtifactPaths */, null /* testArtifactPaths */, webResourceDirs /* webResources */
+                    projectModuleList.size() > 0 /* recompileDependencies as true for multi module */, packagingType, buildFile, parentBuildGradle /* parent build files */, generateFeatures, generateToSrc, null /* compileArtifactPaths */, null /* testArtifactPaths */, webResourceDirs /* webResources */
                 );
             this.libertyDirPropertyFiles = LibertyPropFilesUtility.getLibertyDirectoryPropertyFiles(new CommonLogger(project), installDirectory, userDirectory, serverDirectory, serverOutputDir);
             ServerFeatureUtil servUtil = getServerFeatureUtil(true, libertyDirPropertyFiles);
@@ -1351,7 +1351,7 @@ class DevTask extends AbstractFeatureTask {
                 verifyAppStartTimeout.intValue(), verifyAppStartTimeout.intValue(), compileWait.doubleValue(),
                 libertyDebug.booleanValue(), pollingTest.booleanValue(), container.booleanValue(), containerfile, containerBuildContext, containerRunOpts,
                 containerBuildTimeout, skipDefaultPorts.booleanValue(), keepTempContainerfile.booleanValue(), localMavenRepoForFeatureUtility,
-                DevTaskHelper.getPackagingType(project), buildFile, generateFeatures.booleanValue(), webResourceDirs, projectModules, parentBuildGradle, new File(outputDir, serverName)
+                DevTaskHelper.getPackagingType(project), buildFile, generateFeatures.booleanValue(), false /* generateToSrc */, webResourceDirs, projectModules, parentBuildGradle, new File(outputDir, serverName)
             );
         } catch (IOException | PluginExecutionException e) {
             throw new GradleException("Error initializing dev mode.", e)

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
@@ -1467,9 +1467,6 @@ class DevTask extends AbstractFeatureTask {
         if (hotTests && testSourceDirectory.exists()) {
             // if hot testing, run tests on startup and then watch for keypresses
             util.runTestThread(false, executor, -1, false, false);
-        } else {
-            // else watch for key presses immediately
-            util.runHotkeyReaderThread(executor);
         }
 
         // Note that serverXMLFile can be null. DevUtil will automatically watch

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
@@ -17,7 +17,7 @@ package io.openliberty.tools.gradle.tasks
 
 import groovy.xml.XmlParser
 import io.openliberty.tools.ant.ServerTask
-import io.openliberty.tools.common.plugins.util.BinaryScannerUtil
+import io.openliberty.tools.common.plugins.util.FeatureGeneratorUtil
 import io.openliberty.tools.common.plugins.util.DevUtil
 import io.openliberty.tools.common.plugins.util.InstallFeatureUtil
 import io.openliberty.tools.common.plugins.util.JavaCompilerOptions
@@ -710,7 +710,7 @@ class DevTask extends AbstractFeatureTask {
             if (optimizeGenerateFeatures && generateFeatures) {
                 logger.debug("Detected a change in the compile dependencies, regenerating features");
                 // optimize generate features on build dependency change
-                boolean generateFeaturesSuccess = libertyGenerateFeatures(null, true);
+                boolean generateFeaturesSuccess = libertyGenerateFeatures(null, true, false, false, false);
                 if (generateFeaturesSuccess) {
                     util.javaSourceClassPaths.clear();
                 } else {
@@ -1058,17 +1058,22 @@ class DevTask extends AbstractFeatureTask {
         }
 
         @Override
-        public boolean libertyGenerateFeatures(Collection<String> classes, boolean optimize) {
+        public boolean libertyGenerateFeatures(Collection<String> classes, boolean optimize, boolean genToSrc, boolean useTmpDirOut, boolean useTmpDirIn) {
             ProjectConnection gradleConnection = initGradleProjectConnection();
             BuildLauncher gradleBuildLauncher = gradleConnection.newBuild();
 
             try {
                 List<String> options = new ArrayList<String>();
-                classes.each {
-                    // generate features for only the classFiles passed (if any)
-                    options.add("--classFile=" + it);
+                if (classes != null) {
+                    classes.each {
+                        // generate features for only the classFiles passed (if any)
+                        options.add("--classFile=" + it);
+                    }
                 }
                 options.add("--optimize=" + optimize);
+                options.add("--generateToSrc=" + genToSrc);
+                options.add("--useTmpDirOut=" + useTmpDirOut);
+                options.add("--useTmpDirIn=" + useTmpDirIn);
                 runGenerateFeaturesTask(gradleBuildLauncher, options);
                 return true; // successfully generated features
             } catch (BuildException e) {
@@ -1374,10 +1379,10 @@ class DevTask extends AbstractFeatureTask {
                 String generatedFileCanonicalPath;
                 try {
                     generatedFileCanonicalPath = new File(configDirectory,
-                            BinaryScannerUtil.GENERATED_FEATURES_FILE_PATH).getCanonicalPath();
+                            FeatureGeneratorUtil.GENERATED_FEATURES_FILE_PATH).getCanonicalPath();
                 } catch (IOException e) {
                     generatedFileCanonicalPath = new File(configDirectory,
-                            BinaryScannerUtil.GENERATED_FEATURES_FILE_PATH).toString();
+                            FeatureGeneratorUtil.GENERATED_FEATURES_FILE_PATH).toString();
                 }
                 logger.warn(
                         "The source configuration directory will be modified. Features will automatically be generated in a new file: "

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/GenerateFeaturesTask.groovy
@@ -18,8 +18,8 @@ package io.openliberty.tools.gradle.tasks
 
 import io.openliberty.tools.common.plugins.config.ServerConfigXmlDocument
 import io.openliberty.tools.common.plugins.config.XmlDocument
-import io.openliberty.tools.common.plugins.util.BinaryScannerUtil
-import static io.openliberty.tools.common.plugins.util.BinaryScannerUtil.*;
+import io.openliberty.tools.common.plugins.util.FeatureGeneratorUtil
+import static io.openliberty.tools.common.plugins.util.FeatureGeneratorUtil.*;
 import io.openliberty.tools.common.plugins.util.PluginExecutionException
 import io.openliberty.tools.common.plugins.util.ServerFeatureUtil
 import io.openliberty.tools.common.plugins.util.ServerFeatureUtil.FeaturesPlatforms
@@ -69,6 +69,27 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
         this.optimize = Boolean.parseBoolean(optimize);
     }
 
+    private boolean generateToSrc = false;
+
+    @Option(option = 'generateToSrc', description = 'If true, generate the features file into the src/main/liberty/config directory instead of a temporary directory.')
+    void setGenerateToSrc(String generateToSrc) {
+        this.generateToSrc = Boolean.parseBoolean(generateToSrc);
+    }
+
+    private boolean useTmpDirOut = false;
+
+    @Option(option = 'useTmpDirOut', description = 'If true, write the generated features file to a temporary directory.')
+    void setUseTmpDirOut(String useTmpDirOut) {
+        this.useTmpDirOut = Boolean.parseBoolean(useTmpDirOut);
+    }
+
+    private boolean useTmpDirIn = false;
+
+    @Option(option = 'useTmpDirIn', description = 'If true, read the existing generated features file from the temporary directory as input.')
+    void setUseTmpDirIn(String useTmpDirIn) {
+        this.useTmpDirIn = Boolean.parseBoolean(useTmpDirIn);
+    }
+
     @TaskAction
     void generateFeatures() {
         binaryScanner = getBinaryScannerJarFromRepository();
@@ -80,6 +101,9 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
 
         logger.debug("--- Generate Features values ---");
         logger.debug("optimize generate features: " + optimize);
+        logger.debug("generateToSrc: " + generateToSrc);
+        logger.debug("useTmpDirOut: " + useTmpDirOut);
+        logger.debug("useTmpDirIn: " + useTmpDirIn);
         if (classFiles != null && !classFiles.isEmpty()) {
             logger.debug("Generate features for the following class files: " + classFiles);
         }
@@ -127,9 +151,9 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
             String eeVersionArg = composeEEVersion(eeVersion);
             String mpVersionArg = composeMPVersion(mpVersion);
             scannedFeatureList = binaryScannerHandler.runBinaryScanner(nonCustomFeatures, classFiles, directories, logLocation, eeVersionArg, mpVersionArg, optimize);
-        } catch (BinaryScannerUtil.NoRecommendationException noRecommendation) {
-            throw new GradleException(String.format(BinaryScannerUtil.BINARY_SCANNER_CONFLICT_MESSAGE3, noRecommendation.getConflicts()));
-        } catch (BinaryScannerUtil.FeatureModifiedException featuresModified) {
+        } catch (FeatureGeneratorUtil.NoRecommendationException noRecommendation) {
+            throw new GradleException(String.format(FeatureGeneratorUtil.FEATURE_GEN_CONFLICT_MESSAGE3, noRecommendation.getConflicts()));
+        } catch (FeatureGeneratorUtil.FeatureModifiedException featuresModified) {
             Set<String> userFeatures = (optimize) ? existingFeatures : 
                 getServerFeatures(servUtil, generatedFiles, true); // user features excludes generatedFiles
             Set<String> modifiedSet = featuresModified.getFeatures(); // a set that works after being modified by the scanner
@@ -144,19 +168,19 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
                 Set<String> allAppFeatures = featuresModified.getSuggestions(); // suggestions are scanned from binaries
                 allAppFeatures.addAll(userFeatures); // scanned plus configured features were detected to be in conflict
                 logger.debug("FeatureModifiedException, combine suggestions from scanner with user features in error msg");
-                throw new GradleException(String.format(BinaryScannerUtil.BINARY_SCANNER_CONFLICT_MESSAGE1, allAppFeatures, modifiedSet));
+                throw new GradleException(String.format(FeatureGeneratorUtil.FEATURE_GEN_CONFLICT_MESSAGE1, allAppFeatures, modifiedSet));
             }
-        } catch (BinaryScannerUtil.RecommendationSetException showRecommendation) {
+        } catch (FeatureGeneratorUtil.RecommendationSetException showRecommendation) {
             if (showRecommendation.isExistingFeaturesConflict()) {
-                throw new GradleException(String.format(BinaryScannerUtil.BINARY_SCANNER_CONFLICT_MESSAGE2, showRecommendation.getConflicts(), showRecommendation.getSuggestions()));
+                throw new GradleException(String.format(FeatureGeneratorUtil.FEATURE_GEN_CONFLICT_MESSAGE2, showRecommendation.getConflicts(), showRecommendation.getSuggestions()));
             }
-            throw new GradleException(String.format(BinaryScannerUtil.BINARY_SCANNER_CONFLICT_MESSAGE1, showRecommendation.getConflicts(), showRecommendation.getSuggestions()));
-        } catch (BinaryScannerUtil.FeatureUnavailableException featureUnavailable) {
-            throw new GradleException(String.format(BinaryScannerUtil.BINARY_SCANNER_CONFLICT_MESSAGE5, featureUnavailable.getConflicts(), featureUnavailable.getMPLevel(),
+            throw new GradleException(String.format(FeatureGeneratorUtil.FEATURE_GEN_CONFLICT_MESSAGE1, showRecommendation.getConflicts(), showRecommendation.getSuggestions()));
+        } catch (FeatureGeneratorUtil.FeatureUnavailableException featureUnavailable) {
+            throw new GradleException(String.format(FeatureGeneratorUtil.FEATURE_GEN_CONFLICT_MESSAGE5, featureUnavailable.getConflicts(), featureUnavailable.getMPLevel(),
                     featureUnavailable.getEELevel(), featureUnavailable.getUnavailableFeatures()));
-        } catch (BinaryScannerUtil.IllegalTargetComboException illegalCombo) {
-            throw new GradleException(String.format(BinaryScannerUtil.BINARY_SCANNER_INVALID_COMBO_MESSAGE, eeVersion, mpVersion));
-        } catch (BinaryScannerUtil.IllegalTargetException illegalTargets) {
+        } catch (FeatureGeneratorUtil.IllegalTargetComboException illegalCombo) {
+            throw new GradleException(String.format(FeatureGeneratorUtil.FEATURE_GEN_INVALID_COMBO_MESSAGE, eeVersion, mpVersion));
+        } catch (FeatureGeneratorUtil.IllegalTargetException illegalTargets) {
             String messages = buildInvalidArgExceptionMessage(illegalTargets.getEELevel(), illegalTargets.getMPLevel(), eeVersion, mpVersion);
             throw new GradleException(messages);
         } catch (PluginExecutionException x) {
@@ -190,7 +214,8 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
         }
         logger.debug("Features detected by binary scanner which are not in server.xml : " + missingLibertyFeatures);
 
-        def newServerXmlSrc = new File(server.configDirectory, GENERATED_FEATURES_FILE_PATH);
+        File outputDir = (useTmpDirOut) ? new File(project.getBuildDir(), GENERATED_FEATURES_TEMP_DIR) : server.configDirectory;
+        def newServerXmlSrc = new File(outputDir, GENERATED_FEATURES_FILE_PATH);
         try {
             if (missingLibertyFeatures.size() > 0) {
                 Set<String> existingGeneratedFeatures = getGeneratedFeatures(servUtil, newServerXmlSrc);
@@ -267,12 +292,12 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
      */
     private File getBinaryScannerJarFromRepository() throws PluginExecutionException {
         try {
-            return ArtifactDownloadUtil.downloadBuildArtifact(project, BINARY_SCANNER_MAVEN_GROUP_ID, BINARY_SCANNER_MAVEN_ARTIFACT_ID, BINARY_SCANNER_MAVEN_TYPE, BINARY_SCANNER_MAVEN_VERSION);
+            return ArtifactDownloadUtil.downloadBuildArtifact(project, FEATURE_GEN_MAVEN_GROUP_ID, FEATURE_GEN_MAVEN_ARTIFACT_ID, FEATURE_GEN_MAVEN_TYPE, FEATURE_GEN_MAVEN_VERSION);
         } catch (Exception e) {
-            throw new PluginExecutionException("Could not retrieve the artifact " + BINARY_SCANNER_MAVEN_GROUP_ID + "."
-                    + BINARY_SCANNER_MAVEN_ARTIFACT_ID + "." + BINARY_SCANNER_MAVEN_VERSION
+            throw new PluginExecutionException("Could not retrieve the artifact " + FEATURE_GEN_MAVEN_GROUP_ID + "."
+                    + FEATURE_GEN_MAVEN_ARTIFACT_ID + "." + FEATURE_GEN_MAVEN_VERSION
                     + " needed for generateFeatures. Ensure you have a connection to Maven Central or another repository that contains the "
-                    + BINARY_SCANNER_MAVEN_GROUP_ID + "." + BINARY_SCANNER_MAVEN_ARTIFACT_ID
+                    + FEATURE_GEN_MAVEN_GROUP_ID + "." + FEATURE_GEN_MAVEN_ARTIFACT_ID
                     + ".jar configured in your build.gradle.",
                     e);
         }
@@ -392,7 +417,7 @@ class GenerateFeaturesTask extends AbstractFeatureTask {
     }
 
     // Define the logging functions of the binary scanner handler and make it available in this plugin
-    private class BinaryScannerHandler extends BinaryScannerUtil {
+    private class BinaryScannerHandler extends FeatureGeneratorUtil {
         BinaryScannerHandler(File scannerFile) {
             super(scannerFile);
         }

--- a/src/test/groovy/io/openliberty/tools/gradle/GenerateFeaturesTest.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/GenerateFeaturesTest.groovy
@@ -25,7 +25,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 
 import static org.junit.Assert.*
-import static io.openliberty.tools.common.plugins.util.BinaryScannerUtil.*;
+import static io.openliberty.tools.common.plugins.util.FeatureGeneratorUtil.*;
 
 class GenerateFeaturesTest extends BaseGenerateFeaturesTest {
 
@@ -179,7 +179,7 @@ class GenerateFeaturesTest extends BaseGenerateFeaturesTest {
 
     /**
      * Conflict between user specified features.
-     * Check for BINARY_SCANNER_CONFLICT_MESSAGE2 (conflict between configured features)
+     * Check for FEATURE_GEN_CONFLICT_MESSAGE2 (conflict between configured features)
      *
      * @throws Exception
      */
@@ -194,16 +194,16 @@ class GenerateFeaturesTest extends BaseGenerateFeaturesTest {
             "  </featureManager>\n", serverXmlFile);
         runCompileAndGenerateFeatures();
 
-        // Verify BINARY_SCANNER_CONFLICT_MESSAGE2 error is thrown (BinaryScannerUtil.RecommendationSetException)
+        // Verify FEATURE_GEN_CONFLICT_MESSAGE2 error is thrown (FeatureGeneratorUtil.RecommendationSetException)
         Set<String> recommendedFeatureSet = new HashSet<String>(Arrays.asList("servlet-4.0"));
         // search log file instead of process output because warning message in process output may be interrupted
-        boolean b = verifyLogMessageExists(String.format(BINARY_SCANNER_CONFLICT_MESSAGE2, getCdi12ConflictingFeatures(), recommendedFeatureSet), 1000, errFile);
+        boolean b = verifyLogMessageExists(String.format(FEATURE_GEN_CONFLICT_MESSAGE2, getCdi12ConflictingFeatures(), recommendedFeatureSet), 1000, errFile);
         assertTrue(formatOutput(getProcessOutput()), b);
     }
 
     /**
      * Conflict between user specified features and API usage.
-     * Check for BINARY_SCANNER_CONFLICT_MESSAGE1 (conflict between configured features and API usage)
+     * Check for FEATURE_GEN_CONFLICT_MESSAGE1 (conflict between configured features and API usage)
      *
      * @throws Exception
      */
@@ -217,18 +217,18 @@ class GenerateFeaturesTest extends BaseGenerateFeaturesTest {
             "  </featureManager>\n", serverXmlFile);
         runCompileAndGenerateFeatures();
 
-        // Verify BINARY_SCANNER_CONFLICT_MESSAGE1 error is thrown (BinaryScannerUtil.FeatureModifiedException)
+        // Verify FEATURE_GEN_CONFLICT_MESSAGE1 error is thrown (FeatureGeneratorUtil.FeatureModifiedException)
         Set<String> recommendedFeatureSet = new HashSet<String>(Arrays.asList("cdi-2.0", "servlet-4.0"));
         // search log file instead of process output because warning message in process output may be interrupted
-        boolean b = verifyLogMessageExists(String.format(BINARY_SCANNER_CONFLICT_MESSAGE1, getCdi12ConflictingFeatures(), recommendedFeatureSet), 1000, errFile);
+        boolean b = verifyLogMessageExists(String.format(FEATURE_GEN_CONFLICT_MESSAGE1, getCdi12ConflictingFeatures(), recommendedFeatureSet), 1000, errFile);
         assertTrue(formatOutput(getProcessOutput()), b);
     }
 
-    // TODO add an integration test for feature conflict for API usage (BINARY_SCANNER_CONFLICT_MESSAGE3), ie. MP4 and EE9
+    // TODO add an integration test for feature conflict for API usage (FEATURE_GEN_CONFLICT_MESSAGE3), ie. MP4 and EE9
 
     /**
      * Conflict between required features in API usage or configured features and MP/EE level specified
-     * Check for BINARY_SCANNER_CONFLICT_MESSAGE5 (feature unavailable for required MP/EE levels)
+     * Check for FEATURE_GEN_CONFLICT_MESSAGE5 (feature unavailable for required MP/EE levels)
      *
      * @throws Exception
      */
@@ -245,7 +245,7 @@ class GenerateFeaturesTest extends BaseGenerateFeaturesTest {
                         "  </featureManager>\n", serverXmlFile);
         runCompileAndGenerateFeatures();
 
-        // use just beginning of BINARY_SCANNER_CONFLICT_MESSAGE5 as error message in logFile may be interrupted with "1 actionable task: 1 executed"
+        // use just beginning of FEATURE_GEN_CONFLICT_MESSAGE5 as error message in logFile may be interrupted with "1 actionable task: 1 executed"
         assertTrue("Could not find the feature unavailable conflict message in the process output.\n" + processOutput,
                 verifyLogMessageExists("required features: [servlet-4.0, mpOpenAPI-1.0]" +
                         " and required levels of MicroProfile: mp1.2, Java EE or Jakarta EE: ee8", 1000, errFile));


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/ci.maven/issues/2070

PR Ci.Common: https://github.com/OpenLiberty/ci.common/pull/526
PR Ci.Maven: https://github.com/OpenLiberty/ci.maven/pull/2073

Removed the runHotkeyReaderThread() call between startServer() and watchFiles() because the startup banner has moved into watchFiles() in ci.common.