### PR TITLE
Fixed misleading expansion variable log message in ci.common

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -39,8 +39,7 @@ jobs:
     - name: Checkout ci.common
       uses: actions/checkout@v3
       with:
-        repository: sajeerzeji/ci.common
-        ref: fix/GHMVN2076-Message_update
+        repository: OpenLiberty/ci.common
         path: ci.common
     - name: Checkout ci.ant
       uses: actions/checkout@v3
@@ -122,7 +121,7 @@ jobs:
     - name: Clone ci.ant, ci.common, ci.gradle repos to C drive
       run: |
         echo ${{github.workspace}}
-        git clone https://github.com/sajeerzeji/ci.common.git --branch fix/GHMVN2076-Message_update --single-branch ${{github.workspace}}/ci.common
+        git clone https://github.com/OpenLiberty/ci.common.git ${{github.workspace}}/ci.common
         git clone https://github.com/OpenLiberty/ci.ant.git ${{github.workspace}}/ci.ant
     # Cache mvn/gradle packages
     - name: Cache Maven packages

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -39,7 +39,8 @@ jobs:
     - name: Checkout ci.common
       uses: actions/checkout@v3
       with:
-        repository: OpenLiberty/ci.common
+        repository: sajeerzeji/ci.common
+        ref: fix/GHMVN2076-Message_update
         path: ci.common
     - name: Checkout ci.ant
       uses: actions/checkout@v3
@@ -121,7 +122,7 @@ jobs:
     - name: Clone ci.ant, ci.common, ci.gradle repos to C drive
       run: |
         echo ${{github.workspace}}
-        git clone https://github.com/OpenLiberty/ci.common.git ${{github.workspace}}/ci.common
+        git clone https://github.com/sajeerzeji/ci.common.git --branch fix/GHMVN2076-Message_update --single-branch ${{github.workspace}}/ci.common
         git clone https://github.com/OpenLiberty/ci.ant.git ${{github.workspace}}/ci.ant
     # Cache mvn/gradle packages
     - name: Cache Maven packages

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         # test against latest update of each major Java version, as well as specific updates of LTS versions:
         RUNTIME: [ol, wlp]
-        RUNTIME_VERSION: [26.0.0.4]
+        RUNTIME_VERSION: [26.0.0.6]
         java: [21, 17, 25]
         exclude:
         - java: 8
@@ -99,7 +99,7 @@ jobs:
       matrix:
         # test against latest update of each major Java version, as well as specific updates of LTS versions:
         RUNTIME: [ol, wlp]
-        RUNTIME_VERSION: [26.0.0.4]
+        RUNTIME_VERSION: [26.0.0.6]
         java: [21, 17, 25]
         exclude:
         - java: 8

--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ java {
 }
 
 def libertyAntVersion = "1.9.18"
-def libertyCommonVersion = "1.8.42"
+def libertyCommonVersion = "1.8.43-SNAPSHOT"
 
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ java {
 }
 
 def libertyAntVersion = "1.9.18"
