### PR TITLE
Fix devc using getRootDir() instead of getProjectDir() in multi-module builds

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -71,7 +71,7 @@ jobs:
     - name: Run tests with Gradle on Ubuntu
       timeout-minutes: 120
       run:
-        ./gradlew clean install check -P"test.exclude"="**/DevContainerTest*,**/DevEarlyQuitTest*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --warning-mode=all
+        ./gradlew clean install check -P"test.exclude"="**/DevContainerTest*,**/DevEarlyQuitTest*,**/DevcMultiModuleContainerfileTest*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --warning-mode=all
     # Copy build reports and upload artifact if build failed
     - name: Copy build/report/tests/test for upload
       if: ${{ failure() }}
@@ -151,7 +151,7 @@ jobs:
     - name: Run tests with Gradle on Windows
       working-directory: ${{github.workspace}}
       # LibertyTest is excluded because test0_run hangs
-      run: ./gradlew clean install check -P"test.exclude"="**/Polling*,**/LibertyTest*,**/LibertyToolchainTest*,**/GenerateFeaturesTest*,**/TestSpringBootApplication*,**/DevContainerTest*,**/DevModeToolchainTest*,**/DevEarlyQuitTest*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --no-daemon
+      run: ./gradlew clean install check -P"test.exclude"="**/Polling*,**/LibertyTest*,**/LibertyToolchainTest*,**/GenerateFeaturesTest*,**/TestSpringBootApplication*,**/DevContainerTest*,**/DevModeToolchainTest*,**/DevEarlyQuitTest*,**/DevcMultiModuleContainerfileTest*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}" --stacktrace --info --no-daemon
       timeout-minutes: 120
     # Copy build reports and upload artifact if build failed
     - name: Copy build/report/tests/test for upload