-def libertyCommonVersion = "1.8.43-SNAPSHOT"
+def libertyCommonVersion = "1.8.43"
 
 
 dependencies {

--- a/src/test/groovy/io/openliberty/tools/gradle/TestAppConfig.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/TestAppConfig.groovy
@@ -28,11 +28,11 @@ public class TestAppConfig extends AbstractIntegrationTest{
             BuildResult result = runTasksResult(buildDir, 'libertyStart')
             String output = result.getOutput()
             if (OSUtil.isWindows()) {
-                assert output.contains('Resolved environment variable "EXP_VAR" in path "!EXP_VAR!_!EXP_VAR3!" to "TEST_WINDOWS"'): 'Expected info about expansion variable resolution for !EXP_VAR!_!EXP_VAR3!'
-                assert output.contains('Resolved environment variable "EXP_VAR3" in path "!EXP_VAR!_!EXP_VAR3!" to "TEST_WINDOWS"'): 'Expected info about expansion variable resolution for TEST_!EXP_VAR3!'
+                assert output.contains('Resolved environment variable "EXP_VAR" in path "!EXP_VAR!_!EXP_VAR3!" to "TEST"'): 'Expected info about expansion variable resolution for !EXP_VAR!_!EXP_VAR3!'
+                assert output.contains('Resolved environment variable "EXP_VAR3" in path "!EXP_VAR!_!EXP_VAR3!" to "WINDOWS"'): 'Expected info about expansion variable resolution for TEST_!EXP_VAR3!'
             } else {
-                assert output.contains('Resolved environment variable "EXP_VAR" in path "${EXP_VAR}_${EXP_VAR2}" to "TEST_UNIX"'): 'Expected info about expansion variable resolution for ${EXP_VAR}_${EXP_VAR2}'
-                assert output.contains('Resolved environment variable "EXP_VAR2" in path "${EXP_VAR}_${EXP_VAR2}" to "TEST_UNIX"'): 'Expected info about expansion variable resolution for TEST_${EXP_VAR2}'
+                assert output.contains('Resolved environment variable "EXP_VAR" in path "${EXP_VAR}_${EXP_VAR2}" to "TEST"'): 'Expected info about expansion variable resolution for ${EXP_VAR}_${EXP_VAR2}'
+                assert output.contains('Resolved environment variable "EXP_VAR2" in path "${EXP_VAR}_${EXP_VAR2}" to "UNIX"'): 'Expected info about expansion variable resolution for TEST_${EXP_VAR2}'
             }
         } catch (Exception e) {
             throw new AssertionError("Fail on task libertyStart.", e)

--- a/src/test/groovy/io/openliberty/tools/gradle/TestAppConfig.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/TestAppConfig.groovy
@@ -28,11 +28,11 @@ public class TestAppConfig extends AbstractIntegrationTest{
             BuildResult result = runTasksResult(buildDir, 'libertyStart')
             String output = result.getOutput()
             if (OSUtil.isWindows()) {
-                assert output.contains('Resolving Property EXP_VAR for expression !EXP_VAR!_!EXP_VAR3!. Resolved expression value is TEST'): 'Expected info about expansion variable resolution for !EXP_VAR!_!EXP_VAR3!'
-                assert output.contains('Resolving Property EXP_VAR3 for expression !EXP_VAR!_!EXP_VAR3!. Resolved expression value is TEST_WINDOWS'): 'Expected info about expansion variable resolution for TEST_!EXP_VAR3!'
+                assert output.contains('Resolved environment variable "EXP_VAR" in path "!EXP_VAR!_!EXP_VAR3!" to "TEST_WINDOWS"'): 'Expected info about expansion variable resolution for !EXP_VAR!_!EXP_VAR3!'
+                assert output.contains('Resolved environment variable "EXP_VAR3" in path "!EXP_VAR!_!EXP_VAR3!" to "TEST_WINDOWS"'): 'Expected info about expansion variable resolution for TEST_!EXP_VAR3!'
             } else {
-                assert output.contains('Resolving Property EXP_VAR for expression ${EXP_VAR}_${EXP_VAR2}. Resolved expression value is TEST'): 'Expected info about expansion variable resolution for ${EXP_VAR}_${EXP_VAR2}'
-                assert output.contains('Resolving Property EXP_VAR2 for expression ${EXP_VAR}_${EXP_VAR2}. Resolved expression value is TEST_UNIX'): 'Expected info about expansion variable resolution for TEST_${EXP_VAR2}'
+                assert output.contains('Resolved environment variable "EXP_VAR" in path "${EXP_VAR}_${EXP_VAR2}" to "TEST_UNIX"'): 'Expected info about expansion variable resolution for ${EXP_VAR}_${EXP_VAR2}'
+                assert output.contains('Resolved environment variable "EXP_VAR2" in path "${EXP_VAR}_${EXP_VAR2}" to "TEST_UNIX"'): 'Expected info about expansion variable resolution for TEST_${EXP_VAR2}'
             }
         } catch (Exception e) {
             throw new AssertionError("Fail on task libertyStart.", e)

--- a/src/test/groovy/io/openliberty/tools/gradle/TestAppConfig.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/TestAppConfig.groovy
@@ -30,9 +30,11 @@ public class TestAppConfig extends AbstractIntegrationTest{
             if (OSUtil.isWindows()) {
                 assert output.contains('Resolved environment variable "EXP_VAR" in path "!EXP_VAR!_!EXP_VAR3!" to "TEST"'): 'Expected info about expansion variable resolution for !EXP_VAR!_!EXP_VAR3!'
                 assert output.contains('Resolved environment variable "EXP_VAR3" in path "!EXP_VAR!_!EXP_VAR3!" to "WINDOWS"'): 'Expected info about expansion variable resolution for TEST_!EXP_VAR3!'
+                assert output.contains('Resolved path "!EXP_VAR!_!EXP_VAR3!" to "TEST_WINDOWS"'): 'Expected complete resolved value log for !EXP_VAR!_!EXP_VAR3!'
             } else {
                 assert output.contains('Resolved environment variable "EXP_VAR" in path "${EXP_VAR}_${EXP_VAR2}" to "TEST"'): 'Expected info about expansion variable resolution for ${EXP_VAR}_${EXP_VAR2}'
                 assert output.contains('Resolved environment variable "EXP_VAR2" in path "${EXP_VAR}_${EXP_VAR2}" to "UNIX"'): 'Expected info about expansion variable resolution for TEST_${EXP_VAR2}'
+                assert output.contains('Resolved path "${EXP_VAR}_${EXP_VAR2}" to "TEST_UNIX"'): 'Expected complete resolved value log for ${EXP_VAR}_${EXP_VAR2}'
             }
         } catch (Exception e) {
             throw new AssertionError("Fail on task libertyStart.", e)


### PR DESCRIPTION
Fixes [#2076 ](https://github.com/OpenLiberty/ci.maven/issues/2076)

Reference: https://github.com/OpenLiberty/ci.maven/issues/2076#issuecomment-5191485848

In ci.common, moved the log call to after the full string is assembled, so the complete resolved path is shown, and updates the message format to clearly state which variable was expanded, the original expression it appeared in, and the fully resolved result. The corresponding IT assertions in ci.maven and ci.gradle are updated to match the new message format.