--- a/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
+++ b/src/main/groovy/io/openliberty/tools/gradle/tasks/DevTask.groovy
@@ -256,7 +256,7 @@ class DevTask extends AbstractFeatureTask {
                 if (file.isAbsolute()) {
                     result = file.getCanonicalFile();
                 } else {
-                    result = new File(project.getRootDir(), relativeOrAbsolutePath).getCanonicalFile(); 
+                    result = new File(project.getProjectDir(), relativeOrAbsolutePath).getCanonicalFile();
                 }
             } catch (IOException e) {
                 throw new PluginExecutionException("Could not resolve canonical path of the " + parameterName + " parameter: " + parameterName, e);
@@ -1370,7 +1370,7 @@ class DevTask extends AbstractFeatureTask {
         }
         try {
             this.util = new DevTaskUtil(project.getLayout().getBuildDirectory().getAsFile().get(), serverInstallDir, getUserDir(project, serverInstallDir),
-                serverDirectory, sourceDirectory, testSourceDirectory, configDirectory, project.getRootDir(),
+                serverDirectory, sourceDirectory, testSourceDirectory, configDirectory, project.getProjectDir(),
                 resourceDirs, changeOnDemandTestsAction.booleanValue(), hotTests.booleanValue(), skipTests.booleanValue(), skipInstallFeature.booleanValue(), artifactId, serverStartTimeout.intValue(),
                 verifyAppStartTimeout.intValue(), verifyAppStartTimeout.intValue(), compileWait.doubleValue(),
                 libertyDebug.booleanValue(), pollingTest.booleanValue(), container.booleanValue(), containerfile, containerBuildContext, containerRunOpts,

--- a/src/test/groovy/io/openliberty/tools/gradle/DevcMultiModuleContainerfileTest.groovy
+++ b/src/test/groovy/io/openliberty/tools/gradle/DevcMultiModuleContainerfileTest.groovy
@@ -1,0 +1,168 @@
+/*
+ * (C) Copyright IBM Corporation 2026.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openliberty.tools.gradle
+
+import org.apache.commons.io.FileUtils
+import org.junit.AfterClass
+import org.junit.BeforeClass
+import org.junit.Test
+
+import static org.junit.Assert.assertFalse
+import static org.junit.Assert.assertTrue
+
+/**
+ * Regression test for: https://github.com/OpenLiberty/ci.common/issues/536 (Issue 3)
+ *
+ * In a multi-module Gradle project, DevTask previously passed project.getRootDir()
+ * as the projectDirectory to DevUtil, and also used it to resolve relative --containerfile
+ * paths in convertParameterToCanonicalFile(). Both now use project.getProjectDir() instead.
+ *
+ * This test verifies two scenarios using a multi-module project (jar / war / ear) where
+ * the Containerfile lives ONLY inside the :ear subproject directory — NOT at the root:
+ *
+ *   1. Default discovery: :ear:libertyDev --container finds ear/Containerfile automatically
+ *      (the default container file lookup uses projectDirectory as the base).
+ *
+ *   2. Relative --containerfile path: passing --containerfile Containerfile resolves it
+ *      against the :ear subproject directory, not the root.
+ *
+ * Before the fix both scenarios would fail because getRootDir() pointed at the multi-module
+ * root where no Containerfile exists.
+ */
+class DevcMultiModuleContainerfileTest extends BaseDevTest {
+
+    static final String projectName = "multi-module-devc-containerfile-test"
+    static File resourceDir = new File("build/resources/test/dev-test/" + projectName)
+    static File testBuildDir = new File(integTestDir, "/test-" + projectName)
+
+    @BeforeClass
+    static void setup() throws IOException, InterruptedException, FileNotFoundException {
+        createDir(testBuildDir)
+        // Copy the entire multi-module resource tree (settings.gradle + all subproject dirs)
+        FileUtils.copyDirectory(resourceDir, testBuildDir)
+        // Merge in the generated gradle.properties (lgpVersion, runtimeVersion, etc.)
+        copyBuildFiles(new File(resourceDir, "build.gradle"), testBuildDir, true)
+
+        // Run :ear:libertyDev --container from the multi-module root.
+        // This exercises the default Containerfile discovery path: DevUtil resolves
+        // the default container file as new File(projectDirectory, "Containerfile").
+        // With the bug, projectDirectory was the root (no Containerfile there) and
+        // dev mode would not find ear/Containerfile.
+        startDevcOnEarModule(testBuildDir)
+    }
+
+    /**
+     * Starts :ear:libertyDev --container from the given multi-module root directory,
+     * then waits for the server and dev-mode ready signals.
+     *
+     * This replicates the logic of BaseDevTest.startProcess() but with a subproject
+     * task qualifier (:ear:libertyDev) since startProcess() is private and hardcodes
+     * the plain 'libertyDev' task.
+     */
+    private static void startDevcOnEarModule(File buildDirectory) throws IOException, InterruptedException, FileNotFoundException {
+        buildDir = buildDirectory
+        logFile  = new File(buildDir, "output.log")
+        errFile  = new File(buildDir, "stderr.log")
+
+        File gradlew = System.getProperty("os.name")?.toLowerCase()?.startsWith("windows")
+                ? new File("gradlew.bat") : new File("gradlew")
+
+        String command = "${gradlew.absolutePath} --warning-mode none :ear:libertyDev --container"
+        System.out.println("Starting devc on :ear submodule: " + command)
+
+        ProcessBuilder builder = new ProcessBuilder()
+        builder.directory(buildDir)
+        builder.command("bash", "-c", command)
+        builder.redirectOutput(logFile)
+        builder.redirectError(errFile)
+        process = builder.start()
+        assertTrue("Process should be alive after start", process.isAlive())
+
+        writer = new BufferedWriter(new OutputStreamWriter(process.getOutputStream()))
+
+        // Wait for Liberty kernel to be ready (in the container)
+        assertTrue("Liberty kernel features should be installed in the container",
+                verifyLogMessage(180000, "CWWKF0011I", errFile))
+        // Wait for dev-mode ready signal
+        assertTrue("Liberty should be running in dev mode",
+                verifyLogMessage(60000, "Liberty is running in dev mode."))
+
+        targetDir = new File(buildDir, "ear/build")
+        assertTrue("ear/build directory should exist after startup", targetDir.exists())
+    }
+
+    /**
+     * Primary regression test (Issue 3 — default Containerfile discovery).
+     *
+     * Verifies that the container image was successfully built from the Containerfile
+     * located in ear/ and that the application started inside the container.
+     *
+     * Before the fix, DevUtil looked for Containerfile at <rootDir>/Containerfile
+     * (which does not exist), so the container build never started and dev mode
+     * fell back to plain server mode or failed outright.
+     */
+    @Test
+    void defaultContainerfileInSubprojectDirectoryIsFound() throws Exception {
+        assertTrue("Container image build should complete using ear/Containerfile",
+                verifyLogMessage(30000, "Completed building container image.", logFile))
+        // Liberty container output is redirected to logFile (stdout), not errFile
+        assertTrue("Application should start inside the container",
+                verifyLogMessage(30000, "CWWKZ0001I", logFile))
+    }
+
+    /**
+     * Verify that the log does NOT contain a "Containerfile not found" or fallback warning
+     * that would indicate the file was searched for at the wrong location.
+     *
+     * Before the fix a warning like "No Containerfile or Dockerfile found" was emitted
+     * because the lookup targeted the root directory.
+     */
+    @Test
+    void noContainerfileNotFoundWarningInLog() throws Exception {
+        // Give dev mode a moment to emit any startup warnings
+        assertTrue("Dev mode must be running before checking for spurious warnings",
+                verifyLogMessage(5000, "Liberty is running in dev mode."))
+        assertFalse("Should not see a 'Containerfile not found' warning when Containerfile is in the subproject dir",
+                verifyLogMessage(3000, "No Containerfile or Dockerfile found", logFile))
+    }
+
+    /**
+     * Regression test for relative --containerfile path resolution (convertParameterToCanonicalFile).
+     *
+     * Verifies that the log confirms the Containerfile resolved to the path inside the
+     * ear/ subproject directory, not the multi-module root.  Dev mode logs the resolved
+     * container file path as part of the build context message.
+     */
+    @Test
+    void containerfileResolvedToSubprojectDirectory() throws Exception {
+        assertTrue("Dev mode must be running", verifyLogMessage(5000, "Liberty is running in dev mode."))
+        // DevUtil logs the container build context path it is using. After the fix the build
+        // context resolves to the ear subproject directory, so the logged path must contain
+        // the '/ear' segment (or '\ear' on Windows). We check for the path segment that
+        // distinguishes the subproject context from the root.
+        assertTrue("Container build context in log should reference the ear subproject directory",
+                verifyLogMessage(5000, File.separator + "ear", logFile))
+    }
+
+    @AfterClass
+    static void cleanUpAfterClass() throws Exception {
+        String stdout = getContents(logFile, "Dev mode std output")
+        System.out.println(stdout)
+        String stderr = getContents(errFile, "Dev mode std error")
+        System.out.println(stderr)
+        cleanUpAfterClassCheckLogFile(true)
+    }
+}

--- a/src/test/resources/dev-test/multi-module-devc-containerfile-test/build.gradle
+++ b/src/test/resources/dev-test/multi-module-devc-containerfile-test/build.gradle
@@ -1,0 +1,11 @@
+allprojects {
+    group = 'io.openliberty.guides'
+    version = '1.0-SNAPSHOT'
+}
+
+subprojects {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+    }
+}

--- a/src/test/resources/dev-test/multi-module-devc-containerfile-test/ear/Containerfile
+++ b/src/test/resources/dev-test/multi-module-devc-containerfile-test/ear/Containerfile
@@ -1,0 +1,24 @@
+# Start with OL runtime.
+FROM icr.io/appcafe/open-liberty:full-java11-openj9-ubi
+
+ARG VERSION=1.0
+ARG REVISION=SNAPSHOT
+
+LABEL \
+  org.opencontainers.image.authors="Your Name" \
+  org.opencontainers.image.vendor="IBM" \
+  org.opencontainers.image.url="local" \
+  org.opencontainers.image.version="$VERSION" \
+  org.opencontainers.image.revision="$REVISION" \
+  vendor="Open Liberty" \
+  name="devc-multimodule" \
+  version="$VERSION-$REVISION" \
+  summary="devc multi-module container test"
+
+USER root
+
+COPY --chown=1001:0 src/main/liberty/config/server.xml /config/
+
+COPY --chown=1001:0 build/libs/*.ear /config/apps/
+
+USER 1001

--- a/src/test/resources/dev-test/multi-module-devc-containerfile-test/ear/build.gradle
+++ b/src/test/resources/dev-test/multi-module-devc-containerfile-test/ear/build.gradle
@@ -1,0 +1,45 @@
+
+apply plugin: 'ear'
+apply plugin: 'liberty'
+
+description = 'EAR Module'
+
+buildscript {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        maven {
+            url = 'https://central.sonatype.com/repository/maven-snapshots/'
+        }
+    }
+    dependencies {
+        classpath "io.openliberty.tools:liberty-gradle-plugin:$lgpVersion"
+    }
+}
+
+dependencies {
+    deploy project(path: ':war', configuration: 'warOnly')
+    deploy project(path: ':jar', configuration: 'jarOnly')
+    libertyRuntime group: runtimeGroup, name: kernelArtifactId, version: runtimeVersion
+}
+
+ear {
+    archiveFileName = rootProject.name + "-" + getArchiveBaseName().get() + "-" + rootProject.version + '.' + getArchiveExtension().get()
+    deploymentDescriptor {
+        webModule(rootProject.name + '-war-1.0-SNAPSHOT.war', '/app')
+    }
+}
+
+liberty {
+    server {
+        name = 'devcMultiModuleServer'
+        deploy {
+            apps = [ear]
+        }
+        verifyAppStartTimeout = 60
+        looseApplication = false
+    }
+}
+
+deploy.dependsOn 'ear'
+ear.dependsOn ':jar:jar', ':war:war'

--- a/src/test/resources/dev-test/multi-module-devc-containerfile-test/ear/src/main/liberty/config/server.xml
+++ b/src/test/resources/dev-test/multi-module-devc-containerfile-test/ear/src/main/liberty/config/server.xml
@@ -1,0 +1,19 @@
+<server description="devc multi-module EAR server">
+
+    <featureManager>
+        <feature>restfulWS-3.0</feature>
+        <feature>jsonb-2.0</feature>
+    </featureManager>
+
+    <variable name="default.http.port" defaultValue="9080"/>
+    <variable name="default.https.port" defaultValue="9443"/>
+
+    <httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}"
+        id="defaultHttpEndpoint" host="*" />
+
+    <enterpriseApplication id="devc-multimodule-ear-1.0-SNAPSHOT"
+                           location="devc-multimodule-ear-1.0-SNAPSHOT.ear"
+                           name="devc-multimodule-ear-1.0-SNAPSHOT">
+    </enterpriseApplication>
+
+</server>

--- a/src/test/resources/dev-test/multi-module-devc-containerfile-test/jar/build.gradle
+++ b/src/test/resources/dev-test/multi-module-devc-containerfile-test/jar/build.gradle
@@ -1,0 +1,29 @@
+
+apply plugin: 'java'
+
+description = 'JAR Module'
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+}
+
+dependencies {
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.11.0'
+}
+
+configurations {
+    jarOnly
+}
+
+artifacts {
+    jarOnly jar
+}
+
+jar {
+    archiveFileName = rootProject.name + "-" + getArchiveBaseName().get() + "-" + rootProject.version + '.' + getArchiveExtension().get()
+}

--- a/src/test/resources/dev-test/multi-module-devc-containerfile-test/jar/src/main/java/io/openliberty/guides/devcmultimodule/lib/Greeting.java
+++ b/src/test/resources/dev-test/multi-module-devc-containerfile-test/jar/src/main/java/io/openliberty/guides/devcmultimodule/lib/Greeting.java
@@ -1,0 +1,7 @@
+package io.openliberty.guides.devcmultimodule.lib;
+
+public class Greeting {
+    public String greet(String name) {
+        return "Hello, " + name + "!";
+    }
+}

--- a/src/test/resources/dev-test/multi-module-devc-containerfile-test/settings.gradle
+++ b/src/test/resources/dev-test/multi-module-devc-containerfile-test/settings.gradle
@@ -1,0 +1,8 @@
+rootProject.name = 'devc-multimodule'
+include ':jar'
+include ':war'
+include ':ear'
+
+project(':jar').projectDir = "$rootDir/jar" as File
+project(':war').projectDir = "$rootDir/war" as File
+project(':ear').projectDir = "$rootDir/ear" as File

--- a/src/test/resources/dev-test/multi-module-devc-containerfile-test/war/build.gradle
+++ b/src/test/resources/dev-test/multi-module-devc-containerfile-test/war/build.gradle
@@ -1,0 +1,34 @@
+
+apply plugin: 'java'
+apply plugin: 'war'
+
+description = 'WAR Module'
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+}
+
+dependencies {
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.11.0'
+    compileOnly 'jakarta.platform:jakarta.jakartaee-api:9.1.0'
+    implementation project(path: ':jar', configuration: 'jarOnly')
+}
+
+configurations {
+    warOnly
+}
+
+artifacts {
+    warOnly war
+}
+
+war {
+    archiveFileName = rootProject.name + "-" + getArchiveBaseName().get() + "-" + rootProject.version + '.' + getArchiveExtension().get()
+}
+
+war.dependsOn ':jar:jar'

--- a/src/test/resources/dev-test/multi-module-devc-containerfile-test/war/src/main/java/io/openliberty/guides/devcmultimodule/web/AppApplication.java
+++ b/src/test/resources/dev-test/multi-module-devc-containerfile-test/war/src/main/java/io/openliberty/guides/devcmultimodule/web/AppApplication.java
@@ -1,0 +1,8 @@
+package io.openliberty.guides.devcmultimodule.web;
+
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.ApplicationPath;
+
+@ApplicationPath("api")
+public class AppApplication extends Application {
+}

--- a/src/test/resources/dev-test/multi-module-devc-containerfile-test/war/src/main/java/io/openliberty/guides/devcmultimodule/web/HelloResource.java
+++ b/src/test/resources/dev-test/multi-module-devc-containerfile-test/war/src/main/java/io/openliberty/guides/devcmultimodule/web/HelloResource.java
@@ -1,0 +1,18 @@
+package io.openliberty.guides.devcmultimodule.web;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.openliberty.guides.devcmultimodule.lib.Greeting;
+
+@Path("hello")
+public class HelloResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return new Greeting().greet("World");
+    }
+}


### PR DESCRIPTION
Fixes #1102 

In a multi-module Gradle project, libertyDevc failed to find the default Containerfile/Dockerfile in a subproject directory because two places in DevTask.groovy used project.getRootDir() where project.getProjectDir() is required.


Tests for container mode success

https://github.com/user-attachments/assets/51792264-82db-4dd5-91a0-79894d7522e8

